### PR TITLE
Add some graphics operations to context menu.

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2070,6 +2070,40 @@ class DisplayPanelManager(metaclass=Utility.Singleton):
 
         display_panel_type = display_panel.display_panel_type
 
+        if display_panel_type == "data_item" and display_panel.display_canvas_item:
+            valid_graphics = display_panel.display_canvas_item.valid_graphics_descriptions
+            if display_panel.display_item and display_panel.display_item.graphic_selection.has_selection:
+                valid_graphics += [{
+                                        "type": "separator"
+                                    },
+                                    {
+                                        "type": "item",
+                                        "action_id": "graphics.add_graphic_mask"
+                                    },
+                                    {
+                                        "type": "item",
+                                        "action_id": "graphics.remove_graphic_mask"
+                                    },
+                                    {
+                                        "type": "separator"
+                                    },
+                                    {
+                                        "type": "item",
+                                        "action_id": "window.delete"
+                                    }]
+            graphics_menu_description = [
+               {
+                "type": "sub_menu",
+                "menu_id": "processing_transform",
+                "title": "Graphics",
+                "items": valid_graphics
+                },
+                {
+                 "type": "separator"
+                }
+            ]
+            document_controller.build_menu(display_type_menu, graphics_menu_description)
+
         empty_action.checked = display_panel_type == "empty" and display_panel.display_panel_controller is None
         data_item_display_action.checked = display_panel_type == "data_item"
         thumbnail_browser_action.checked = display_panel_type == "horizontal"

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -501,6 +501,27 @@ class ImageCanvasItem(CanvasItem.LayerCanvasItem):
     def _info_overlay_canvas_item_for_test(self):
         return self.__info_overlay_canvas_item
 
+    @property
+    def valid_graphics_descriptions(self):
+        return [
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_line_graphic"
+                },
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_ellipse_graphic"
+                },
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_rectangle_graphic"
+                },
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_point_graphic"
+                }
+               ]
+
     def update_display_values(self, display_values_list) -> None:
         self.__display_values = display_values_list[0] if display_values_list else None
         self.__display_values_dirty = True

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -251,6 +251,19 @@ class LinePlotCanvasItem(CanvasItem.LayerCanvasItem):
     def _has_valid_drawn_graph_data(self):
         return self.___has_valid_drawn_graph_data
 
+    @property
+    def valid_graphics_descriptions(self):
+        return [
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_interval_graphic"
+                },
+                {
+                    "type": "item",
+                    "action_id": "graphics.add_channel_graphic"
+                }
+               ]
+
     def __update_legend_origin(self):
         plot_rect = self.__line_graph_area_stack.canvas_bounds
         if plot_rect:

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1192,14 +1192,14 @@ class TestDisplayPanelClass(unittest.TestCase):
     def test_image_display_panel_produces_context_menu_with_correct_item_count(self):
         self.assertIsNone(self.document_controller.ui.popup)
         self.display_panel.root_container.canvas_widget.on_context_menu_event(500, 500, 500, 500)
-        # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(15, len(self.document_controller.ui.popup.items))
+        # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep, graphics, sep
+        self.assertEqual(17, len(self.document_controller.ui.popup.items))
 
     def test_image_display_panel_produces_context_menu_with_correct_item_count_outside_image_area(self):
         self.assertIsNone(self.document_controller.ui.popup)
         self.display_panel.root_container.canvas_widget.on_context_menu_event(10, 32, 10, 32)  # header + 10
-        # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(15, len(self.document_controller.ui.popup.items))
+        # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep, graphics, sep
+        self.assertEqual(17, len(self.document_controller.ui.popup.items))
 
     def test_image_display_panel_with_no_image_produces_context_menu_with_correct_item_count(self):
         self.display_panel.set_display_panel_display_item(None)


### PR DESCRIPTION
This does not add a keyboard shortcut as requested in #382 but the context menu functionality we discussed there.
The context menu entries are dynamically adapted to the display type of the data panel and whether a graphic is currently selected or not.