### PR TITLE
Fix bug when dragging channel graphic outside data range. Fixes #644.

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -621,7 +621,6 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
             self.update()
 
     def _repaint(self, drawing_context):
-
         # draw the data, if any
         axes = self.__axes
         data = self.__calibrated_data
@@ -665,7 +664,12 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
                     if region.style == "tag" and data is not None:
                         if calibrated_data_range != 0.0:
                             channel = (left_channel + right_channel) / 2
-                            data_value = data[int(channel * data.shape[0])]
+                            data_index = int(channel * data.shape[0])
+                            if 0 <= data_index < len(data):
+                                data_value = data[data_index]
+                            else:
+                                data_value = 0
+                                #data_value = data[data_index]
                             py = plot_origin_y + plot_height - (plot_height * (data_value - calibrated_data_min) / calibrated_data_range)
                             py = max(plot_origin_y, py)
                             py = min(plot_origin_y + plot_height, py)


### PR DESCRIPTION
I also tried to write a test for this, but I couldn't figure out how to make the system actually repaint the graphics on the line plot.

My test would look something like this:

```python
def test_channel_graphic_outside_data_range_does_not_fail(self):
        with TestContext.create_memory_context() as test_context:
            document_controller = test_context.create_document_controller()
            document_model = document_controller.document_model
            display_panel = document_controller.selected_display_panel
            data_item = DataItem.DataItem(numpy.arange(10))
            document_model.append_data_item(data_item)
            display_item = document_model.get_display_item_for_data_item(data_item)
            display_item.set_display_property('right_channel', 25)
            channel_graphic = Graphics.ChannelGraphic()
            channel_graphic.position = 0.99
            display_item.add_graphic(channel_graphic)
            display_panel.set_display_panel_display_item(display_item)
            display_panel.layout_immediate((640, 480))
            document_controller.periodic()
            display_panel.display_canvas_item.refresh_layout_immediate()
``` 

And then there needs to be some call that triggers drawing, I guess.