### PR TITLE
imageio3

### DIFF
--- a/nion/swift/model/ImportExportManager.py
+++ b/nion/swift/model/ImportExportManager.py
@@ -11,7 +11,7 @@ import zipfile
 import itertools
 
 # third party libraries
-import imageio
+import imageio.v3 as imageio
 import numpy
 
 # local libraries
@@ -512,7 +512,7 @@ def read_image_from_file(filename: pathlib.Path) -> _DataArrayType:
     if str(filename).startswith(":"):
         return numpy.zeros((20, 20, 4), numpy.uint8)
     # TODO: fix typing when imageio gets their numpy typing correct.
-    image = imageio.imread(filename)  # type: ignore
+    image = imageio.imread(filename, index=0)  # type: ignore
     if image is not None:
         image_u8 = convert_to_uint8(image)
         if len(image_u8.shape) == 3:
@@ -573,10 +573,9 @@ class StandardImportExportHandler(ImportExportHandler):
         display_values = display_data_channel.get_calculated_display_values()
         assert display_values
         data = display_values.display_rgba  # export the display rather than the data for these types
-        display_values = None
         assert data is not None
         # TODO: fix typing when imageio gets their numpy typing correct.
-        imageio.imwrite(path, Image.get_rgb_view(data), extension)  # type: ignore
+        imageio.imwrite(path, Image.get_rgb_view(data), extension="." + extension)  # type: ignore
 
 
 class CSVImportExportHandler(ImportExportHandler):
@@ -785,5 +784,4 @@ ImportExportManager().register_io_handler(CSVImportExportHandler("csv-io-handler
 ImportExportManager().register_io_handler(CSV1ImportExportHandler("csv1-io-handler", "CSV 1D", ["csv"]))
 ImportExportManager().register_io_handler(NDataImportExportHandler("ndata1-io-handler", "NData 1", ["ndata1"]))
 ImportExportManager().register_io_handler(NumPyImportExportHandler("numpy-io-handler", "Raw NumPy", ["npy"]))
-# webp not available until we use imageio v3, which we can't until conda updates imageio to 2.10 or later
-# ImportExportManager().register_io_handler(StandardImportExportHandler("webp-io-handler", "WebP", ["webp"]))
+ImportExportManager().register_io_handler(StandardImportExportHandler("webp-io-handler", "WebP", ["webp"]))

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -67,7 +67,7 @@ try:
         if local_utcoffset_override is not None:
             return local_utcoffset_override[0]
         datetime_local = datetime_local if datetime_local else datetime.datetime.now()
-        return int(pytz.reference.LocalTimezone().utcoffset(datetime_local).total_seconds() // 60)
+        return int(pytz.reference.LocalTimezone().utcoffset(datetime_local).total_seconds() // 60)  # type: ignore
 except ImportError:
     def local_utcoffset_minutes(datetime_local: typing.Optional[datetime.datetime] = None) -> int:
         if local_utcoffset_override is not None:

--- a/nion/swift/test/HistogramPanel_test.py
+++ b/nion/swift/test/HistogramPanel_test.py
@@ -255,6 +255,7 @@ class TestHistogramPanelClass(unittest.TestCase):
             with contextlib.closing(histogram_processor.property_changed_event.listen(property_changed)):
                 while not had_histogram or not had_statistics:
                     document_controller.periodic()
+            display_values = None
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/ImportExportManager_test.py
+++ b/nion/swift/test/ImportExportManager_test.py
@@ -118,7 +118,7 @@ class TestImportExportManagerClass(unittest.TestCase):
         with TestContext.create_memory_context() as test_context:
             document_model = test_context.create_document_model()
             current_working_directory = os.getcwd()
-            extensions = ("jpeg", "png", "gif", "bmp")
+            extensions = ("jpeg", "png", "gif", "bmp", "webp")
             for extension in extensions:
                 file_path = os.path.join(current_working_directory, f"__file.{extension}")
                 handler = ImportExportManager.StandardImportExportHandler(f"{extension}-io-handler", extension, [extension])

--- a/nion/swift/test/TestContext.py
+++ b/nion/swift/test/TestContext.py
@@ -1,4 +1,5 @@
 # system libraries
+import gc
 import typing
 import unittest
 import uuid
@@ -33,6 +34,7 @@ def begin_leaks() -> None:
 
 
 def end_leaks(test_case: unittest.TestCase) -> None:
+    gc.collect()  # force garbage collection before checking counts
     test_case.assertEqual(0, Cache.DbStorageCache.count)
     test_case.assertEqual(0, NDataHandler.NDataHandler.count)
     test_case.assertEqual(0, HDF5Handler.HDF5Handler.count)


### PR DESCRIPTION
- Reinstate imageio.v3/webp changes now that imageio 2.19 is widely available.
- Make leak tests more reliable by forcing garbage collection.
