### PR TITLE
Fix #657 Utility Class Approach

### DIFF
--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -24,7 +24,6 @@ from nion.swift.model import Utility
 from nion.ui import CanvasItem
 from nion.utils import Geometry
 from nion.utils import Registry
-from nion.utils import Color
 
 if typing.TYPE_CHECKING:
     from nion.swift.model import Persistence
@@ -512,7 +511,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if self.__display_frame_rate_id:
                 Utility.fps_tick("prepare_"+self.__display_frame_rate_id)
 
-            colors = list({*Color.svg_color_map.values()})
+            colors = list(DisplayItem.DisplayItem.DEFAULT_COLORS)
 
             max_layer_count = len(self.__line_graph_stack.canvas_items)
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -512,7 +512,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if self.__display_frame_rate_id:
                 Utility.fps_tick("prepare_"+self.__display_frame_rate_id)
 
-            colors = Color.svg_color_map.values()
+            colors = typing.cast(typing.List[str], [*{Color.svg_color_map.values()}])
 
             max_layer_count = len(self.__line_graph_stack.canvas_items)
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -512,7 +512,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if self.__display_frame_rate_id:
                 Utility.fps_tick("prepare_"+self.__display_frame_rate_id)
 
-            colors = typing.cast(typing.List[str], [*{Color.svg_color_map.values()}])
+            colors = list({*Color.svg_color_map.values()})
 
             max_layer_count = len(self.__line_graph_stack.canvas_items)
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -24,6 +24,7 @@ from nion.swift.model import Utility
 from nion.ui import CanvasItem
 from nion.utils import Geometry
 from nion.utils import Registry
+from nion.utils import Color
 
 if typing.TYPE_CHECKING:
     from nion.swift.model import Persistence
@@ -511,7 +512,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if self.__display_frame_rate_id:
                 Utility.fps_tick("prepare_"+self.__display_frame_rate_id)
 
-            colors = ('#1E90FF', "#F00", "#0F0", "#00F", "#FF0", "#0FF", "#F0F", "#888", "#800", "#080", "#008", "#CCC", "#880", "#088", "#808", "#964B00")
+            colors = Color.svg_color_map.values()
 
             max_layer_count = len(self.__line_graph_stack.canvas_items)
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2000,7 +2000,7 @@ class DisplayItem(Persistence.PersistentObject):
 
     def __get_unique_display_layer_color(self) -> str:
         existing_colors = [display_layer.fill_color for display_layer in self.display_layers]
-        unused_colors = list(*{Color.svg_color_map.values()})
+        unused_colors = typing.cast(typing.List[str], [*{Color.svg_color_map.values()}])
         matches = [False] * len(unused_colors)
         for color_str in existing_colors:
             source_color = Color.Color(color_str)
@@ -2009,7 +2009,7 @@ class DisplayItem(Persistence.PersistentObject):
         try:
             return unused_colors[matches.index(False)]
         except ValueError:
-            return Color.svg_color_map.values()[0]
+            return unused_colors[0]
 
     def auto_display_legend(self) -> None:
         if len(self.display_layers) == 2 and self.get_display_property("legend_position") is None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1313,6 +1313,8 @@ def display_layer_factory(lookup_id: typing.Callable[[str], str]) -> DisplayLaye
 
 
 class DisplayItem(Persistence.PersistentObject):
+    DEFAULT_COLORS = ("#1E90FF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#00FFFF", "#FF00FF", "#888888", "#880000", "#008800", "#000088", "#CCCCCC", "#888800", "#008888", "#880088", "#964B00")
+
     def __init__(self, item_uuid: typing.Optional[uuid.UUID] = None, *, data_item: typing.Optional[DataItem.DataItem] = None) -> None:
         super().__init__()
         if item_uuid:
@@ -2000,16 +2002,16 @@ class DisplayItem(Persistence.PersistentObject):
 
     def __get_unique_display_layer_color(self) -> str:
         existing_colors = [display_layer.fill_color for display_layer in self.display_layers]
-        unused_colors = list({*Color.svg_color_map.values()})
-        matches = [False] * len(unused_colors)
+        choice_colors = list(copy.copy(self.DEFAULT_COLORS))
         for color_str in existing_colors:
