### PR TITLE
Renamed "Snapshot Display Item" to "Snapshot Display", and assigned t…

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3449,7 +3449,7 @@ class DisplayRevealAction(Window.Action):
 
 class DisplaySnapshotAction(Window.Action):
     action_id = "display.snapshot_display"
-    action_name = _("Snapshot Display Item")
+    action_name = _("Snapshot Display")
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
         context = typing.cast(DocumentController.ActionContext, context)

--- a/nion/swift/resources/key_config.json
+++ b/nion/swift/resources/key_config.json
@@ -1,4 +1,7 @@
 {
+    "display.snapshot_display": {
+        "window": "Ctrl+S"
+    },
     "display_panel.delete_graphics": {
         "display_panel": "delete"
     },
@@ -100,9 +103,6 @@
     },
     "item.copy_uuid": {
         "window": "Ctrl+Shift+U"
-    },
-    "item.snapshot": {
-        "window": "Ctrl+S"
     },
     "item.duplicate": {
         "window": "Ctrl+D"


### PR DESCRIPTION
…he Ctrl+S hotkey to it.

Removed "Item" from the listing of "Snapshot Item" in the Display root menu.
Removed the Ctrl+S hotkey from item.snapshot to display.snapshot_display.