### PR TITLE
Add support for folders to Run Script. Add script folders to sys.path.

### DIFF
--- a/nion/swift/ScriptsDialog.py
+++ b/nion/swift/ScriptsDialog.py
@@ -8,6 +8,11 @@ import gettext
 import os
 import threading
 import traceback
+import typing
+import re
+import locale
+from importlib import reload
+import sys
 
 # typing
 from typing import AbstractSet
@@ -24,6 +29,7 @@ from nion.ui import Dialog
 from nion.ui import Widgets
 from nion.utils import Converter
 from nion.utils import Selection
+from nion.utils import Geometry
 
 _ = gettext.gettext
 
@@ -111,6 +117,121 @@ def pose_confirmation_message_box(ui, message_column, caption, accepted_fn, reje
     return message_box_widget
 
 
+class ScriptListItem:
+    def __init__(self, full_path: str, indent: int = 0, show_dirname: bool = True):
+        self.__full_path = os.path.abspath(full_path)
+        self.indent = indent
+        self.show_dirname = show_dirname
+
+    @property
+    def full_path(self) -> str:
+        return self.__full_path
+
+    @property
+    def basename(self) -> str:
+        return os.path.basename(self.full_path)
+
+    @property
+    def dirname(self) -> str:
+        return os.path.dirname(self.full_path)
+
+    # Used by "sort"
+    def __lt__(self, other) -> bool:
+        if isinstance(other, FolderListItem):
+            return False
+        if isinstance(other, ScriptListItem):
+            return locale.strxfrm(self.basename) < locale.strxfrm(other.basename)
+        return NotImplemented
+
+
+class FolderListItem(ScriptListItem):
+    def __init__(self, full_path: str, content: typing.Optional[list] = None):
+        super().__init__(full_path)
+        self.__content = content if content is not None else list()
+        self.folder_closed = True
+
+    @property
+    def content(self) -> list:
+        return self.__content
+
+    def update_content_from_file_system(self, filter_pattern: typing.Optional[str] = None):
+        if os.path.isdir(self.full_path):
+            dirlist = os.listdir(self.full_path)
+            filtered_items = list()
+            for item in dirlist:
+                if filter_pattern is None or re.search(filter_pattern, item):
+                    filtered_items.append(ScriptListItem(os.path.join(self.full_path, item), indent=20, show_dirname=False))
+            self.__content = filtered_items
+
+    # Used by "sort"
+    def __lt__(self, other) -> bool:
+        if isinstance(other, FolderListItem):
+            return locale.strxfrm(self.basename) < locale.strxfrm(other.basename)
+        if isinstance(other, ScriptListItem):
+            return True
+        return NotImplemented
+
+
+def _build_sorted_scripts_list(scripts_list):
+        filtered_items = []
+        for item in scripts_list:
+            if item.indent == 0:
+                filtered_items.append(item)
+        filtered_items.sort()
+        set_items = []
+        for item in filtered_items:
+            set_items.append(item)
+            if isinstance(item, FolderListItem):
+                if not item.folder_closed:
+                    for content_item in item.content:
+                        set_items.append(content_item)
+        return set_items
+
+
+class ScriptListCanvasItemDelegate(Widgets.ListCanvasItemDelegate):
+
+    def __init__(self, ui, update_list_fn: typing.Callable[[], typing.Any]):
+        super().__init__()
+        self.__ui = ui
+        self.__update_list_fn = update_list_fn
+
+    def close(self):
+        ...
+
+    def mouse_pressed_in_item(self, mouse_index: int, pos: Geometry.IntPoint, modifiers) -> bool:
+        display_item = self.items[mouse_index]
+        if isinstance(display_item, FolderListItem) and display_item.indent < pos.x < display_item.indent + 20:
+            display_item.folder_closed = not display_item.folder_closed
+            self.__update_list_fn()
+            return True
+        return False
+
+    def paint_item(self, drawing_context, display_item, rect, is_selected):
+        folder_string = ''
+        if isinstance(display_item, FolderListItem):
+            if display_item.folder_closed:
+                folder_string = f"\N{BLACK RIGHT-POINTING TRIANGLE} \N{FILE FOLDER} "
+            else:
+                folder_string = f"\N{BLACK DOWN-POINTING TRIANGLE} \N{OPEN FILE FOLDER} "
+
+        if isinstance(display_item, ScriptListItem):
+            with drawing_context.saver():
+
+                drawing_context.fill_style = "#000"
+                drawing_context.font = "12px"
+                drawing_context.text_align = "left"
+                drawing_context.text_baseline = "bottom"
+                name_string = folder_string + display_item.basename
+                drawing_context.fill_text(name_string, rect[0][1] + 4 + display_item.indent, rect[0][0] + 20 - 4)
+                if display_item.show_dirname:
+                    drawing_context.fill_style = "#888"
+                    drawing_context.font = "8px"
+                    name_width = self.__ui.get_font_metrics("12px", name_string).width
+                    drawing_context.fill_text(f"({display_item.dirname})",
+                                              rect[0][1] + 4 + display_item.indent + 4 + name_width,
+                                              rect[0][0] + 20 - 4)
+
+
 class RunScriptDialog(Dialog.ActionDialog):
 
     def __init__(self, document_controller):
@@ -137,7 +258,25 @@ class RunScriptDialog(Dialog.ActionDialog):
 
         self.__message_column.add(self.__make_cancel_row())
 
-        items = self.ui.get_persistent_object("interactive_scripts_0", list())
+
+
+        items = self.ui.get_persistent_object("interactive_scripts_1", list())
+        if not items:
+            items_old = self.ui.get_persistent_object("interactive_scripts_0", list())
+            for item in items_old:
+                items.append(ScriptListItem(item))
+        if items:
+            items = _build_sorted_scripts_list(items)
+            self.ui.set_persistent_object("interactive_scripts_1", items)
+
+        self.__new_path_entries = []
+
+        for item in items:
+            if isinstance(item, FolderListItem):
+                full_path = item.full_path
+                self.__new_path_entries.append(full_path)
+                if not full_path in sys.path:
+                    sys.path.append(full_path)
 
         def selected_changed(indexes: AbstractSet[int]) -> None:
             run_button_widget.enabled = len(indexes) == 1
@@ -146,34 +285,54 @@ class RunScriptDialog(Dialog.ActionDialog):
             add_dir = self.ui.get_persistent_string("import_directory", "")
             file_paths, filter_str, directory = self.get_file_paths_dialog(_("Add Scripts"), add_dir, "Python Files (*.py)", "Python Files (*.py)")
             self.ui.set_persistent_string("import_directory", directory)
-            items.extend(file_paths)
-            items.sort()
-            list_widget.items = items
-            self.ui.set_persistent_object("interactive_scripts_0", items)
+            items = self.scripts_list_widget.items
+            items.extend([ScriptListItem(file_path) for file_path in file_paths])
+            self.update_scripts_list(items)
+
+        def add_folder_clicked() -> None:
+            add_dir = self.ui.get_persistent_string("import_directory", "")
+            existing_directory, directory = self.ui.get_existing_directory_dialog(_("Add Scripts Folder"), add_dir)
+            if existing_directory:
+                new_folder = FolderListItem(existing_directory)
+                new_folder.update_content_from_file_system(filter_pattern="\.py$")
+                full_path = new_folder.full_path
+                if not full_path in sys.path:
+                    sys.path.append(full_path)
+                    self.__new_path_entries.append(full_path)
+                items = self.scripts_list_widget.items
+                items.append(new_folder)
+                self.update_scripts_list(items)
 
         def remove_clicked() -> None:
-            indexes = list(list_widget.selected_items)
-            for index in sorted(indexes, reverse=True):
-                del items[index]
-            list_widget.items = items
-            self.ui.set_persistent_object("interactive_scripts_0", items)
+            indexes = list(self.scripts_list_widget.selected_items)
+            new_items = []
+            for i, item in enumerate(self.scripts_list_widget.items):
+                if not i in indexes:
+                    new_items.append(item)
+            self.update_scripts_list(new_items)
 
         def run_clicked() -> None:
-            indexes = list_widget.selected_items
+            indexes = self.scripts_list_widget.selected_items
             if len(indexes) == 1:
-                script_path = items[list(indexes)[0]]
-                self.run_script(script_path)
+                script_item = self.scripts_list_widget.items[list(indexes)[0]]
+                # Use "type" instead of "isinstance" to exclude subclasses from matching
+                if type(script_item) is ScriptListItem:
+                    script_path = script_item.full_path
+                    self.run_script(script_path)
 
         def item_selected(index: int) -> bool:
             run_clicked()
             return True
 
-        list_widget = Widgets.StringListWidget(ui, items=items, selection_style=Selection.Style.single_or_none, border_color="#888", properties={"min-height": 200, "min-width": 560})
-        list_widget.on_selection_changed = selected_changed
-        list_widget.on_item_selected = item_selected
+        self.scripts_list_widget = Widgets.ListWidget(ui, ScriptListCanvasItemDelegate(ui, self.rebuild_scripts_list), items=items, selection_style=Selection.Style.single_or_none, border_color="#888", properties={"min-height": 200, "min-width": 560, "size-policy-vertical": "expanding"})
+        self.scripts_list_widget.on_selection_changed = selected_changed
+        self.scripts_list_widget.on_item_selected = item_selected
 
         add_button_widget = ui.create_push_button_widget(_("Add..."))
         add_button_widget.on_clicked = add_clicked
+
+        add_folder_button_widget = ui.create_push_button_widget(_("Add Folder..."))
+        add_folder_button_widget.on_clicked = add_folder_clicked
 
         remove_button_widget = ui.create_push_button_widget(_("Remove"))
         remove_button_widget.on_clicked = remove_clicked
@@ -184,7 +343,7 @@ class RunScriptDialog(Dialog.ActionDialog):
 
         list_widget_row = ui.create_row_widget()
         list_widget_row.add_spacing(8)
-        list_widget_row.add(list_widget)
+        list_widget_row.add(self.scripts_list_widget)
         list_widget_row.add_spacing(8)
 
         close_button_widget = ui.create_push_button_widget(_("Close"))
@@ -193,6 +352,9 @@ class RunScriptDialog(Dialog.ActionDialog):
         button_row = ui.create_row_widget()
         button_row.add_spacing(12)
         button_row.add(add_button_widget)
+        button_row.add_spacing(4)
+        button_row.add(add_folder_button_widget)
+        button_row.add_spacing(4)
         button_row.add(remove_button_widget)
         button_row.add_stretch()
         button_row.add(run_button_widget)
@@ -233,6 +395,13 @@ class RunScriptDialog(Dialog.ActionDialog):
     def cancelled(self):
         return self.__cancelled
 
+    def update_scripts_list(self, new_scripts_list):
+        self.scripts_list_widget.items = _build_sorted_scripts_list(new_scripts_list)
+        self.ui.set_persistent_object("interactive_scripts_1", self.scripts_list_widget.items)
+
+    def rebuild_scripts_list(self):
+        self.update_scripts_list(self.scripts_list_widget.items)
+
     def __make_cancel_row(self):
         def cancel_script():
             self.__cancelled = True
@@ -246,6 +415,24 @@ class RunScriptDialog(Dialog.ActionDialog):
         return cancel_row
 
     def run_script(self, script_path: str) -> None:
+        # Reload modules that are in on of the script folders.
+        current_modules = list(sys.modules.values())
+        for module in current_modules:
+            for path in self.__new_path_entries:
+                try:
+                    do_reload = os.path.abspath(module.__file__)[:len(path)] == path
+                except (AttributeError, ValueError, TypeError):
+                    pass
+                else:
+                    try:
+                        if do_reload:
+                            reload(module)
+                    except:
+                        self.print(traceback.format_exc())
+                        self.__stack.current_index = 1
+                        self.continue_after_parse_error(script_path)
+                        return
+
         self.__output_widget.text = None
 
         script_name = os.path.basename(script_path)

--- a/nion/swift/ScriptsDialog.py
+++ b/nion/swift/ScriptsDialog.py
@@ -241,6 +241,8 @@ class RunScriptDialog(Dialog.ActionDialog):
         self.ui = ui
         self.document_controller = document_controller
 
+        self.script_filter_pattern = "\.py$"
+
         self._create_menus()
 
         self.__cancelled = False
@@ -294,7 +296,7 @@ class RunScriptDialog(Dialog.ActionDialog):
             existing_directory, directory = self.ui.get_existing_directory_dialog(_("Add Scripts Folder"), add_dir)
             if existing_directory:
                 new_folder = FolderListItem(existing_directory)
-                new_folder.update_content_from_file_system(filter_pattern="\.py$")
+                new_folder.update_content_from_file_system(filter_pattern=self.script_filter_pattern)
                 full_path = new_folder.full_path
                 if not full_path in sys.path:
                     sys.path.append(full_path)
@@ -400,6 +402,10 @@ class RunScriptDialog(Dialog.ActionDialog):
         self.ui.set_persistent_object("interactive_scripts_1", self.scripts_list_widget.items)
 
     def rebuild_scripts_list(self):
+        items = self.scripts_list_widget.items
+        for item in items:
+            if isinstance(item, FolderListItem):
+                item.update_content_from_file_system(filter_pattern=self.script_filter_pattern)
         self.update_scripts_list(self.scripts_list_widget.items)
 
     def __make_cancel_row(self):


### PR DESCRIPTION
This is the implementation of what we discussed via Email last week.
New features:

- You can now add folders to the Run Script system. Every top-level python file in a folder will be treated as a script and shown underneath the folder
- Folders are automatically added to `sys.path` so that you can import from packages that are inside script folders
- Modules from script folders will automatically be reloaded (via `importlib.reload`) before a script is executed
- Scripts are now sorted by script name only instead of their full path. Additionally, the path to a script is only shown in small and gray font after the script name.