### PR TITLE
Provide collection/index controls in display panel

### DIFF
--- a/nion/swift/DataItemThumbnailWidget.py
+++ b/nion/swift/DataItemThumbnailWidget.py
@@ -1,11 +1,10 @@
 # standard libraries
-# None
+import typing
 
 # third party libraries
 # None
 
 # local libraries
-import typing
 from nion.data import Image
 from nion.swift import MimeTypes
 from nion.swift import Thumbnails
@@ -15,6 +14,9 @@ from nion.ui import CanvasItem
 from nion.ui import UserInterface
 from nion.ui import Widgets
 from nion.utils import Geometry
+
+if typing.TYPE_CHECKING:
+    import numpy
 
 
 class AbstractThumbnailSource:
@@ -149,7 +151,7 @@ class ThumbnailCanvasItem(CanvasItem.CanvasItemComposition):
             thumbnail_source.overlay_canvas_item.update_sizing(thumbnail_source.overlay_canvas_item.sizing.with_fixed_size(size))
         bitmap_overlay_canvas_item.add_canvas_item(thumbnail_source.overlay_canvas_item)
         self.__thumbnail_source = thumbnail_source
-        self.on_drag = None
+        self.on_drag: typing.Optional[typing.Callable[[UserInterface.MimeData, numpy.ndarray, int, int], None]] = None
         self.on_drop_mime_data = None
         self.on_delete = None
 
@@ -226,7 +228,7 @@ class ThumbnailWidget(Widgets.CompositeWidgetBase):
         bitmap_canvas_widget.canvas_item.add_canvas_item(thumbnail_square)
         self.content_widget.add(bitmap_canvas_widget)
         self.on_drop_mime_data = None
-        self.on_drag = None
+        self.on_drag: typing.Optional[typing.Callable[[UserInterface.MimeData, numpy.ndarray, int, int], None]] = None
         self.on_delete = None
 
         def drop_mime_data(mime_data: UserInterface.MimeData, x: int, y: int) -> str:

--- a/nion/swift/DisplayScriptCanvasItem.py
+++ b/nion/swift/DisplayScriptCanvasItem.py
@@ -75,6 +75,9 @@ class DisplayScriptCanvasItem(CanvasItem.CanvasItemComposition):
     def default_aspect_ratio(self):
         return 1.0
 
+    def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> bool:
+        return False
+
     def update_display_values(self, display_values_list) -> None:
         self.__display_data = display_values_list[0].data_and_metadata if display_values_list else None
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -170,7 +170,7 @@ class InspectorPanel(Panel.Panel):
 
     # not thread safe
     def __set_display_item(self, display_item: typing.Optional[DisplayItem.DisplayItem]) -> None:
-        if not self.document_controller.document_model.are_display_items_equal(self.__display_item, display_item):
+        if self.__display_item != display_item:
             self.__display_item = display_item
             self.__update_display_inspector()
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -190,17 +190,27 @@ class LinePlotCanvasItem(CanvasItem.CanvasItemComposition):
         line_graph_group_canvas_item.add_canvas_item(self.__line_graph_area_stack, Geometry.IntPoint(x=1, y=0))
         line_graph_group_canvas_item.add_canvas_item(self.line_graph_horizontal_axis_group_canvas_item, Geometry.IntPoint(x=1, y=1))
 
+        self.__overlap_controls = CanvasItem.CanvasItemComposition()
+        self.__overlap_controls.layout = CanvasItem.CanvasItemColumnLayout()
+        self.__overlap_controls.add_stretch()
+
         # draw the background
         line_graph_background_canvas_item = CanvasItem.CanvasItemComposition()
         #line_graph_background_canvas_item.update_sizing(line_graph_background_canvas_item.size.with_minimum_aspect_ratio(1.5))  # note: no maximum aspect ratio; line plot looks nice wider.
         line_graph_background_canvas_item.add_canvas_item(CanvasItem.BackgroundCanvasItem("#FFF"))
         line_graph_background_canvas_item.add_canvas_item(line_graph_group_canvas_item)
+        line_graph_background_canvas_item.add_canvas_item(self.__overlap_controls)
+
+        self.__display_controls = CanvasItem.CanvasItemComposition()
+        self.__display_controls.layout = CanvasItem.CanvasItemColumnLayout()
+        self.__display_controls.add_canvas_item(line_graph_background_canvas_item)
 
         # canvas items get added back to front
         # create the child canvas items
         # the background
