### PR TITLE
Reordered User Guide Outline

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -2,16 +2,16 @@
 
 .. _user-guide:
 
+##########
 User Guide
-==========
+##########
 
 .. toctree::
     introduction
-    user_interface
     display_panels
+    user_interface
     data
-    data_management
     graphics
     processing
+    data_management
     :maxdepth: 2
-    :caption: User Guide:


### PR DESCRIPTION
All of the same document are still there but the order has been slightly modified. display_panels was moved above user_interface, and data_management was moved to the bottom.