### PR TITLE
Added the Ability to Have Legend Outside of LinePlot

### DIFF
--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -1981,9 +1981,10 @@ class ImageDisplayInspectorSection(InspectorSection):
 
 
 def make_legend_position(document_controller: DocumentController.DocumentController, display_item: DisplayItem.DisplayItem) -> typing.Tuple[UserInterface.BoxWidget, Event.EventListener]:
+    # This function is currently only utilized by lineplots
     ui = document_controller.ui
     legend_position_row = ui.create_row_widget()
-    legend_position_options = [(_("None"), None), (_("Top Left"), "top-left"), (_("Top Right"), "top-right")]
+    legend_position_options = [(_("None"), None), (_("Top Left"), "top-left"), (_("Top Right"), "top-right"), (_("Outer Left"), "outer-left"), (_("Outer Right"), "outer-right")]
     legend_position_reverse_map = {p[1]: i for i, p in enumerate(legend_position_options)}
     legend_position_chooser = ui.create_combo_box_widget(items=legend_position_options, item_getter=operator.itemgetter(0))
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -260,16 +260,22 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_outer_left_legend.size_to_content()
         self.__line_graph_outer_right_legend.size_to_content()
 
+        self.__line_graph_legend_row.visible = False
+        self.__line_graph_legend_row.canvas_items[0].visible = False
+        self.__line_graph_legend_row.canvas_items[2].visible = False
+        self.__line_graph_outer_left_legend.visible = False
+        self.__line_graph_outer_right_legend.visible = False
+
         if self.__legend_position == "top-left":
-            self.__line_graph_legend_canvas_item.visible = True
-            self.__line_graph_legend_row.canvas_items[0].visible = False
+            self.__line_graph_legend_row.visible= True
             self.__line_graph_legend_row.canvas_items[2].visible = True
         elif self.__legend_position == "top-right":
-            self.__line_graph_legend_canvas_item.visible = True
+            self.__line_graph_legend_row.visible = True
             self.__line_graph_legend_row.canvas_items[0].visible = True
-            self.__line_graph_legend_row.canvas_items[2].visible = False
-        else:
-            self.__line_graph_legend_canvas_item.visible = False
+        elif self.__legend_position == "outer-left":
+            self.__line_graph_outer_left_legend.visible = True
+        elif self.__legend_position == "outer-right":
+            self.__line_graph_outer_right_legend.visible = True
 
     def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> None:
         if role == "related_icons":

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -121,6 +121,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_legend_column.layout = CanvasItem.CanvasItemColumnLayout()
         self.__line_graph_legend_column.add_canvas_item(self.__line_graph_legend_row)
         self.__line_graph_legend_column.add_stretch()
+        self.__line_graph_outer_left_legend = LineGraphCanvasItem.LineGraphLegendCanvasItem(ui_settings, typing.cast(LineGraphCanvasItem.LineGraphLegendCanvasItemDelegate, delegate))
+        self.__line_graph_outer_right_legend = LineGraphCanvasItem.LineGraphLegendCanvasItem(ui_settings, typing.cast(LineGraphCanvasItem.LineGraphLegendCanvasItemDelegate, delegate))
         self.__line_graph_frame_canvas_item = LineGraphCanvasItem.LineGraphFrameCanvasItem()
         self.__line_graph_area_stack.add_canvas_item(self.__line_graph_background_canvas_item)
         self.__line_graph_area_stack.add_canvas_item(self.__line_graph_stack)
@@ -161,12 +163,20 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__overlap_controls.layout = CanvasItem.CanvasItemColumnLayout()
         self.__overlap_controls.add_stretch()
 
+        # create and add the outer level labels
+        legend_row = CanvasItem.CanvasItemComposition()
+        legend_row.layout = CanvasItem.CanvasItemRowLayout()
+        legend_row.add_canvas_item(self.__line_graph_outer_left_legend)
+        legend_row.add_canvas_item(line_graph_group_canvas_item)
+        legend_row.add_canvas_item(self.__line_graph_outer_right_legend)
+
         # draw the background
         line_graph_background_canvas_item = CanvasItem.CanvasItemComposition()
         #line_graph_background_canvas_item.update_sizing(line_graph_background_canvas_item.size.with_minimum_aspect_ratio(1.5))  # note: no maximum aspect ratio; line plot looks nice wider.
         line_graph_background_canvas_item.add_canvas_item(CanvasItem.BackgroundCanvasItem("#FFF"))
-        line_graph_background_canvas_item.add_canvas_item(line_graph_group_canvas_item)
         line_graph_background_canvas_item.add_canvas_item(self.__overlap_controls)
+
+        line_graph_background_canvas_item.add_canvas_item(legend_row)
 
         self.__display_controls = CanvasItem.CanvasItemComposition()
         self.__display_controls.layout = CanvasItem.CanvasItemColumnLayout()
@@ -247,6 +257,9 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def __update_legend_origin(self) -> None:
         self.__line_graph_legend_canvas_item.size_to_content()
+        self.__line_graph_outer_left_legend.size_to_content()
+        self.__line_graph_outer_right_legend.size_to_content()
+
         if self.__legend_position == "top-left":
             self.__line_graph_legend_canvas_item.visible = True
             self.__line_graph_legend_row.canvas_items[0].visible = False
