### PR TITLE
Make sure tick labels are not wider than drawing area for log line plots.

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -152,6 +152,18 @@ class LineGraphAxes:
         return self.__calibrated_data_max
 
     @property
+    def calibrated_value_max(self):
+        if self.data_style == "log":
+            return math.pow(10, self.__calibrated_data_max)
+        return self.__calibrated_data_max
+
+    @property
+    def calibrated_value_min(self):
+        if self.data_style == "log":
+            return math.pow(10, self.__calibrated_data_min)
+        return self.__calibrated_data_min
+
+    @property
     def drawn_left_channel(self):
         assert self.is_valid
         return self.__uncalibrated_left_channel
@@ -896,10 +908,10 @@ class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
             font = "{0:d}px".format(self.font_size)
 
             max_width = 0
-            y_range = axes.calibrated_data_max - axes.calibrated_data_min
-            label = axes.y_ticker.value_label(axes.calibrated_data_max + y_range * 5)
+            y_range = axes.calibrated_value_max - axes.calibrated_value_min
+            label = axes.y_ticker.value_label(axes.calibrated_value_max + y_range * 5)
             max_width = max(max_width, get_font_metrics_fn(font, label).width)
-            label = axes.y_ticker.value_label(axes.calibrated_data_min - y_range * 5)
+            label = axes.y_ticker.value_label(axes.calibrated_value_min - y_range * 5)
             max_width = max(max_width, get_font_metrics_fn(font, label).width)
 
             new_sizing.minimum_width = max_width


### PR DESCRIPTION
The function that calculates the width of the y-axis tick labels widget was not aware of log-scale data. Since the data that gets drawn is the log of the actual data this width was too small for large values (for 10,000 it would calculate the width for a max value of 5). Now the system is aware of log-scaled data and calculates the width corretly.