### PR TITLE
binder and release

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 .. _index:
 
-Nion Swift User's Guide (0.16.0)
+Nion Swift User's Guide (0.16.1)
 ================================
 Nion Swift is open source scientific image processing software integrating hardware control, data acquisition,
 visualization, processing, and analysis using Python. Nion Swift is easily extended using Python. It runs on

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,12 @@ in bug fix releases, we choose to include them for evaluation and feedback. If y
 or have feedback about these types of new features, please contact us or file issues at
 https://github.com/nion-software/nionswift/issues.
 
+Version 0.16.1 (2021-12-13)
+---------------------------
+* `#772 <https://github.com/nion-software/nionswift/issues/772>`_ Fix issue deselecting empty display panels.
+* `#770 <https://github.com/nion-software/nionswift/issues/770>`_ Fix issue where some HDF5 files may not load properly.
+* `#765 <https://github.com/nion-software/nionswift/issues/765>`_ Add support for Python 3.10.
+
 Version 0.16.0 (2021-11-12)
 ---------------------------
 The highlights of this release are improved performance, reliability, and internal Python code maintainability.

--- a/meta.yaml
+++ b/meta.yaml
@@ -2,10 +2,10 @@
 
 package:
   name: 'nionswift'
-  version: '0.16.0'
+  version: '0.16.1'
 
 source:
-  git_rev: 0.16.0
+  git_rev: 0.16.1
   git_url: https://github.com/nion-software/nionswift.git
 
 build:
@@ -22,7 +22,7 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >=3.8
+    - python >=3.8,<3.11
     - nionutils >=0.4.0,<0.5.0
     - niondata >=0.14.0,<0.15.0
     - nionui >=0.6.0,<0.7.0

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -109,7 +109,7 @@ class Application(UIApplication.BaseApplication):
 
         ui.set_persistence_handler(PersistenceHandler())
         setattr(self.ui, "persistence_root", "3")  # sets of preferences
-        self.version_str = "0.16.0"
+        self.version_str = "0.16.1"
 
         self.document_model_available_event = Event.Event()
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1888,7 +1888,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             d["controller_type"] = self.__display_panel_controller.type
             self.__display_panel_controller.save(d)
         if self.__display_item:
-            d["display_item_specifier"] = self.__display_item.project.create_specifier(self.__display_item).write()
+            d["display_item_specifier"] = Persistence.write_persistent_specifier(self.__display_item.uuid)
         if self.__display_panel_controller is None and self.__horizontal_browser_canvas_item.visible:
             d["browser_type"] = "horizontal"
         if self.__display_panel_controller is None and self.__grid_browser_canvas_item.visible:
@@ -1908,7 +1908,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             if not self.__display_panel_controller:
                 display_item: typing.Optional[DisplayItem.DisplayItem] = None
                 if "display_item_specifier" in d:
-                    display_item_specifier = Persistence.PersistentObjectSpecifier.read(d["display_item_specifier"])
+                    display_item_specifier = Persistence.read_persistent_specifier(d["display_item_specifier"])
                     display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], self.document_controller.document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
                 self.set_display_item(display_item)
                 if d.get("browser_type") == "horizontal":
@@ -2028,7 +2028,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
     def set_display_panel_display_item(self, display_item: typing.Optional[DisplayItem.DisplayItem], detect_controller: bool=False) -> None:
         if display_item:
-            d = {"type": "image", "display_item_specifier": display_item.project.create_specifier(display_item).write()}
+            d = {"type": "image", "display_item_specifier": Persistence.write_persistent_specifier(display_item.uuid)}
             if detect_controller:
                 data_item = display_item.data_item
                 if display_item == self.document_controller.document_model.get_any_display_item_for_data_item(data_item) and data_item:

--- a/nion/swift/Facade.py
+++ b/nion/swift/Facade.py
@@ -193,7 +193,7 @@ class ObjectSpecifier:
                         return DisplayPanel(display_panel)
         elif object_type == "data_item":
             data_item_uuid = uuid_module.UUID(object_uuid_str)
-            data_item_specifier = Persistence.PersistentObjectSpecifier(item_uuid=data_item_uuid)
+            data_item_specifier = Persistence.PersistentObjectSpecifier(data_item_uuid)
             data_item = document_model.resolve_item_specifier(data_item_specifier)
             return DataItem(typing.cast(DataItemModule.DataItem, data_item)) if data_item else None
         elif object_type == "data_group":
