### PR TITLE
imageio v3

### DIFF
--- a/nion/swift/test/ImportExportManager_test.py
+++ b/nion/swift/test/ImportExportManager_test.py
@@ -114,6 +114,27 @@ class TestImportExportManagerClass(unittest.TestCase):
                 os.remove(file_path_npy)
                 os.remove(file_path_json)
 
+    def test_standard_io_write_to_then_read_from_temp_file(self):
+        with TestContext.create_memory_context() as test_context:
+            document_model = test_context.create_document_model()
+            current_working_directory = os.getcwd()
+            extensions = ("jpeg", "png", "gif", "bmp")
+            for extension in extensions:
+                file_path = os.path.join(current_working_directory, f"__file.{extension}")
+                handler = ImportExportManager.StandardImportExportHandler(f"{extension}-io-handler", extension, [extension])
+                data_item = DataItem.DataItem(numpy.zeros((16, 16), dtype=numpy.double))
+                document_model.append_data_item(data_item)
+                display_item = document_model.get_display_item_for_data_item(data_item)
+                handler.write_display_item(display_item, pathlib.Path(file_path), extension)
+                self.assertTrue(os.path.exists(file_path))
+                try:
+                    data_items = handler.read_data_items(extension, pathlib.Path(file_path))
+                    self.assertEqual(len(data_items), 1)
+                    for data_item in data_items:
+                        data_item.close()
+                finally:
+                    os.remove(file_path)
+
     def test_get_writers_for_empty_data_item_returns_valid_list(self):
         data_item = DataItem.DataItem()
         with contextlib.closing(data_item):

--- a/nion/swift/test/Symbolic_test.py
+++ b/nion/swift/test/Symbolic_test.py
@@ -10,13 +10,13 @@ import uuid
 # third party libraries
 import numpy
 import scipy
+import scipy.fft
 
 # local libraries
 from nion.data import Calibration
 from nion.data import Core
 from nion.data import Image
 from nion.swift import Application
-from nion.swift import DocumentController
 from nion.swift import Facade
 from nion.swift.model import DataItem
 from nion.swift.model import DocumentModel
@@ -376,7 +376,7 @@ class TestSymbolicClass(unittest.TestCase):
             computation.create_input_item("a", Symbolic.make_item(data_item))
             document_model.append_computation(computation)
             data = DocumentModel.evaluate_data(computation).data
-            assert numpy.array_equal(data, scipy.fftpack.fftshift(numpy.fft.fft2(d) * 1.0 / numpy.sqrt(d.shape[1] * d.shape[0])))
+            assert numpy.array_equal(data, scipy.fft.fftshift(scipy.fft.fft2(d) * 1.0 / numpy.sqrt(d.shape[1] * d.shape[0])))
 
     def test_gaussian_blur_handles_scalar_argument(self):
         with TestContext.create_memory_context() as test_context:


### PR DESCRIPTION
- Use scipy.fft instead of fftpack or numpy.fft.
- Use imageio.v3. Fix typing.