-        self.add_canvas_item(CanvasItem.BackgroundCanvasItem())
-        self.add_canvas_item(line_graph_background_canvas_item)
+        self.add_canvas_item(CanvasItem.BackgroundCanvasItem("#FFF"))
+        # self.add_canvas_item(line_graph_background_canvas_item)
+        self.add_canvas_item(self.__display_controls)
 
         self.__display_values_list = None
 
@@ -276,6 +286,13 @@ class LinePlotCanvasItem(CanvasItem.CanvasItemComposition):
             self.__line_graph_legend_row.canvas_items[2].visible = False
         else:
             self.__line_graph_legend_canvas_item.visible = False
+
+    def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> bool:
+        if role == "related_icons":
+            self.__overlap_controls.add_canvas_item(display_control_canvas_item)
+        else:
+            self.__display_controls.add_canvas_item(display_control_canvas_item)
+        return True
 
     def update_display_values(self, display_values_list) -> None:
         self.__display_values_list = display_values_list

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -789,6 +789,14 @@ class DisplayDataChannel(Observable.Observable, Persistence.PersistentObject):
         return self.__data_item and self.__data_item.is_collection and self.__data_item.collection_dimension_count == 2 and self.__data_item.datum_dimension_count == 1
 
     @property
+    def datum_rank(self) -> int:
+        return self.__data_item.datum_dimension_count if self.__data_item else 0
+
+    @property
+    def collection_rank(self) -> int:
+        return self.__data_item.collection_dimension_count if self.__data_item else 0
+
+    @property
     def is_display_1d_preferred(self) -> bool:
         data_item = self.data_item
         if not data_item:

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -1646,9 +1646,6 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                 return display_item
         return next(iter(display_items)) if len(display_items) == 1 else None
 
-    def are_display_items_equal(self, display_item1: DisplayItem.DisplayItem, display_item2: DisplayItem.DisplayItem) -> bool:
-        return display_item1 == display_item2
-
     def get_or_create_data_group(self, group_name):
         data_group = DataGroup.get_data_group_in_container_by_title(self, group_name)
         if data_group is None:

--- a/nion/swift/test/ImageCanvasItem_test.py
+++ b/nion/swift/test/ImageCanvasItem_test.py
@@ -75,7 +75,7 @@ class TestImageCanvasItemClass(unittest.TestCase):
             header_height = display_panel.header_canvas_item.header_height
             display_panel.root_container.layout_immediate((1000 + header_height, 1000))
             # run test
-            self.assertEqual(display_panel.display_canvas_item._info_overlay_canvas_item_for_test._dimension_calibration_for_test.units, "x")
+            self.assertEqual(display_panel.display_canvas_item._scale_marker_canvas_item_for_test._dimension_calibration_for_test.units, "x")
 
     def test_dimension_used_for_scale_marker_on_3d_spectrum_image_is_correct(self):
         with TestContext.create_memory_context() as test_context:
@@ -91,7 +91,7 @@ class TestImageCanvasItemClass(unittest.TestCase):
             header_height = display_panel.header_canvas_item.header_height
             display_panel.root_container.layout_immediate((1000 + header_height, 1000))
             # run test
-            self.assertEqual(display_panel.display_canvas_item._info_overlay_canvas_item_for_test._dimension_calibration_for_test.units, "x")
+            self.assertEqual(display_panel.display_canvas_item._scale_marker_canvas_item_for_test._dimension_calibration_for_test.units, "x")
 
     def test_dimension_used_for_scale_marker_on_4d_diffraction_image_is_correct(self):
         with TestContext.create_memory_context() as test_context:
@@ -107,7 +107,7 @@ class TestImageCanvasItemClass(unittest.TestCase):
             header_height = display_panel.header_canvas_item.header_height
             display_panel.root_container.layout_immediate((1000 + header_height, 1000))
             # run test
-            self.assertEqual(display_panel.display_canvas_item._info_overlay_canvas_item_for_test._dimension_calibration_for_test.units, "b")
+            self.assertEqual(display_panel.display_canvas_item._scale_marker_canvas_item_for_test._dimension_calibration_for_test.units, "b")
 
     def test_tool_returns_to_pointer_after_but_not_during_creating_rectangle(self):
         # setup


### PR DESCRIPTION
Also will reorganize how adornments such as source/dependency items, collection/sequence/item pickers, and the scale marker are laid out.

- [x] The scale marker overlaps and needs to participate in the layout, but only for raster
- [x] The index slider overlaps the line plot and needs to reserve space, but only for line plot
- [ ] Update the index, etc. through a window action instead of direct modification, undo
- [ ] The sequence, collection index needs to display values in calibrated coordinates
- [ ] Add a slice control also