### PR TITLE
Fix #640 Non-Fixed Place Import Menus Now Return to Previous Location

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -379,8 +379,8 @@ class Application(UIApplication.BaseApplication):
             filter_str = "Projects (*.nsproj);;Legacy Libraries (*.nslib);;All Files (*.*)"
             import_dir = ui.get_persistent_string("open_directory", ui.get_document_location())
             paths, selected_filter, selected_directory = ui.get_file_paths_dialog(_("Add Existing Library"), import_dir, filter_str)
-            ui.set_persistent_string("open_directory", selected_directory)
             if len(paths) == 1:
+                ui.set_persistent_string("open_directory", selected_directory)
                 project_reference = profile.open_project(pathlib.Path(paths[0]))
                 if project_reference:
                     self.open_project_reference(project_reference)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -749,8 +749,9 @@ class DocumentController(Window.Window):
         filter += ";;All Files (*.*)"
         import_dir = self.ui.get_persistent_string("import_directory", "")
         paths, selected_filter, selected_directory = self.get_file_paths_dialog(_("Import File(s)"), import_dir, filter)
-        self.ui.set_persistent_string("import_directory", selected_directory)
-        self.receive_files(paths, display_panel=self.next_result_display_panel())
+        if len(paths) > 0:
+            self.ui.set_persistent_string("import_directory", selected_directory)
+            self.receive_files(paths, display_panel=self.next_result_display_panel())
 
     def export_file(self, display_item: DisplayItem.DisplayItem) -> None:
         # present a loadfile dialog to the user

--- a/nion/swift/ScriptsDialog.py
+++ b/nion/swift/ScriptsDialog.py
@@ -403,15 +403,16 @@ class RunScriptDialog(Dialog.ActionDialog):
             assert self.__profile
             add_dir = self.ui.get_persistent_string("import_directory", "")
             file_paths, filter_str, directory = self.get_file_paths_dialog(_("Add Scripts"), add_dir, "Python Files (*.py)", "Python Files (*.py)")
-            self.ui.set_persistent_string("import_directory", directory)
-            items = list(self.scripts_list_widget.items)
-            for file_path_str in file_paths:
-                script_item = Profile.FileScriptItem(pathlib.Path(file_path_str))
-                self.__profile.append_script_item(script_item)
-                script_list_item = ScriptListItem(file_path_str)
-                script_list_item.script_item = script_item
-                items.append(script_list_item)
-            self.update_scripts_list(items)
+            if len(file_paths) > 0:
+                self.ui.set_persistent_string("import_directory", directory)
+                items = list(self.scripts_list_widget.items)
+                for file_path_str in file_paths:
+                    script_item = Profile.FileScriptItem(pathlib.Path(file_path_str))
+                    self.__profile.append_script_item(script_item)
+                    script_list_item = ScriptListItem(file_path_str)
+                    script_list_item.script_item = script_item
+                    items.append(script_list_item)
+                self.update_scripts_list(items)
 
         def add_folder_clicked() -> None:
             assert self.__profile


### PR DESCRIPTION
Import menus will now return to their previous location on reopen if nothing was imported
