### PR TITLE
Fix bug where foreign layers could not be inserted before index 0

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -1131,7 +1131,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         else:
             end_index = len(self.__legend_entries) - (1 if not insertion else 0)
             # return the current item, clamped to length-1 and 0
-            return max(min(y // line_height, end_index), 0)
+            return max(min(index, end_index), 0)
 
     def mouse_position_changed(self, x, y, modifiers):
         # if the mouse is pressed and the distance it greater than the distance to start dragging, start the drag using
@@ -1275,7 +1275,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         font = "{0:d}px".format(self.font_size)
 
         effective_entries_and_foreign = self.__effective_entries[:]
-        if self.__foreign_legend_entry is not None and self.__entry_to_insert:
+        if self.__foreign_legend_entry is not None and self.__entry_to_insert is not None:
             effective_entries_and_foreign.insert(self.__entry_to_insert, self.__foreign_legend_entry)
 
         legend_height = len(effective_entries_and_foreign) * line_height + border * 2


### PR DESCRIPTION
This check would fail incorrectly when __entry_to_insert == 0.
```
if self.__foreign_legend_entry is not None and self.__entry_to_insert:
```