### PR TITLE
Improved console

### DIFF
--- a/nion/swift/ConsoleDialog.py
+++ b/nion/swift/ConsoleDialog.py
@@ -122,7 +122,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
         if len(result) > 0:
             self.__text_edit_widget.set_text_color("red" if error_code else "green")
             self.__text_edit_widget.append_text(result[:-1])
-            self.__text_edit_widget.set_text_color("white")
+        self.__text_edit_widget.set_text_color("white")
         self.__text_edit_widget.append_text(prompt)
         self.__text_edit_widget.move_cursor_position("end")
         self.__last_position = copy.deepcopy(self.__cursor_position)
@@ -140,6 +140,9 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
 
     def __key_pressed(self, key):
         is_cursor_on_last_line = self.__cursor_position.block_number == self.__last_position.block_number
+        prompt = self.continuation_prompt if self.__incomplete else self.prompt
+        partial_command = self.__get_partial_command()
+        is_cursor_on_last_column = len(partial_command.strip()) and self.__cursor_position.column_number == len(prompt + partial_command)
 
         if is_cursor_on_last_line and key.is_up_arrow:
             if self.__history_point is None:
@@ -195,7 +198,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
             self.__last_position = copy.deepcopy(self.__cursor_position)
             return True
 
-        if is_cursor_on_last_line and key.is_tab:
+        if is_cursor_on_last_line and is_cursor_on_last_column and key.is_tab:
             partial_command = self.__get_partial_command()
             terms = list()
             completer = rlcompleter.Completer(namespace=self.console.locals)
@@ -231,8 +234,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
                     self.__text_edit_widget.insert_text("{}{}".format(prompt, common_prefix))
                     self.__text_edit_widget.move_cursor_position("end")
                     self.__last_position = copy.deepcopy(self.__cursor_position)
-                return True
-
+            return True
         return False
 
     def __cursor_position_changed(self, cursor_position):

--- a/nion/swift/ConsoleDialog.py
+++ b/nion/swift/ConsoleDialog.py
@@ -77,6 +77,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
 
         self.__history = list()
         self.__history_point = None
+        self.__command_cache = ""
 
     def close(self):
         super().close()
@@ -128,6 +129,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
         self.__last_position = copy.deepcopy(self.__cursor_position)
         if command: self.__history.append(command)
         self.__history_point = None
+        self.__command_cache = ""
         return True
 
     def __get_partial_command(self):
@@ -142,11 +144,11 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
         is_cursor_on_last_line = self.__cursor_position.block_number == self.__last_position.block_number
         prompt = self.continuation_prompt if self.__incomplete else self.prompt
         partial_command = self.__get_partial_command()
-        is_cursor_on_last_column = len(partial_command.strip()) and self.__cursor_position.column_number == len(prompt + partial_command)
-
+        is_cursor_on_last_column = partial_command.strip() and self.__cursor_position.column_number == len(prompt + partial_command)
         if is_cursor_on_last_line and key.is_up_arrow:
             if self.__history_point is None:
                 self.__history_point = len(self.__history)
+                self.__command_cache = partial_command
             self.__history_point = max(0, self.__history_point - 1)
             if self.__history_point < len(self.__history):
                 line = self.__history[self.__history_point]
@@ -165,7 +167,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
                     line = self.__history[self.__history_point]
                 else:
                     self.__history_point = None
-                    line = ""
+                    line = self.__command_cache
                 self.__text_edit_widget.move_cursor_position("start_para", "move")
                 self.__text_edit_widget.move_cursor_position("end_para", "keep")
                 prompt = self.continuation_prompt if self.__incomplete else self.prompt

--- a/nion/swift/ConsoleDialog.py
+++ b/nion/swift/ConsoleDialog.py
@@ -77,7 +77,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
 
         self.__history = list()
         self.__history_point = None
-        self.__command_cache = ""
+        self.__command_cache = (None, "") # Meaning of the tuple: (history_point where the command belongs, command)
 
     def close(self):
         super().close()
@@ -129,7 +129,7 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
         self.__last_position = copy.deepcopy(self.__cursor_position)
         if command: self.__history.append(command)
         self.__history_point = None
-        self.__command_cache = ""
+        self.__command_cache = (None, "")
         return True
 
     def __get_partial_command(self):
@@ -145,13 +145,20 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
         prompt = self.continuation_prompt if self.__incomplete else self.prompt
         partial_command = self.__get_partial_command()
         is_cursor_on_last_column = partial_command.strip() and self.__cursor_position.column_number == len(prompt + partial_command)
+
         if is_cursor_on_last_line and key.is_up_arrow:
             if self.__history_point is None:
                 self.__history_point = len(self.__history)
-                self.__command_cache = partial_command
+                # do not update command_cache if the user didn't type anything
+                if partial_command:
+                    self.__command_cache = (None, partial_command)
+            elif self.__history_point < len(self.__history):
+                # This means the user changed something at the current point in history. Save the temporary command.
+                if partial_command != self.__history[self.__history_point]:
+                    self.__command_cache = (self.__history_point, partial_command)
             self.__history_point = max(0, self.__history_point - 1)
             if self.__history_point < len(self.__history):
-                line = self.__history[self.__history_point]
+                line = self.__command_cache[1] if self.__command_cache[0] == self.__history_point else self.__history[self.__history_point]
                 self.__text_edit_widget.move_cursor_position("start_para", "move")
                 self.__text_edit_widget.move_cursor_position("end_para", "keep")
                 prompt = self.continuation_prompt if self.__incomplete else self.prompt
@@ -162,12 +169,17 @@ class ConsoleWidget(Widgets.CompositeWidgetBase):
 
         if is_cursor_on_last_line and key.is_down_arrow:
             if self.__history_point is not None:
+                if self.__history_point < len(self.__history):
+                    # This means the user changed something at the current point in history.
+                    # Save the temporary command, but only if the user actually typed something
+                    if partial_command and partial_command != self.__history[self.__history_point]:
+                        self.__command_cache = (self.__history_point, partial_command)
                 self.__history_point = min(len(self.__history), self.__history_point + 1)
                 if self.__history_point < len(self.__history):
-                    line = self.__history[self.__history_point]
+                    line = self.__command_cache[1] if self.__command_cache[0] == self.__history_point else self.__history[self.__history_point]
                 else:
                     self.__history_point = None
-                    line = self.__command_cache
+                    line = self.__command_cache[1] if self.__command_cache[0] is None else ""
                 self.__text_edit_widget.move_cursor_position("start_para", "move")
                 self.__text_edit_widget.move_cursor_position("end_para", "keep")
                 prompt = self.continuation_prompt if self.__incomplete else self.prompt


### PR DESCRIPTION
Lots of small improvements to the Swift builtin console:

- FIXED: When the cursor is in a line where the text is not white and you hit "enter", the new line has the same color as the line where the cursor was before.

- FIXED: Starting an assignment (e.g. a = api.) and hitting <TAB> removes everything until the equals sign when there is more than one suggestion for the completion. Similar behavior for starting a function call and hitting <TAB> after the opening parenthesis.

- IMPROVED: Overall behavior of <TAB> key, for instance you can now use tab to indent code when the cursor is not at the last position in the last line.

- IMPROVED: Behavior of up/down arrows when moving through history is now very similar to how bash does it. Most importantly unfinished commands (i.e. "enter" was not pressed) will be kept as a temporary history.

- CHANGED: The interpretation, auto-completion and history are now in a separate class. "ConsoleDialog" only handles display-related tasks, everything else is handled by the new class "ConsoleDialogController".
