### PR TITLE
Restructure User Guide Without Heading Formatting

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -7,11 +7,11 @@ User Guide
 
 .. toctree::
     introduction
-    user_interface
     display_panels
+    user_interface
     data
-    data_management
     graphics
     processing
+    data_management
     :maxdepth: 2
     :caption: User Guide:


### PR DESCRIPTION
Same new order without the heading reformatting. Disregard the previous pull request to restructure the user guide.