### PR TITLE
Export Filename Sanitization and Directory Expansion for #591

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -822,7 +822,9 @@ class DocumentController(Window.Window):
 
             svg = drawing_context.to_svg(shape, view_box)
 
-            with Utility.AtomicFileWriter(pathlib.Path(path)) as fp:
+            path_obj = pathlib.Path(path)
+            path_obj = path_obj.with_name(Utility.sanitize_filename(path_obj.name))
+            with Utility.AtomicFileWriter(path_obj) as fp:
                 fp.write(svg)
 
     # this method creates a task. it is thread safe.

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -753,7 +753,7 @@ class DocumentController(Window.Window):
             self.ui.set_persistent_string("import_directory", selected_directory)
             self.receive_files(paths, display_panel=self.next_result_display_panel())
 
-    def export_file(self, display_item: DisplayItem.DisplayItem) -> None:
+    def export_file(self, display_item: DisplayItem.DisplayItem, path: typing.Optional[str] = None) -> None:
         # present a loadfile dialog to the user
         writers = ImportExportManager.ImportExportManager().get_writers_for_display_item(display_item)
         name_writer_dict: typing.Dict[typing.Tuple[str, str], typing.Any] = dict()  # TODO: fix writer typing
@@ -773,7 +773,12 @@ class DocumentController(Window.Window):
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
         selected_filter = self.ui.get_persistent_string("export_filter")
-        path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, selected_filter)
+        if not path:
+            path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, selected_filter)
+        else:
+            selected_directory = os.sep.join(path[0:-1])
+        logging.critical(path)
+        logging.critical(selected_directory)
         selected_writer = filter_line_to_writer_map.get(selected_filter)
         if path and not os.path.splitext(path)[1]:
             if selected_writer:
@@ -791,11 +796,14 @@ class DocumentController(Window.Window):
         elif len(display_items) == 1:
             self.export_file(display_items[0])
 
-    def export_svg(self, display_item: DisplayItem.DisplayItem) -> None:
+    def export_svg(self, display_item: DisplayItem.DisplayItem, path: typing.Optional[str] = None) -> None:
         filter = "SVG File (*.svg);;All Files (*.*)"
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
-        path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, None)
+        if not path:
+            path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, None)
+        else:
+            selected_directory = os.sep.join(path[0:-1])
         if path and not os.path.splitext(path)[1]:
             path = path + os.path.extsep + "svg"
         if path:

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -768,17 +768,19 @@ class DocumentController(Window.Window):
             filter_line = writer_name + " files (" + writer_extensions + ")"
             filter_lines.append(filter_line)
             filter_line_to_writer_map[filter_line] = writer
-        filter = ";;".join(filter_lines)
-        filter += ";;All Files (*.*)"
+        filter_str = ";;".join(filter_lines)
+        filter_str += ";;All Files (*.*)"
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
         selected_filter = self.ui.get_persistent_string("export_filter")
         if not path:
-            path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, selected_filter)
+            path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter_str, selected_filter)
         else:
-            selected_directory = os.sep.join(path[0:-1])
-        logging.critical(path)
-        logging.critical(selected_directory)
+            extension = path.split(".")[-1]
+            filter_map = [extension in filter_line for filter_line in filter_lines]
+            if True in filter_map:
+                selected_filter = filter_lines[filter_map.index(True)]
+            selected_directory = export_dir if len(export_dir.split(os.sep)) > 1 else ".{}".format(os.sep)
         selected_writer = filter_line_to_writer_map.get(selected_filter)
         if path and not os.path.splitext(path)[1]:
             if selected_writer:
@@ -803,7 +805,7 @@ class DocumentController(Window.Window):
         if not path:
             path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, None)
         else:
-            selected_directory = os.sep.join(path[0:-1])
+            selected_directory = export_dir if len(export_dir.split(os.sep)) > 1 else ".{}".format(os.sep)
         if path and not os.path.splitext(path)[1]:
             path = path + os.path.extsep + "svg"
         if path:

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -772,6 +772,7 @@ class DocumentController(Window.Window):
         filter_str += ";;All Files (*.*)"
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
+        export_dir = export_dir.replace("\\", "/").replace("/", os.sep)
         selected_filter = self.ui.get_persistent_string("export_filter")
         if not path:
             path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter_str, selected_filter)
@@ -782,6 +783,7 @@ class DocumentController(Window.Window):
                 selected_filter = filter_lines[filter_map.index(True)]
             selected_directory = export_dir if len(export_dir.split(os.sep)) > 1 else ".{}".format(os.sep)
         selected_writer = filter_line_to_writer_map.get(selected_filter)
+        path = path.replace("\\", "/").replace("/", os.sep)
         if path and not os.path.splitext(path)[1]:
             if selected_writer:
                 path = path + os.path.extsep + selected_writer.extensions[0]
@@ -802,6 +804,7 @@ class DocumentController(Window.Window):
         filter = "SVG File (*.svg);;All Files (*.*)"
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
+        export_dir = export_dir.replace("\\", "/").replace("/", os.sep)
         if not path:
             path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, None)
         else:
@@ -809,6 +812,7 @@ class DocumentController(Window.Window):
         if path and not os.path.splitext(path)[1]:
             path = path + os.path.extsep + "svg"
         if path:
+            path = path.replace("\\", "/").replace("/", os.sep)
             self.ui.set_persistent_string("export_directory", selected_directory)
 
             if display_item.display_data_shape and len(display_item.display_data_shape) == 2:

--- a/nion/swift/model/ImportExportManager.py
+++ b/nion/swift/model/ImportExportManager.py
@@ -173,6 +173,9 @@ class ImportExportManager(metaclass=Utility.Singleton):
             extension = extension.lower()
             data_metadata = display_item.data_items[0].data_metadata if display_item.data_items else None
             if extension in writer.extensions and data_metadata and writer.can_write(data_metadata, extension):
