### PR TITLE
Add MANIFEST.in to include missing files in the source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include nion *.png *.json


### PR DESCRIPTION
Files are missing from the source distribution (.tar.tz) on pypi. Add MANIFEST.in to include them.