### PR TITLE
Fix #681. Normalize string used in axis label size calculation.

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -11,6 +11,7 @@
 import collections
 import gettext
 import math
+import re
 import typing
 
 # third party libraries
@@ -969,12 +970,20 @@ class Exponenter:
             drawing_context.fill_text(label, width, y)
 
 
+_LABEL_SIZE_CALCULATION_NORMALIZE_RE = re.compile(r"\d")
+
+
+def _normalize_label_for_size_calculation(label):
+    return _LABEL_SIZE_CALCULATION_NORMALIZE_RE.sub("0", label)
+
+
 def calculate_scientific_notation_drawing_width(ui_settings: UISettings.UISettings, fonts: typing.Tuple[str, str], label: str) -> int:
     labels = label.lower().split("e")
     if len(labels) == 2:
         labels[0] = labels[0] + " x 10"
         labels[1] = str(int(labels[1]))
-    return sum(ui_settings.get_font_metrics(font, label).width for font, label in zip(fonts, labels))
+    return sum(ui_settings.get_font_metrics(font, _normalize_label_for_size_calculation(label)).width
+               for font, label in zip(fonts, labels))
 
 
 

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -448,7 +448,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
         does not change for moderate sized drags.
         """
         with TestContext.create_memory_context() as test_context:
-            document_controller = test_context.create_document_controller(ui=TestContext.VarWidthSystemFontUserInterface())
+            document_controller = test_context.create_document_controller()
             document_model = document_controller.document_model
             display_panel = document_controller.selected_display_panel
             data = numpy.sin(numpy.linspace(0, 20, 100)) * 53488.2

--- a/nion/swift/test/TestContext.py
+++ b/nion/swift/test/TestContext.py
@@ -14,7 +14,6 @@ from nion.swift.model import NDataHandler
 from nion.swift.model import Persistence
 from nion.swift.model import Profile
 from nion.ui import TestUI
-from nion.ui import UserInterface as UserInterfaceModule
 from nion.utils import Event
 
 
@@ -36,17 +35,6 @@ def end_leaks(test_case: unittest.TestCase) -> None:
     test_case.assertEqual(0, Persistence.PersistentObjectReference.count)
     test_case.assertEqual(0, Persistence.PersistentObject.count)
 
-
-class VarWidthSystemFontUserInterface(TestUI.UserInterface):
-    def get_font_metrics(self, font_str: str, text: str) -> UserInterfaceModule.FontMetrics:
-        var_char_widths = {
-            '1': 5.0,
-            '6': 8.0, '9': 8.0, '0': 8.0,
-            '.': 4.0
-        }
-        default_char_width = 7.0
-        var_text_width = int(round(sum(map((lambda _: var_char_widths.get(_, default_char_width)), text))))
-        return UserInterfaceModule.FontMetrics(width=var_text_width, height=12, ascent=10, descent=2, leading=0)
 
 class MemoryProfileContext:
     # used for testing
@@ -130,12 +118,9 @@ class MemoryProfileContext:
             self.__items_to_close.append(document_model)
         return document_model
 
-    def create_document_controller(self, *, auto_close: bool = True, var_width_font: bool = False,
-                                   ui: UserInterfaceModule.UserInterface = None) -> DocumentController.DocumentController:
-        if ui is None:
-            ui = TestUI.UserInterface()
+    def create_document_controller(self, *, auto_close: bool = True) -> DocumentController.DocumentController:
         document_model = self.create_document_model(auto_close=False)
-        document_controller = DocumentController.DocumentController(ui, document_model, workspace_id="library")
+        document_controller = DocumentController.DocumentController(TestUI.UserInterface(), document_model, workspace_id="library")
         if auto_close:
             self.__items_to_close.append(document_controller)
         return document_controller

--- a/nion/swift/test/TestContext.py
+++ b/nion/swift/test/TestContext.py
@@ -14,6 +14,7 @@ from nion.swift.model import NDataHandler
 from nion.swift.model import Persistence
 from nion.swift.model import Profile
 from nion.ui import TestUI
+from nion.ui import UserInterface as UserInterfaceModule
 from nion.utils import Event
 
 
@@ -35,6 +36,17 @@ def end_leaks(test_case: unittest.TestCase) -> None:
     test_case.assertEqual(0, Persistence.PersistentObjectReference.count)
     test_case.assertEqual(0, Persistence.PersistentObject.count)
 
+
+class VarWidthSystemFontUserInterface(TestUI.UserInterface):
+    def get_font_metrics(self, font_str: str, text: str) -> UserInterfaceModule.FontMetrics:
+        var_char_widths = {
+            '1': 5.0,
+            '6': 8.0, '9': 8.0, '0': 8.0,
+            '.': 4.0
+        }
+        default_char_width = 7.0
+        var_text_width = int(round(sum(map((lambda _: var_char_widths.get(_, default_char_width)), text))))
+        return UserInterfaceModule.FontMetrics(width=var_text_width, height=12, ascent=10, descent=2, leading=0)
 
 class MemoryProfileContext:
     # used for testing
@@ -118,9 +130,12 @@ class MemoryProfileContext:
             self.__items_to_close.append(document_model)
         return document_model
 
-    def create_document_controller(self, *, auto_close: bool = True) -> DocumentController.DocumentController:
+    def create_document_controller(self, *, auto_close: bool = True, var_width_font: bool = False,
+                                   ui: UserInterfaceModule.UserInterface = None) -> DocumentController.DocumentController:
+        if ui is None:
+            ui = TestUI.UserInterface()
         document_model = self.create_document_model(auto_close=False)
-        document_controller = DocumentController.DocumentController(TestUI.UserInterface(), document_model, workspace_id="library")
+        document_controller = DocumentController.DocumentController(ui, document_model, workspace_id="library")
         if auto_close:
             self.__items_to_close.append(document_controller)
         return document_controller

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = nionswift
 version = 0.15.7
 # requires nionutils>=0.3.27,<0.4.0 (single item dispatcher)
+# requires nionui>=0.5.3,<0.6.0 (var with text metrics in TestUI)
 author = Nion Software
 author_email = swift@nion.com
 description = Nion Swift: Scientific Image Processing.


### PR DESCRIPTION
This is not complete yet, but I wanted to create the PR to start a discussion about the general approach. As mentioned in the issue, the problem is that
- the content size calculation for the label is based on an integer calculated from the min/max calibrated bounds
- that integer is not rounded in any way, so as the axis is dragged the digits are changed almost pixel-by-pixel
- if the font is not monospace, the calculated width varies depending on which digits show up in the number
- thus the calculated width will tend to vary every pixel or so of drag.

The implemented fix avoids this by replacing all digits with `'0'` (because in most fonts it seems to be at least as wide as other digits), so it only varies roughly if the order of magnitude changes. This might be a slight overestimation of the width for the exact number, but it shouldn't be too much of one at least when the tick labels are rounded so most digits are `'0'`. 

A few questions
- How much of an expectation is there that the layout of a line plot does not vary between versions by a few pixels.
-- This question would apply both for this fix, and for potential further fine-tuning in later releases.
- Is there any reason to fine-tune the normalization so, say, it does not normalize the `'1'`in the exponential form `' x 10'` .
- Is there a reasonable way in tests to create a `UISettings.UISettings` instance so `calculate_scientific_notation_drawing_width` can be unit tested in isolation, or is the preferred way to test it via an actual line plot being rendered. 
- I'm not sure I'll do it yet here, but what is the preferred route for refactors related to an issue? The code related to calculating the size and rendering effectively copies the following logic in several places
```
    labels = label.lower().split("e")
    if len(labels) == 2:
        labels[0] = labels[0] + " x 10"
        labels[1] = str(int(labels[1]))
```
It is not that complex, but I think rearranging the code so all paths go through a shared path to break apart the exponential case would make the overall logic simpler. I'm guessing this should be a separate PR, but does it need an issue created, or should it be related to the issue that motivated it?
- The same label normalization when fitting a label-based canvas item to content could potentially be applied to the other components that call `self.__ui_settings.get_font_metrics`, which I guess is just `LineGraphLegendCanvasItem`. I'm not sure the problem will be as apparent in that component, unless there is a similar drag operation that will update the legend label in a similar manner to the vertical axis dragging, so there might not be an apparent need, but it naively seems to me that calculation of size for numbers should be done consistently.


### TODO
- ~~Decide whether normalization should be fine-tuned to match string more.~~
- ~~Add unit tests~~