@@ -3363,7 +3363,7 @@ class API_1:
 
         Scriptable: No
         """
-        return Persistence.PersistentObjectSpecifier(item_uuid=item_uuid)
+        return Persistence.PersistentObjectSpecifier(item_uuid)
 
     def create_unary_operation(self, unary_operation_delegate: typing.Any) -> typing.Any:
         raise NotImplementedError()

--- a/nion/swift/MimeTypes.py
+++ b/nion/swift/MimeTypes.py
@@ -30,19 +30,19 @@ def mime_data_get_data_source(mime_data: UserInterface.MimeData, document_model:
     graphic = None
     if mime_data.has_format(DATA_SOURCE_MIME_TYPE):
         data_source_mime_data = json.loads(mime_data.data_as_string(DATA_SOURCE_MIME_TYPE))
-        display_item_specifier = Persistence.PersistentObjectSpecifier.read(data_source_mime_data["display_item_specifier"])
+        display_item_specifier = Persistence.read_persistent_specifier(data_source_mime_data["display_item_specifier"])
         display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
         if "graphic_specifier" in data_source_mime_data:
-            graphic_specifier = Persistence.PersistentObjectSpecifier.read(data_source_mime_data["graphic_specifier"])
+            graphic_specifier = Persistence.read_persistent_specifier(data_source_mime_data["graphic_specifier"])
             graphic = typing.cast(typing.Optional[Graphics.Graphic], document_model.resolve_item_specifier(graphic_specifier)) if graphic_specifier else None
     return display_item, graphic
 
 
 def mime_data_put_data_source(mime_data: UserInterface.MimeData, display_item: DisplayItem.DisplayItem, graphic: typing.Optional[Graphics.Graphic]) -> None:
     mime_data_content = dict()
-    mime_data_content["display_item_specifier"] = display_item.project.create_specifier(display_item).write()
+    mime_data_content["display_item_specifier"] = Persistence.write_persistent_specifier(display_item.uuid)
     if graphic and graphic.project:
-        mime_data_content["graphic_specifier"] = graphic.project.create_specifier(graphic).write()
+        mime_data_content["graphic_specifier"] = Persistence.write_persistent_specifier(graphic.uuid)
     mime_data.set_data_as_string(DATA_SOURCE_MIME_TYPE, json.dumps(mime_data_content))
 
 
@@ -50,7 +50,7 @@ def mime_data_get_display_item(mime_data: UserInterface.MimeData, document_model
     display_item = None
     if mime_data.has_format(DISPLAY_ITEM_MIME_TYPE):
         data_source_mime_data = json.loads(mime_data.data_as_string(DISPLAY_ITEM_MIME_TYPE))
-        display_item_specifier = Persistence.PersistentObjectSpecifier.read(data_source_mime_data["display_item_specifier"])
+        display_item_specifier = Persistence.read_persistent_specifier(data_source_mime_data["display_item_specifier"])
         display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
     return display_item
 
@@ -60,13 +60,13 @@ def mime_data_get_display_items(mime_data: UserInterface.MimeData, document_mode
     if mime_data.has_format(DISPLAY_ITEMS_MIME_TYPE):
         data_sources_mime_data = json.loads(mime_data.data_as_string(DISPLAY_ITEMS_MIME_TYPE))
         for data_source_mime_data in data_sources_mime_data:
-            display_item_specifier = Persistence.PersistentObjectSpecifier.read(data_source_mime_data["display_item_specifier"])
+            display_item_specifier = Persistence.read_persistent_specifier(data_source_mime_data["display_item_specifier"])
             display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
             if display_item:
                 display_items.append(display_item)
     if mime_data.has_format(DISPLAY_ITEM_MIME_TYPE):
         data_source_mime_data = json.loads(mime_data.data_as_string(DISPLAY_ITEM_MIME_TYPE))
-        display_item_specifier = Persistence.PersistentObjectSpecifier.read(data_source_mime_data["display_item_specifier"])
+        display_item_specifier = Persistence.read_persistent_specifier(data_source_mime_data["display_item_specifier"])
         display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
         if display_item:
             display_items.append(display_item)
@@ -74,12 +74,12 @@ def mime_data_get_display_items(mime_data: UserInterface.MimeData, document_mode
 
 
 def mime_data_put_display_item(mime_data: UserInterface.MimeData, display_item: DisplayItem.DisplayItem) -> None:
-    mime_data_content = {"display_item_specifier": display_item.project.create_specifier(display_item).write()}
+    mime_data_content = {"display_item_specifier": Persistence.write_persistent_specifier(display_item.uuid)}
     mime_data.set_data_as_string(DISPLAY_ITEM_MIME_TYPE, json.dumps(mime_data_content))
 
 
 def mime_data_put_display_items(mime_data: UserInterface.MimeData, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
-    mime_data_content = [{"display_item_specifier": display_item.project.create_specifier(display_item).write()} for display_item in display_items]
+    mime_data_content = [{"display_item_specifier": Persistence.write_persistent_specifier(display_item.uuid)} for display_item in display_items]
     mime_data.set_data_as_string(DISPLAY_ITEMS_MIME_TYPE, json.dumps(mime_data_content))
 
 
@@ -107,7 +107,7 @@ def mime_data_put_graphics(mime_data: UserInterface.MimeData, graphics: typing.S
 def mime_data_get_layer(mime_data: UserInterface.MimeData, document_model: DocumentModel.DocumentModel) -> typing.Tuple[Persistence.PersistentDictType, typing.Optional[DisplayItem.DisplayItem]]:
     mime_dict = json.loads(mime_data.data_as_string(LAYER_MIME_TYPE))
     legend_data = mime_dict["legend_data"]
-    display_item_specifier = Persistence.PersistentObjectSpecifier.read(mime_dict["display_item_specifier"])
+    display_item_specifier = Persistence.read_persistent_specifier(mime_dict["display_item_specifier"])
     display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
     return legend_data, display_item
 
@@ -124,7 +124,7 @@ def mime_data_put_layer(mime_data: UserInterface.MimeData, index: int, display_i
         legend_data["stroke_color"] = stroke_color
     mime_dict = {
         "legend_data": legend_data,
-        "display_item_specifier": display_item.project.create_specifier(display_item).write()
+        "display_item_specifier": Persistence.write_persistent_specifier(display_item.uuid)
     }
     mime_data.set_data_as_string(LAYER_MIME_TYPE, json.dumps(mime_dict))
 
@@ -135,7 +135,7 @@ def mime_data_get_panel(mime_data: UserInterface.MimeData, document_model: Docum
     if mime_data.has_format(DISPLAY_PANEL_MIME_TYPE):
         d = json.loads(mime_data.data_as_string(DISPLAY_PANEL_MIME_TYPE))
         if "display_item_specifier" in d:
-            display_item_specifier = Persistence.PersistentObjectSpecifier.read(d["display_item_specifier"])
+            display_item_specifier = Persistence.read_persistent_specifier(d["display_item_specifier"])
             display_item = typing.cast(typing.Optional[DisplayItem.DisplayItem], document_model.resolve_item_specifier(display_item_specifier)) if display_item_specifier else None
     return display_item, d
 
@@ -143,5 +143,5 @@ def mime_data_get_panel(mime_data: UserInterface.MimeData, document_model: Docum
 def mime_data_put_panel(mime_data: UserInterface.MimeData, display_item: typing.Optional[DisplayItem.DisplayItem], d: Persistence.PersistentDictType) -> None:
     if display_item:
         d = dict(d)
-        d["display_item_specifier"] = display_item.project.create_specifier(display_item).write()
+        d["display_item_specifier"] = Persistence.write_persistent_specifier(display_item.uuid)
     mime_data.set_data_as_string(DISPLAY_PANEL_MIME_TYPE, json.dumps(d))

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -511,7 +511,7 @@ class Workspace:
     def switch_to_display_content(self, display_panel: DisplayPanel.DisplayPanel, display_panel_type: str, display_item: typing.Optional[DisplayItem.DisplayItem] = None) -> None:
         d: Persistence.PersistentDictType = {"type": "image", "display-panel-type": display_panel_type}
         if display_item and display_panel_type != "empty-display-panel":
-            d["display_item_specifier"] = display_item.project.create_specifier(display_item).write()
+            d["display_item_specifier"] = Persistence.write_persistent_specifier(display_item.uuid)
         command = ChangeWorkspaceContentsCommand(self, _("Replace Display Panel"))
         display_panel.change_display_panel_content(d)
         self.document_controller.push_undo_command(command)

--- a/nion/swift/model/Connection.py
+++ b/nion/swift/model/Connection.py
@@ -33,7 +33,7 @@ class Connection(Persistence.PersistentObject):
         self.define_type(type)
         self.define_property("parent_specifier", changed=self.__parent_specifier_changed, key="parent_uuid", hidden=True)
         self.__parent_reference = self.create_item_reference(item=parent)
-        self.parent_specifier = getattr(parent, "project").create_specifier(parent).write() if parent else None
+        self.parent_specifier = Persistence.write_persistent_specifier(parent.uuid) if parent else None
 
     @property
     def parent_specifier(self) -> typing.Optional[Persistence._SpecifierType]:
@@ -52,7 +52,7 @@ class Connection(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def clone(self) -> Connection:
         connection = copy.deepcopy(self)
@@ -69,10 +69,10 @@ class Connection(Persistence.PersistentObject):
     @parent.setter
     def parent(self, parent: typing.Optional[Persistence.PersistentObject]) -> None:
         self.__parent_reference.item = parent
-        self.parent_specifier = getattr(parent, "project").create_specifier(parent).write() if parent else None
+        self.parent_specifier = Persistence.write_persistent_specifier(parent.uuid) if parent else None
 
     def __parent_specifier_changed(self, name: str, d: _SpecifierType) -> None:
-        self.__parent_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__parent_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
 
 class PropertyConnection(Connection):
@@ -84,9 +84,9 @@ class PropertyConnection(Connection):
                  target_property: typing.Optional[str] = None, *,
                  parent: typing.Optional[Persistence.PersistentObject] = None) -> None:
         super().__init__("property-connection", parent=parent)
-        self.define_property("source_specifier", getattr(source, "project").create_specifier(source).write() if source else None, changed=self.__source_specifier_changed, key="source_uuid", hidden=True)
+        self.define_property("source_specifier", Persistence.write_persistent_specifier(source.uuid) if source else None, changed=self.__source_specifier_changed, key="source_uuid", hidden=True)
         self.define_property("source_property", hidden=True)
-        self.define_property("target_specifier", getattr(target, "project").create_specifier(target).write() if target else None, changed=self.__target_specifier_changed, key="target_uuid", hidden=True)
+        self.define_property("target_specifier", Persistence.write_persistent_specifier(target.uuid) if target else None, changed=self.__target_specifier_changed, key="target_uuid", hidden=True)
         self.define_property("target_property", hidden=True)
         # these are only set in persistent object context changed
         self.__binding: typing.Optional[Binding.Binding] = None
@@ -197,10 +197,10 @@ class PropertyConnection(Connection):
         return self.__target_reference.item
 
     def __source_specifier_changed(self, name: str, d: _SpecifierType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     def __target_specifier_changed(self, name: str, d: _SpecifierType) -> None:
-        self.__target_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__target_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     def __set_target_from_source(self, value: typing.Any) -> None:
         assert not self._closed
@@ -228,8 +228,8 @@ class IntervalListConnection(Connection):
                  line_profile: typing.Optional[Graphics.LineProfileGraphic] = None, *,
                  parent: typing.Optional[Persistence.PersistentObject] = None) -> None:
         super().__init__("interval-list-connection", parent=parent)
-        self.define_property("source_specifier", display_item.project.create_specifier(display_item).write() if display_item else None, changed=self.__source_specifier_changed, key="source_uuid", hidden=True)
-        self.define_property("target_specifier", line_profile.project.create_specifier(line_profile).write() if line_profile and line_profile.project else None, changed=self.__target_specifier_changed, key="target_uuid", hidden=True)
+        self.define_property("source_specifier", Persistence.write_persistent_specifier(display_item.uuid) if display_item else None, changed=self.__source_specifier_changed, key="source_uuid", hidden=True)
+        self.define_property("target_specifier", Persistence.write_persistent_specifier(line_profile.uuid) if line_profile and line_profile.project else None, changed=self.__target_specifier_changed, key="target_uuid", hidden=True)
         # these are only set in persistent object context changed
         self.__item_inserted_event_listener: typing.Optional[Event.EventListener] = None
         self.__item_removed_event_listener: typing.Optional[Event.EventListener] = None
@@ -323,10 +323,10 @@ class IntervalListConnection(Connection):
         return self.__target_reference.item
 
     def __source_specifier_changed(self, name: str, d: _SpecifierType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     def __target_specifier_changed(self, name: str, d: _SpecifierType) -> None:
-        self.__target_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__target_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
 
 def connection_factory(lookup_id: typing.Callable[[str], str]) -> typing.Optional[Connection]:

--- a/nion/swift/model/DataGroup.py
+++ b/nion/swift/model/DataGroup.py
@@ -135,7 +135,7 @@ class DataGroup(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def __validate_title(self, value: typing.Any) -> str:
         return str(value) if value is not None else str()
@@ -176,7 +176,7 @@ class DataGroup(Persistence.PersistentObject):
         self.notify_insert_item("display_items", display_item, before_index)
         self.update_counted_display_items(collections.Counter([display_item]))
         display_item_specifiers = self.display_item_specifiers
-        display_item_specifier = display_item.project.create_specifier(display_item).write()
+        display_item_specifier = Persistence.write_persistent_specifier(display_item.uuid)
         assert display_item_specifier is not None
         display_item_specifiers.insert(before_index, display_item_specifier)
         self.display_item_specifiers = display_item_specifiers

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -363,7 +363,7 @@ class DataItem(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def clone(self) -> DataItem:
         data_item = self.__class__()
@@ -481,10 +481,10 @@ class DataItem(Persistence.PersistentObject):
     @source.setter
     def source(self, source: typing.Optional[Persistence.PersistentObject]) -> None:
         self.__source_reference.item = source
-        self.source_specifier = getattr(source, "project").create_specifier(source).write() if source else None
+        self.source_specifier = Persistence.write_persistent_specifier(source.uuid) if source else None
 
     def __source_specifier_changed(self, name: str, d: Persistence._SpecifierType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     def persistent_object_context_changed(self) -> None:
         # handle case where persistent object context is set on an item that is already under transaction.

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -553,7 +553,7 @@ class DisplayDataChannel(Persistence.PersistentObject):
 
         self.__slice_interval: typing.Optional[typing.Tuple[float, float]] = None
 
-        data_item_specifier = Persistence.PersistentObjectSpecifier.read(self.data_item_reference) if self.data_item_reference else None
+        data_item_specifier = Persistence.read_persistent_specifier(self.data_item_reference) if self.data_item_reference else None
         self.__data_item_reference = self.create_item_reference(item_specifier=data_item_specifier, item=data_item)
 
         self.__old_data_shape: typing.Optional[DataAndMetadata.ShapeType] = None
@@ -752,7 +752,7 @@ class DisplayDataChannel(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def clone(self) -> DisplayDataChannel:
         display_data_channel = DisplayDataChannel()
@@ -778,7 +778,7 @@ class DisplayDataChannel(Persistence.PersistentObject):
     def __data_item_reference_changed(self, name: str, data_item_reference: str) -> None:
         if data_item_reference:
             item_uuid = uuid.UUID(data_item_reference)
-            self.__data_item_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(item_uuid)
+            self.__data_item_reference.item_specifier = Persistence.read_persistent_specifier(item_uuid)
         self.__current_display_values = None
 
     def __connect_data_item_events(self) -> None:
@@ -1447,7 +1447,7 @@ class DisplayItem(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     # call this when the listeners need to be updated (via data_item_content_changed).
     # Calling this method will send the data_item_content_changed method to each listener by using the method

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -801,7 +801,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         Registry.register_component(self, {"document_model"})
 
     def __resolve_display_item_specifier(self, display_item_specifier_d: Persistence._SpecifierType) -> typing.Optional[DisplayItem.DisplayItem]:
-        display_item_specifier = Persistence.PersistentObjectSpecifier.read(display_item_specifier_d)
+        display_item_specifier = Persistence.read_persistent_specifier(display_item_specifier_d)
         if display_item_specifier:
             return typing.cast(typing.Optional[DisplayItem.DisplayItem], self.resolve_item_specifier(display_item_specifier))
         return None
@@ -810,7 +810,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         # handle the reference variable assignments
         for mapped_item in self._project.mapped_items:
             item_proxy = self._project.create_item_proxy(
-                item_specifier=Persistence.PersistentObjectSpecifier.read(mapped_item))
+                item_specifier=Persistence.read_persistent_specifier(mapped_item))
             with contextlib.closing(item_proxy):
                 if isinstance(item_proxy.item, DisplayItem.DisplayItem):
                     display_item = typing.cast(Persistence.PersistentObject, item_proxy.item)
@@ -821,7 +821,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         # update the data item references
         data_item_references = self._project.data_item_references
         for key, data_item_specifier in data_item_references.items():
-            persistent_object_specifier = Persistence.PersistentObjectSpecifier.read(data_item_specifier)
+            persistent_object_specifier = Persistence.read_persistent_specifier(data_item_specifier)
             if persistent_object_specifier:
                 if key in self.__data_item_references:
                     self.__data_item_references[key].set_data_item_specifier(self._project, persistent_object_specifier)
@@ -1207,7 +1207,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         if not r_var:
             r_var = MappedItemManager().register(self, display_item)
             mapped_items = self._project.mapped_items
-            specifier = display_item.project.create_specifier(display_item).write()
+            specifier = Persistence.write_persistent_specifier(display_item.uuid)
             if specifier:
                 mapped_items.append(specifier)
                 self._project.mapped_items = mapped_items

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -718,7 +718,7 @@ class Graphic(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def clone(self) -> Graphic:
         graphic = copy.deepcopy(self)
@@ -758,10 +758,10 @@ class Graphic(Persistence.PersistentObject):
     @source.setter
     def source(self, source: typing.Optional[DisplayItem.DisplayItem]) -> None:
         self.__source_reference.item = source
-        self.source_specifier = source.project.create_specifier(source).write() if source else None
+        self.source_specifier = Persistence.write_persistent_specifier(source.uuid) if source else None
 
     def __source_specifier_changed(self, name: str, d: Persistence._SpecifierType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     def _property_changed(self, name: str, value: typing.Any) -> None:
         self.notify_property_changed(name)

--- a/nion/swift/model/Persistence.py
+++ b/nion/swift/model/Persistence.py
@@ -306,9 +306,14 @@ _SpecifierType = typing.Union[typing.Mapping[str, typing.Any], str, uuid.UUID]
 _SpecifierDictType = typing.Union[PersistentDictType, str, uuid.UUID]
 
 
+class PersistentObjectSpecifiable(typing.Protocol):
+    @property
+    def uuid(self) -> uuid.UUID: raise NotImplementedError()
+
+
 class PersistentObjectSpecifier:
 
-    def __init__(self, *, item: typing.Optional[PersistentObject] = None, item_uuid: typing.Optional[uuid.UUID] = None) -> None:
+    def __init__(self, *, item: typing.Optional[PersistentObjectSpecifiable] = None, item_uuid: typing.Optional[uuid.UUID] = None) -> None:
         self.__item_uuid = item.uuid if item else item_uuid
         assert (self.__item_uuid is None) or isinstance(self.__item_uuid, uuid.UUID)
 

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -143,7 +143,7 @@ class Project(Persistence.PersistentObject):
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
         return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
 
-    def create_specifier(self, item: Persistence.PersistentObject) -> Persistence.PersistentObjectSpecifier:
+    def create_specifier(self, item: Persistence.PersistentObjectSpecifiable) -> Persistence.PersistentObjectSpecifier:
         return Persistence.PersistentObjectSpecifier(item=item)
 
     def insert_model_item(self, container: Persistence.PersistentContainerType, name: str, before_index: int, item: Persistence.PersistentObject) -> None:

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -141,10 +141,7 @@ class Project(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
-
-    def create_specifier(self, item: Persistence.PersistentObjectSpecifiable) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item=item)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def insert_model_item(self, container: Persistence.PersistentContainerType, name: str, before_index: int, item: Persistence.PersistentObject) -> None:
         # special handling to pass on to the document model

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -775,7 +775,7 @@ class BoundData(BoundItemBase):
     def __init__(self, container: Persistence.PersistentObject, specifier: Persistence.PersistentDictType) -> None:
         super().__init__(specifier)
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
         self.__data_changed_event_listener: typing.Optional[Event.EventListener] = None
 
         def maintain_data_source() -> None:
@@ -827,8 +827,8 @@ class BoundDisplayDataChannelBase(BoundItemBase):
     def __init__(self, container: Persistence.PersistentObject, specifier: Persistence.PersistentDictType, secondary_specifier: typing.Optional[Persistence.PersistentDictType]) -> None:
         super().__init__(specifier)
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
-        self.__graphic_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(secondary_specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
+        self.__graphic_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(secondary_specifier))
         self.__display_values_changed_event_listener = None
 
         def maintain_data_source() -> None:
@@ -890,8 +890,8 @@ class BoundDataSource(BoundItemBase):
     def __init__(self, container: Persistence.PersistentObject, specifier: Persistence.PersistentDictType, secondary_specifier: typing.Optional[Persistence.PersistentDictType]) -> None:
         super().__init__(specifier)
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
-        self.__graphic_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(secondary_specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
+        self.__graphic_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(secondary_specifier))
         self.__data_source: typing.Optional[DataItem.DataSource] = None
 
         def maintain_data_source() -> None:
@@ -956,7 +956,7 @@ class BoundDataItem(BoundItemBase):
     def __init__(self, container: Persistence.PersistentObject, specifier: Persistence.PersistentDictType) -> None:
         super().__init__(specifier)
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
         self.__data_item_changed_event_listener: typing.Optional[Event.EventListener] = None
 
         def item_registered(item: Persistence.PersistentObject) -> None:
@@ -1042,7 +1042,7 @@ class BoundFilterLikeData(BoundItemBase):
     def __init__(self, container: Persistence.PersistentObject, specifier: Persistence.PersistentDictType, secondary_specifier: typing.Optional[Persistence.PersistentDictType]) -> None:
         super().__init__(specifier)
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
         self.__display_values_changed_event_listener: typing.Optional[Event.EventListener] = None
         self.__display_item_item_inserted_event_listener: typing.Optional[Event.EventListener] = None
         self.__display_item_item_removed_event_listener: typing.Optional[Event.EventListener] = None
@@ -1166,7 +1166,7 @@ class BoundDataStructure(BoundItemBase):
 
         self.__property_name = property_name
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
         self.__changed_listener: typing.Optional[Event.EventListener] = None
         self.__property_changed_listener: typing.Optional[Event.EventListener] = None
 
@@ -1226,7 +1226,7 @@ class BoundGraphic(BoundItemBase):
 
         self.__property_name = property_name
 
-        self.__item_reference = container.create_item_reference(item_specifier=Persistence.PersistentObjectSpecifier.read(specifier))
+        self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier))
         self.__changed_listener: typing.Optional[Event.EventListener] = None
 
         def property_changed(property_name: str) -> None:
@@ -1444,10 +1444,10 @@ class Computation(Persistence.PersistentObject):
 
     @property
     def item_specifier(self) -> Persistence.PersistentObjectSpecifier:
-        return Persistence.PersistentObjectSpecifier(item_uuid=self.uuid)
+        return Persistence.PersistentObjectSpecifier(self.uuid)
 
     def read_properties_from_dict(self, d: Persistence.PersistentDictType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d.get("source_uuid", None))
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d.get("source_uuid", None))
         self.original_expression = d.get("original_expression", self.original_expression)
         self.error_text = d.get("error_text", self.error_text)
         self.label = d.get("label", self.label)
@@ -1460,7 +1460,7 @@ class Computation(Persistence.PersistentObject):
     @source.setter
     def source(self, source: typing.Optional[Persistence.PersistentObject]) -> None:
         self.__source_reference.item = source
-        self.source_specifier = getattr(source, "project").create_specifier(source).write() if source else None
+        self.source_specifier = Persistence.write_persistent_specifier(source.uuid) if source else None
 
     def is_valid_with_removals(self, items: typing.Set[Persistence.PersistentObject]) -> bool:
         for variable in self.variables:
@@ -1474,7 +1474,7 @@ class Computation(Persistence.PersistentObject):
         return True
 
     def __source_specifier_changed(self, name: str, d: Persistence.PersistentDictType) -> None:
-        self.__source_reference.item_specifier = Persistence.PersistentObjectSpecifier.read(d)
+        self.__source_reference.item_specifier = Persistence.read_persistent_specifier(d)
 
     @property
     def processing_id(self) -> typing.Optional[str]:

--- a/nion/swift/test/DataGroup_test.py
+++ b/nion/swift/test/DataGroup_test.py
@@ -51,7 +51,7 @@ class TestDataGroupClass(unittest.TestCase):
             data_group.append_display_item(display_item)
             data_group_copy = copy.deepcopy(data_group)
             document_model.append_data_group(data_group_copy)
-            display_item_specifier = Persistence.PersistentObjectSpecifier.read(data_group_copy.display_item_specifiers[0])
+            display_item_specifier = Persistence.read_persistent_specifier(data_group_copy.display_item_specifiers[0])
             self.assertEqual(display_item, document_model.resolve_item_specifier(display_item_specifier))
 
     def test_counted_display_items(self):

--- a/nion/swift/test/Persistence_test.py
+++ b/nion/swift/test/Persistence_test.py
@@ -73,7 +73,7 @@ class TestPersistentObjectContextClass(unittest.TestCase):
         persistent_object_context = Persistence.PersistentObjectContext()
         object0 = Persistence.PersistentObject()
         object1 = Persistence.PersistentObject()
-        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.PersistentObjectSpecifier.read(object1.uuid))
+        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.read_persistent_specifier(object1.uuid))
         with contextlib.closing(object0), contextlib.closing(object1), contextlib.closing(object1_proxy):
             object0.persistent_object_context = persistent_object_context
             self.assertIsNone(object1_proxy.item)
@@ -84,7 +84,7 @@ class TestPersistentObjectContextClass(unittest.TestCase):
         persistent_object_context = Persistence.PersistentObjectContext()
         object0 = Persistence.PersistentObject()
         object1 = Persistence.PersistentObject()
-        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.PersistentObjectSpecifier.read(object1.uuid))
+        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.read_persistent_specifier(object1.uuid))
         with contextlib.closing(object0), contextlib.closing(object1), contextlib.closing(object1_proxy):
             object0.persistent_object_context = persistent_object_context
             object1.persistent_object_context = persistent_object_context
@@ -132,7 +132,7 @@ class TestPersistentObjectContextClass(unittest.TestCase):
         persistent_object_context = Persistence.PersistentObjectContext()
         object0 = Persistence.PersistentObject()
         object1 = Persistence.PersistentObject()
-        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.PersistentObjectSpecifier.read(object1.uuid))
+        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.read_persistent_specifier(object1.uuid))
         with contextlib.closing(object0), contextlib.closing(object1), contextlib.closing(object1_proxy):
             object1_proxy.on_item_registered = r
             object1_proxy.on_item_unregistered = u
@@ -164,7 +164,7 @@ class TestPersistentObjectContextClass(unittest.TestCase):
         object0.persistent_object_context = persistent_object_context
         object1.persistent_object_context = persistent_object_context
         # both objects are already registered
-        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.PersistentObjectSpecifier.read(object1.uuid))
+        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.read_persistent_specifier(object1.uuid))
         with contextlib.closing(object0), contextlib.closing(object1), contextlib.closing(object1_proxy):
             object1_proxy.on_item_registered = r
             object1_proxy.on_item_unregistered = u
@@ -188,7 +188,7 @@ class TestPersistentObjectContextClass(unittest.TestCase):
         persistent_object_context = Persistence.PersistentObjectContext()
         object0 = Persistence.PersistentObject()
         object1 = Persistence.PersistentObject()
-        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.PersistentObjectSpecifier.read(object1.uuid))
+        object1_proxy = object0.create_item_proxy(item_specifier=Persistence.read_persistent_specifier(object1.uuid))
         with contextlib.closing(object0), contextlib.closing(object1), contextlib.closing(object1_proxy):
             object1_proxy.on_item_registered = r
             object1_proxy.on_item_unregistered = u

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -449,8 +449,8 @@ class TestStorageClass(unittest.TestCase):
                 data_items_type = type(document_controller.document_model.data_items)
                 data_item0 = document_controller.document_model.data_items[0]
                 data_item1 = document_controller.document_model.data_items[1]
-                data_item0_specifier = data_item0.project.create_specifier(data_item0)
-                data_item1_specifier = data_item1.project.create_specifier(data_item1)
+                data_item0_specifier = Persistence.PersistentObjectSpecifier(data_item0.uuid)
+                data_item1_specifier = Persistence.PersistentObjectSpecifier(data_item1.uuid)
                 data_item0_display_item = document_model.get_display_item_for_data_item(data_item0)
                 data_item0_calibration_len = len(data_item0_display_item.data_item.dimensional_calibrations)
                 data_item1_data_items_len = len(document_controller.document_model.get_dependent_data_items(data_item1))
@@ -487,8 +487,8 @@ class TestStorageClass(unittest.TestCase):
                 dst_data_item = document_model.get_fft_new(src_display_item, src_display_item.data_item)
                 document_model.recompute_all()
                 dst_data_item.created = datetime.datetime(year=2000, month=6, day=30, hour=15, minute=2)
-                src_data_item_specifier = src_data_item.project.create_specifier(src_data_item)
-                dst_data_item_specifier = dst_data_item.project.create_specifier(dst_data_item)
+                src_data_item_specifier = Persistence.PersistentObjectSpecifier(src_data_item.uuid)
+                dst_data_item_specifier = Persistence.PersistentObjectSpecifier(dst_data_item.uuid)
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 src_data_item = typing.cast(DataItem.DataItem, document_model.resolve_item_specifier(src_data_item_specifier))
@@ -523,7 +523,7 @@ class TestStorageClass(unittest.TestCase):
             profile_context.data_properties_map["7d3b374e-e48b-460f-91de-7ff4e1a1a63c"]["created"] = "2015-01-22T17:16:12.308003"
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
-                new_data_item1_specifier = Persistence.PersistentObjectSpecifier(item_uuid=uuid.UUID("71ab9215-c6ae-4c36-aaf5-92ce78db02b6"))
+                new_data_item1_specifier = Persistence.PersistentObjectSpecifier(uuid.UUID("71ab9215-c6ae-4c36-aaf5-92ce78db02b6"))
                 new_data_item1 = typing.cast(DataItem.DataItem, document_model.resolve_item_specifier(new_data_item1_specifier))
                 new_data_item1_data_items_len = len(document_model.get_dependent_data_items(new_data_item1))
                 self.assertEqual(2, new_data_item1_data_items_len)
@@ -1116,7 +1116,7 @@ class TestStorageClass(unittest.TestCase):
             with contextlib.closing(document_controller):
                 self.save_document(document_controller)
                 read_data_item = document_model.data_items[0]
-                read_data_item_specifier = read_data_item.project.create_specifier(read_data_item)
+                read_data_item_specifier = Persistence.PersistentObjectSpecifier(read_data_item.uuid)
                 read_display_item = document_model.get_display_item_for_data_item(read_data_item)
                 self.assertEqual(len(read_display_item.graphics), 9)  # verify assumptions
             # read it back
@@ -1481,7 +1481,7 @@ class TestStorageClass(unittest.TestCase):
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 for data_item_uuid in original_expressions.keys():
-                    data_item_specifier = Persistence.PersistentObjectSpecifier(item_uuid=uuid.UUID(data_item_uuid))
+                    data_item_specifier = Persistence.PersistentObjectSpecifier(uuid.UUID(data_item_uuid))
                     data_item = typing.cast(DataItem.DataItem, document_model.resolve_item_specifier(data_item_specifier))
                     self.assertEqual(document_model.get_data_item_computation(data_item).original_expression, original_expressions[data_item_uuid])
                     self.assertFalse(document_model.get_data_item_computation(data_item).needs_update)
@@ -3272,7 +3272,7 @@ class TestStorageClass(unittest.TestCase):
                 document_model._project.migrate_to_latest()
                 data_item = DataItem.DataItem(numpy.ones((16, 16), numpy.uint32))
                 document_model.append_data_item(data_item)
-                new_data_item_specifier = data_item.project.create_specifier(data_item)
+                new_data_item_specifier = Persistence.PersistentObjectSpecifier(data_item.uuid)
             # auto migrate workspace
             document_model = profile_context.create_document_model(auto_close=False)
             # this migrate is not allowed since it is already migrated.
@@ -3281,7 +3281,7 @@ class TestStorageClass(unittest.TestCase):
             with document_model.ref():
                 self.assertEqual(2, len(document_model.data_items))
                 self.assertEqual(2, len(document_model.display_items))
-                data_item_specifier = Persistence.PersistentObjectSpecifier(item_uuid=uuid.UUID(src_uuid_str))
+                data_item_specifier = Persistence.PersistentObjectSpecifier(uuid.UUID(src_uuid_str))
                 self.assertIsNotNone(typing.cast(DataItem.DataItem, document_model.resolve_item_specifier(data_item_specifier)))
                 self.assertIsNotNone(typing.cast(DataItem.DataItem, document_model.resolve_item_specifier(new_data_item_specifier)))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nionswift
-version = 0.16.0
+version = 0.16.1
 author = Nion Software
 author_email = swift@nion.com
 description = Nion Swift: Scientific Image Processing.
@@ -16,10 +16,10 @@ classifiers =
 
 [options]
 packages = find_namespace:
-python_requires = ~=3.8
+python_requires = >=3.8,<3.11
 install_requires =
     scipy
-    numpy>=1.21.3,<2.0
+    numpy>=1.21,<2.0
     h5py
     pytz
     tzlocal


### PR DESCRIPTION
- Make unbindable protocol for use in unbinder. Eliminates a use of PersistentObject.
- Relax restriction on specifier to only require uuid.
- Simplify persistent object specifier so it is a basic wrapper around uuid.
- Version 0.16.1. Deselect panel. HDF5. Python 3.10.
