### PR TITLE
Allow line plot stroke width to be changed. Add corresponding UI to Inspector.

### DIFF
--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -529,6 +529,7 @@ class LinePlotCanvasItem(CanvasItem.CanvasItemComposition):
             for index, display_layer in enumerate(self.__display_layers[0:max_layer_count]):
                 fill_color = display_layer.get("fill_color")
                 stroke_color = display_layer.get("stroke_color")
+                stroke_width = display_layer.get("stroke_width")
                 data_index = display_layer.get("data_index", 0)
                 data_row = display_layer.get("data_row", 0)
                 if 0 <= data_index < len(scalar_xdata_list):
@@ -543,6 +544,7 @@ class LinePlotCanvasItem(CanvasItem.CanvasItemComposition):
                     line_graph_canvas_item = self.__line_graph_stack.canvas_items[display_layer_count - (index + 1)]
                     line_graph_canvas_item.set_fill_color(fill_color)
                     line_graph_canvas_item.set_stroke_color(stroke_color)
+                    line_graph_canvas_item.set_stroke_width(stroke_width)
                     line_graph_canvas_item.set_axes(axes)
                     line_graph_canvas_item.set_uncalibrated_xdata(scalar_xdata)
                     self.___has_valid_drawn_graph_data = scalar_xdata is not None

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1134,6 +1134,14 @@ class DisplayLayer(Schema.Entity):
     def fill_color(self, value: typing.Optional[str]) -> None:
         self._set_field_value("fill_color", value)
 
+    @property
+    def stroke_width(self) -> typing.Optional[float]:
+        return self._get_field_value("stroke_width")
+
+    @stroke_width.setter
+    def stroke_width(self, value: typing.Optional[float]) -> None:
+        self._set_field_value("stroke_width", value)
+
     # standard overrides from entity to fit within persistent object architecture
 
     def _field_value_changed(self, name: str, value: typing.Any) -> None:
@@ -1466,7 +1474,7 @@ class DisplayItem(Observable.Observable, Persistence.PersistentObject):
 
     @property
     def display_layers_list(self) -> typing.List[typing.Dict[str, typing.Any]]:
-        properties = ["data_row", "fill_color", "stroke_color", "label"]
+        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width"]
         l = list()
         for display_layer in self.display_layers:
             d = dict()
@@ -1485,7 +1493,7 @@ class DisplayItem(Observable.Observable, Persistence.PersistentObject):
     @display_layers_list.setter
     def display_layers_list(self, value: typing.List[typing.Dict[str, typing.Any]]) -> None:
         assert len(value) == len(self.display_layers)
-        properties = ["data_row", "fill_color", "stroke_color", "label"]
+        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width"]
         for index, (display_layer, display_layer_dict) in enumerate(zip(self.display_layers, value)):
             for property in properties:
                 if not property in display_layer_dict:

--- a/nion/swift/model/Model.py
+++ b/nion/swift/model/Model.py
@@ -108,6 +108,7 @@ DisplayLayer = Schema.entity("display_layer", None, None, {
     "fill_color": Schema.prop(Schema.STRING),
     "label": Schema.prop(Schema.STRING),
     "display_data_channel": Schema.reference(DisplayDataChannel),
+    "stroke_width": Schema.prop(Schema.FLOAT),
 })
 
 Graphic = Schema.entity("graphic", None, None, {

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -241,7 +241,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             calibrated_data_min = axes.calibrated_data_min
             calibrated_data_max = axes.calibrated_data_max
             calibrated_data_range = calibrated_data_max - calibrated_data_min
-            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 640, 0, 0, data_item.xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style)
+            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 640, 0, 0, data_item.xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style, 0.5)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 
@@ -265,7 +265,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             calibrated_data_max = axes.calibrated_data_max
             calibrated_data_range = calibrated_data_max - calibrated_data_min
             display_xdata = display_panel.display_canvas_item.line_graph_canvas_item.calibrated_xdata
-            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 640, 0, 0, display_xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style)
+            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 640, 0, 0, display_xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style, 0.5)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 
@@ -345,7 +345,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             calibrated_data_max = axes.calibrated_data_max
             calibrated_data_range = calibrated_data_max - calibrated_data_min
             display_xdata = display_panel.display_canvas_item.line_graph_canvas_item.calibrated_xdata
-            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 100, 0, 0, display_xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style)
+            LineGraphCanvasItem.draw_line_graph(drawing_context, 480, 100, 0, 0, display_xdata, calibrated_data_min, calibrated_data_range, axes.calibrated_left_channel, axes.calibrated_right_channel, axes.x_calibration, "black", "black", None, axes.data_style, 0.5)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 


### PR DESCRIPTION
We could also consider changing the default stroke width to something a bit larger than the current 0.5. I'd say at least 1.0 would be good, maybe even 1.5 or 2. Right now, line plots are hardly visible most of the time because the line is so thin.