@@ -633,6 +646,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_regions_canvas_item.set_calibrated_data(self.line_graph_canvas_item.calibrated_xdata.data if self.line_graph_canvas_item and self.line_graph_canvas_item.calibrated_xdata else None)
         self.__line_graph_frame_canvas_item.set_draw_frame(bool(axes))
         self.__line_graph_legend_canvas_item.set_legend_entries(legend_entries)
+        self.__line_graph_outer_left_legend.set_legend_entries(legend_entries)
+        self.__line_graph_outer_right_legend.set_legend_entries(legend_entries)
         self.__update_legend_origin()
         self.__line_graph_vertical_axis_label_canvas_item.set_axes(axes)
         self.__line_graph_vertical_axis_scale_canvas_item.set_axes(axes, self.__ui_settings)

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -121,8 +121,16 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_legend_column.layout = CanvasItem.CanvasItemColumnLayout()
         self.__line_graph_legend_column.add_canvas_item(self.__line_graph_legend_row)
         self.__line_graph_legend_column.add_stretch()
+        self.__line_graph_outer_left_column = CanvasItem.CanvasItemComposition()
+        self.__line_graph_outer_left_column.layout = CanvasItem.CanvasItemColumnLayout(margins=Geometry.Margins(16, 16, 0, 0))
         self.__line_graph_outer_left_legend = LineGraphCanvasItem.LineGraphLegendCanvasItem(ui_settings, typing.cast(LineGraphCanvasItem.LineGraphLegendCanvasItemDelegate, delegate))
+        self.__line_graph_outer_left_column.add_canvas_item(self.__line_graph_outer_left_legend)
+        self.__line_graph_outer_left_column.add_stretch()
+        self.__line_graph_outer_right_column = CanvasItem.CanvasItemComposition()
+        self.__line_graph_outer_right_column.layout = CanvasItem.CanvasItemColumnLayout(margins=Geometry.Margins(16, 0, 0, 16))
         self.__line_graph_outer_right_legend = LineGraphCanvasItem.LineGraphLegendCanvasItem(ui_settings, typing.cast(LineGraphCanvasItem.LineGraphLegendCanvasItemDelegate, delegate))
+        self.__line_graph_outer_right_column.add_canvas_item(self.__line_graph_outer_right_legend)
+        self.__line_graph_outer_right_column.add_stretch()
         self.__line_graph_frame_canvas_item = LineGraphCanvasItem.LineGraphFrameCanvasItem()
         self.__line_graph_area_stack.add_canvas_item(self.__line_graph_background_canvas_item)
         self.__line_graph_area_stack.add_canvas_item(self.__line_graph_stack)
@@ -166,9 +174,9 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         # create and add the outer level labels
         legend_row = CanvasItem.CanvasItemComposition()
         legend_row.layout = CanvasItem.CanvasItemRowLayout()
-        legend_row.add_canvas_item(self.__line_graph_outer_left_legend)
+        legend_row.add_canvas_item(self.__line_graph_outer_left_column)
         legend_row.add_canvas_item(line_graph_group_canvas_item)
-        legend_row.add_canvas_item(self.__line_graph_outer_right_legend)
+        legend_row.add_canvas_item(self.__line_graph_outer_right_column)
 
         # draw the background
         line_graph_background_canvas_item = CanvasItem.CanvasItemComposition()
@@ -263,8 +271,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_legend_row.visible = False
         self.__line_graph_legend_row.canvas_items[0].visible = False
         self.__line_graph_legend_row.canvas_items[2].visible = False
-        self.__line_graph_outer_left_legend.visible = False
-        self.__line_graph_outer_right_legend.visible = False
+        self.__line_graph_outer_right_column.visible = False
+        self.__line_graph_outer_left_column.visible = False
 
         if self.__legend_position == "top-left":
             self.__line_graph_legend_row.visible= True
@@ -273,9 +281,9 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             self.__line_graph_legend_row.visible = True
             self.__line_graph_legend_row.canvas_items[0].visible = True
         elif self.__legend_position == "outer-left":
-            self.__line_graph_outer_left_legend.visible = True
+            self.__line_graph_outer_left_column.visible = True
         elif self.__legend_position == "outer-right":
-            self.__line_graph_outer_right_legend.visible = True
+            self.__line_graph_outer_right_column.visible = True
 
     def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> None:
         if role == "related_icons":

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -1490,6 +1490,26 @@ class TestInspectorClass(unittest.TestCase):
         self.assertEqual(0, Inspector.GammaIntegerConverter().convert(0.0))
         self.assertEqual(0.1, Inspector.GammaIntegerConverter().convert_back(100))
 
+    def test_line_plot_inspector_handles_legend_position(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            display_panel = document_controller.selected_display_panel
+            data_item = DataItem.DataItem(numpy.zeros((32,)))
+            data_item2 = DataItem.DataItem(numpy.zeros((32,)))
+            document_model.append_data_item(data_item)
+            document_model.append_data_item(data_item2, False)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_item.display_type = "line_plot"
+            display_item.append_display_data_channel(DisplayItem.DisplayDataChannel(data_item=data_item2))
+            display_panel.set_display_panel_display_item(display_item)
+            inspector_panel = document_controller.find_dock_panel("inspector-panel")
+            document_controller.periodic()
+            inspector_panel.show()
+
+            display_item.set_display_property("legend_position", "outer-left")
+            display_item.set_display_property("legend_position", "outer-left")
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
This is the first of a few PRs to address #495. Specifically, in this set of commits the ability for the LinePlot to have its legend drawn outside of the graph area has been added, but the functionality is not yet exposed to the UI.