+                path = path.with_name(Utility.sanitize_filename(path.name))
+                if not path.parents[0].exists():
+                    path.parents[0].mkdir(parents=True, exist_ok=True)
                 writer.write_display_item(display_item, path, extension)
 
     def write_display_item(self, display_item: DisplayItem.DisplayItem, path: pathlib.Path) -> None:

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -9,6 +9,7 @@ import functools
 import logging
 import os
 import pathlib
+import re
 import sys
 import threading
 import time
@@ -460,3 +461,19 @@ class Timer:
         if self.threshold == 0.0 or (current_time - self.last_time_ns) // 1E9 > self.threshold:
             print(f"{title}: {(current_time - self.start_time_ns) // 1E6}ms +{(current_time - self.last_time_ns) // 1E6}ms")
         self.last_time_ns = current_time
+
+
+def sanitize_filename(path_as_str: str) -> typing.Tuple[str, str]:
+    """Splits leading directories from file name, and sanitizes file names.
+    Filenames will be conformed to POSIX's portable file name character set (a-Z0-9._-), plus spaces.
+    This function assumes standard path separators.
+    :param path_as_str: File name as a string
+    :return: Tuple containing path parts extracted from the file name, followed by the file_name
+    """
+    path_as_str = path_as_str.replace("\\", "/")
+    path_as_str = path_as_str.replace("/", os.sep)
+    path_parts = path_as_str.split(os.sep)
+    path_parts[-1] = re.sub(r"[^\w\-\. ]", "", path_parts[-1])
+    path_parts = (os.sep.join(path_parts[0:-1]) + os.sep, path_parts[-1])
+
+    return path_parts

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -463,17 +463,14 @@ class Timer:
         self.last_time_ns = current_time
 
 
-def sanitize_filename(path_as_str: str) -> typing.Tuple[str, str]:
+def sanitize_filename(path_as_str: str) -> str:
     """Splits leading directories from file name, and sanitizes file names.
     Filenames will be conformed to POSIX's portable file name character set (a-Z0-9._-), plus spaces.
-    This function assumes standard path separators.
+    This function assumes you have already isolated the filename from the path
     :param path_as_str: File name as a string
     :return: Tuple containing path parts extracted from the file name, followed by the file_name
     """
     path_as_str = path_as_str.replace("\\", "/")
-    path_as_str = path_as_str.replace("/", os.sep)
-    path_parts = path_as_str.split(os.sep)
-    path_parts[-1] = re.sub(r"[^\w\-\. ]", "", path_parts[-1])
-    path_parts = (os.sep.join(path_parts[0:-1]) + os.sep, path_parts[-1])
+    path_as_str = re.sub(r"[^\w\-\. ]", "", path_as_str)
 
-    return path_parts
+    return path_as_str

--- a/nion/swift/test/DocumentController_test.py
+++ b/nion/swift/test/DocumentController_test.py
@@ -3,6 +3,7 @@ import contextlib
 import gc
 import logging
 import os
+import pathlib
 import tempfile
 import unittest
 import weakref
@@ -21,6 +22,7 @@ from nion.swift.model import DisplayItem
 from nion.swift.model import DocumentModel
 from nion.swift.model import Graphics
 from nion.swift.model import Symbolic
+from nion.swift.model import Utility
 from nion.swift.test import TestContext
 from nion.ui import TestUI
 from nion.utils import Geometry
@@ -1194,32 +1196,35 @@ class TestDocumentControllerClass(unittest.TestCase):
                 file_path = save_dir + os.sep + file_name
                 for x in document_controller.project.display_items:
                     x.title = file_name
+                target = file_name.replace("\\", "/").replace("/", os.sep).replace(".{}".format(os.sep), "")
+                target_name = Utility.sanitize_filename(target.split(os.sep)[-1])
+                target_path = pathlib.Path(save_dir + os.sep + os.sep.join(target.split(os.sep)[0:-1]) + os.sep + target_name)
 
                 with self.subTest(file_name=file_name+"export_file"):
                     try:
-                        os.remove(file_path)
+                        os.remove(target_path)
                     except FileNotFoundError:
                         pass
                     document_controller.export_file(display_item, file_path)
-                    self.assertTrue(os.path.isfile(file_path))
+                    self.assertTrue(target_path.is_file())
 
                 # The code path for export_files ends up at a pass statement unless its given a single item
                 # display_item list. At that point it just calls export_file
                 #with self.subTest(file_name=file_name + "export_files"):
                 #    try:
-                #        os.remove(file_path)
+                #        os.remove(target_path)
                 #    except FileNotFoundError:
                 #        pass
                 #    document_controller.export_files(document_controller.project.display_items)
-                #    self.assertTrue(os.path.isfile(file_path))
+                #    self.assertTrue(target_path.is_file())
 
                 with self.subTest(file_name=file_name + "export_svg"):
                     try:
-                        os.remove(file_path)
+                        os.remove(target_path)
                     except FileNotFoundError:
                         pass
                     document_controller.export_svg(display_item, file_path)
-                    self.assertTrue(os.path.isfile(file_path))
+                    self.assertTrue(target_path.is_file())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This set of patches fixes the bigger issue with #591 that it used to allow for non-valid characters to be attempted to be written.

Now, the program should sanitize file names down to the POSIX portable character set, plus spaces, though this process does occur silently. If slashes are included in the provided file name, the exporter will now attempt to expand those slashes as directories, and create the directories rather than attempt to write a file with slashes in its name.

One of the other issues still remaining about #591 is that swift will not notify the user if certain if checks within the exporting code fail, and result in the file not being written. This would probably require a unification of the exporting logic paths into a single one