### PR TITLE
Line plot bugfixes

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -392,7 +392,7 @@ def draw_line_graph(drawing_context, plot_height, plot_width, plot_origin_y, plo
                 binned_data = Image.rebin_1d(calibrated_data, binned_length, rebin_cache)
                 binned_left = int(uncalibrated_left_channel * plot_width / uncalibrated_width)
                 # draw the plot
-                last_px = plot_origin_x
+                px = plot_origin_x
                 last_py = baseline
                 for i in range(0, plot_width):
                     px = plot_origin_x + i
@@ -419,24 +419,21 @@ def draw_line_graph(drawing_context, plot_height, plot_width, plot_origin_y, plo
                             else:
                                 stroke_path.move_to(px, baseline)
                                 stroke_path.line_to(px, py)
-                        last_px = px
                         last_py = py
                     else:
                         if did_draw:
                             did_draw = False
                             stroke_path.line_to(px, last_py)
                             if stroke_color and not fill_color:
-                                stroke_path.line_to(last_px, shape_origin_y)
-                            finalize_path(drawing_context, stroke_path, shape_origin_x, last_px, shape_origin_y, fill_color, stroke_color)
+                                stroke_path.line_to(px, shape_origin_y)
+                            finalize_path(drawing_context, stroke_path, shape_origin_x, px, shape_origin_y, fill_color, stroke_color)
                             stroke_path = DrawingContext.DrawingContext()
                             drawing_context.begin_path()
-                        last_px = px
-                        #stroke_path.move_to(px, last_py)
 
                 stroke_path.line_to(plot_origin_x + plot_width, last_py)
 
-            if did_draw:
-                finalize_path(drawing_context, stroke_path, shape_origin_x, last_px, shape_origin_y, fill_color, stroke_color)
+                if did_draw:
+                    finalize_path(drawing_context, stroke_path, shape_origin_x, px, shape_origin_y, fill_color, stroke_color)
 
         else:
             if fill_color or stroke_color:

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -968,8 +968,7 @@ class Exponenter:
     def draw_scientific_notation(self, drawing_context: DrawingContext.DrawingContext, ui_settings: UISettings.UISettings, fonts: typing.Tuple[str, str], label: str, width: int, y: int) -> None:
         labels = self.used_labels(label)
         if labels[1] is not None:
-            mw = max(ui_settings.get_font_metrics(fonts[1], _labels[1]).width for _labels in self.__labels_list)
-            w = ui_settings.get_font_metrics(fonts[1], labels[1])
+            mw = max([ui_settings.get_font_metrics(fonts[1], _labels[1]).width for _labels in self.__labels_list], default=0)
             drawing_context.font = fonts[0]
             drawing_context.text_align = "right"
             drawing_context.fill_text(labels[0], width - mw, y)

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -376,9 +376,10 @@ def draw_line_graph(drawing_context, plot_height, plot_width, plot_origin_y, plo
         drawing_context.begin_path()
         if calibrated_data_range != 0.0 and uncalibrated_width > 0.0:
             if data_style == "log":
-                baseline = plot_origin_y + plot_height - (plot_height * float(numpy.amin(calibrated_xdata.data) - calibrated_data_min) / calibrated_data_range)
+                baseline = plot_origin_y + plot_height
             else:
                 baseline = plot_origin_y + plot_height - (plot_height * float(0.0 - calibrated_data_min) / calibrated_data_range)
+
             baseline = min(plot_origin_y + plot_height, baseline)
             baseline = max(plot_origin_y, baseline)
             # rebin so that uncalibrated_width corresponds to plot width

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -321,6 +321,29 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.display_canvas_item.layout_immediate((640, 480))
             display_panel.display_canvas_item.simulate_click((240, 16))
 
+    def test_narrow_line_plot_with_nans_is_drawn_properly(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            display_panel = document_controller.selected_display_panel
+            data = numpy.random.rand(200)
+            data[0] = numpy.nan
+            data_item = DataItem.DataItem(data)
+            data_item.set_xdata(DataAndMetadata.new_data_and_metadata(data))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item.layout_immediate((100, 480))
+            axes = display_panel.display_canvas_item._axes
+            drawing_context = DrawingContext.DrawingContext()
+            calibrated_data_min = axes.calibrated_data_min
+            calibrated_data_max = axes.calibrated_data_max
+            calibrated_data_range = calibrated_data_max - calibrated_data_min
+            display_xdata = display_panel.display_canvas_item.line_graph_canvas_item.calibrated_xdata
+            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 100, 0, 0, display_xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style)
+            # ensure that the drawing commands are sufficiently populated to have drawn the graph
+            self.assertGreater(len(drawing_context.commands), 100)
+
     def test_check_exponents(self):
         e = LineGraphCanvasItem.Exponenter()
         e.add_label("5e+05")


### PR DESCRIPTION
The test I added in the last commit fails for now, because it is fixed by nion-software/niondata#21.

The problem it highlights is that data containing nans will be handled improperly by the binning algorithm used for calculating the data of display panels that are fewer pixels wide than their data. One nan pixel can cause all pixels being nan after binning which will result in an empty line plot. Even thought the fix is in niondata, I still think this test should be here because it covers an important case for line plots.