-            source_color = Color.Color(color_str)
-            for index in range(len(matches)):
-                matches[index] |= source_color.matches_without_alpha(Color.Color(unused_colors[index]))
-        try:
-            return unused_colors[matches.index(False)]
-        except ValueError:
-            return unused_colors[0]
+            color = Color.Color(color_str)
+            index = 0
+            while index < len(choice_colors):
+                if color.matches_without_alpha(Color.Color(choice_colors[index])):
+                    del choice_colors[index]
+                else:
+                    index += 1
+        return choice_colors[0] if len(choice_colors) > 0 else self.DEFAULT_COLORS[0]
 
     def auto_display_legend(self) -> None:
         if len(self.display_layers) == 2 and self.get_display_property("legend_position") is None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2026,6 +2026,9 @@ class DisplayItem(Persistence.PersistentObject):
             display_layer.data_row = data_row
         if not display_layer.fill_color:
             display_layer.fill_color = self.__get_unique_display_layer_color()
+            display_layer.stroke_color = display_layer.fill_color
+            if len(self.display_data_channels) > 1:  # if the layer is an additional stack
+                display_layer.fill_color = "#00" + display_layer.fill_color[1:]  # add only the outline of the original color (but preserve the color w/ maxed alpha)
         self.append_display_layer(display_layer)
         self.auto_display_legend()
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -36,6 +36,7 @@ from nion.utils import Event
 from nion.utils import Geometry
 from nion.utils import ReferenceCounting
 from nion.utils import Registry
+from nion.utils import Color
 
 if typing.TYPE_CHECKING:
     from nion.swift.model import Project
@@ -1998,11 +1999,17 @@ class DisplayItem(Persistence.PersistentObject):
             self.__add_display_layer_auto(display_layer, display_data_channel)
 
     def __get_unique_display_layer_color(self) -> str:
-        existing_colors = {display_layer.fill_color for display_layer in self.display_layers}
-        for color in ('#1E90FF', "#F00", "#0F0", "#00F", "#FF0", "#0FF", "#F0F", "#888", "#800", "#080", "#008", "#CCC", "#880", "#088", "#808", "#964B00"):
-            if not color in existing_colors:
-                return color
-        return '#1E90FF'
+        existing_colors = [display_layer.fill_color for display_layer in self.display_layers]
+        unused_colors = list(*{Color.svg_color_map.values()})
+        matches = [False] * len(unused_colors)
+        for color_str in existing_colors:
+            source_color = Color.Color(color_str)
+            for index in range(len(matches)):
+                matches[index] |= source_color.matches_without_alpha(Color.Color(unused_colors[index]))
+        try:
+            return unused_colors[matches.index(False)]
+        except ValueError:
+            return Color.svg_color_map.values()[0]
 
     def auto_display_legend(self) -> None:
         if len(self.display_layers) == 2 and self.get_display_property("legend_position") is None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2007,9 +2007,9 @@ class DisplayItem(Persistence.PersistentObject):
             for index in range(len(matches)):
                 matches[index] |= source_color.matches_without_alpha(Color.Color(unused_colors[index]))
         try:
-            return unused_colors[matches.index(False)]
+            return str(unused_colors[matches.index(False)])
         except ValueError:
-            return unused_colors[0]
+            return str(unused_colors[0])
 
     def auto_display_legend(self) -> None:
         if len(self.display_layers) == 2 and self.get_display_property("legend_position") is None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2000,16 +2000,16 @@ class DisplayItem(Persistence.PersistentObject):
 
     def __get_unique_display_layer_color(self) -> str:
         existing_colors = [display_layer.fill_color for display_layer in self.display_layers]
-        unused_colors = typing.cast(typing.List[str], [*{Color.svg_color_map.values()}])
+        unused_colors = list({*Color.svg_color_map.values()})
         matches = [False] * len(unused_colors)
         for color_str in existing_colors:
             source_color = Color.Color(color_str)
             for index in range(len(matches)):
                 matches[index] |= source_color.matches_without_alpha(Color.Color(unused_colors[index]))
         try:
-            return str(unused_colors[matches.index(False)])
+            return unused_colors[matches.index(False)]
         except ValueError:
-            return str(unused_colors[0])
+            return unused_colors[0]
 
     def auto_display_legend(self) -> None:
         if len(self.display_layers) == 2 and self.get_display_property("legend_position") is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = nionswift
 version = 0.16.3
+# requires nionutils >=0.4.4,<0.5.0 for color class
 author = Nion Software
 author_email = swift@nion.com
 description = Nion Swift: Scientific Image Processing.


### PR DESCRIPTION
Implementation for #657 utilizing the new color class.

Right now it is utilizing the svg color set within the utility class as a proper default color list did not seem to make the cut.
In addition, the logic __get_unique_display_color is a bit more complicated than I would like due to being unable to get a converted color / color string directly