### PR TITLE
Move script item persistent to profile. Clean up.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,16 +41,24 @@ jobs:
     - name: Test
       run: |
         python -m unittest discover -p '*_test.py'
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/DataPanel.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/DocumentController.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/GeneratorDialog.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/model/FileStorageSystem.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/model/HDF5Handler.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/model/NDataHandler.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/model/Schema.py
-        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent nion/swift/model/StorageHandler.py
-        flake8 --max-line-length=160 nion/swift/GeneratorDialog.py
-        flake8 --max-line-length=160 nion/swift/model/FileStorageSystem.py
+        mypy --namespace-packages --ignore-missing-imports --follow-imports=silent \
+          nion/swift/DataPanel.py \
+          nion/swift/DocumentController.py \
+          nion/swift/GeneratorDialog.py \
+          nion/swift/ScriptsDialog.py \
+          nion/swift/model/FileStorageSystem.py \
+          nion/swift/model/HDF5Handler.py \
+          nion/swift/model/Model.py \
+          nion/swift/model/NDataHandler.py \
+          nion/swift/model/Profile.py \
+          nion/swift/model/Schema.py \
+          nion/swift/model/StorageHandler.py
+        flake8 --max-line-length=160 \
+          nion/swift/GeneratorDialog.py \
+          nion/swift/ScriptsDialog.py \
+          nion/swift/model/FileStorageSystem.py \
+          nion/swift/model/Model.py \
+          nion/swift/model/Profile.py
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1134,6 +1134,8 @@ class DisplayLayer(Schema.Entity):
     def fill_color(self, value: typing.Optional[str]) -> None:
         self._set_field_value("fill_color", value)
 
+    # standard overrides from entity to fit within persistent object architecture
+
     def _field_value_changed(self, name: str, value: typing.Any) -> None:
         # this is called when a property changes. to be compatible with the older
         # persistent object structure, check if persistent storage exists and pass

--- a/nion/swift/model/Model.py
+++ b/nion/swift/model/Model.py
@@ -352,11 +352,24 @@ FolderProjectReference = Schema.entity("project_folder", ProjectReference, None,
 MemoryProjectReference = Schema.entity("project_memory", ProjectReference, None, {
 })
 
+ScriptItem = Schema.entity("script_item", None, None, {
+})
+
+FileScriptItem = Schema.entity("file_script_item", ScriptItem, None, {
+    "path": Schema.prop(Schema.PATH),
+})
+
+FolderScriptItem = Schema.entity("folder_script_item", ScriptItem, None, {
+    "folder_path": Schema.prop(Schema.PATH),
+    "is_closed": Schema.prop(Schema.BOOLEAN),
+})
+
 Profile = Schema.entity("profile", None, 2, {
     "project_references": Schema.array(Schema.component(ProjectReference)),
     "last_project_reference": Schema.reference(ProjectReference),
     "work_project": Schema.reference(ProjectReference),
     "closed_items": Schema.prop(Schema.SET),
+    "script_items": Schema.array(Schema.component(ScriptItem)),
 })
 
 Profile.rename("target_project", "target_project_reference_uuid")

--- a/nion/swift/model/Schema.py
+++ b/nion/swift/model/Schema.py
@@ -573,7 +573,7 @@ class ArrayType(FieldType):
 
 
 class MapType(FieldType):
-    def __init__(self, key: FieldType, value: FieldType, optional: bool):
+    def __init__(self, key: str, value: FieldType, optional: bool):
         super().__init__(MapField, key, value, optional)
         self.key = key
         self.value = value
@@ -873,7 +873,7 @@ def record(field_type_map: typing.Dict[str, FieldType]) -> RecordType:
 def array(type: FieldType, optional: bool = False) -> ArrayType:
     return ArrayType(type, optional)
 
-def map(key: FieldType, value: FieldType, optional: bool = False) -> MapType:
+def map(key: str, value: FieldType, optional: bool = False) -> MapType:
     return MapType(key, value, optional)
 
 def reference(type: typing.Optional[EntityType] = None) -> ReferenceType:


### PR DESCRIPTION
This prepares for expanding script item capabilities, such as
marking them as startup items or using them as buttons in dialogs.
Also type and code checking.
