### PR TITLE
computation errors

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -42,6 +42,7 @@ from nion.swift.model import DocumentModel
 from nion.swift.model import FileStorageSystem
 from nion.swift.model import PlugInManager
 from nion.swift.model import Profile
+from nion.swift.model import Symbolic
 from nion.ui import Application as UIApplication
 from nion.ui import CanvasItem
 from nion.ui import Declarative
@@ -98,8 +99,8 @@ class Application(UIApplication.BaseApplication):
         self.__class__.count += 1
 
         # reset these values for tests. otherwise tests run slower after app.start is called in any previous test.
-        DocumentModel.DocumentModel.computation_min_period = 0.0
-        DocumentModel.DocumentModel.computation_min_factor = 0.0
+        Symbolic.computation_min_period = 0.0
+        Symbolic.computation_min_factor = 0.0
 
         logging.getLogger("migration").setLevel(logging.ERROR)
         logging.getLogger("loader").setLevel(logging.ERROR)
@@ -247,8 +248,8 @@ class Application(UIApplication.BaseApplication):
             self.__profile.script_items_updated = True
 
         # configure the document model object.
-        DocumentModel.DocumentModel.computation_min_period = 0.1
-        DocumentModel.DocumentModel.computation_min_factor = 1.0
+        Symbolic.computation_min_period = 0.1
+        Symbolic.computation_min_factor = 1.0
 
         # if it was created, it probably means it is migrating from an old version. so add all recent projects.
         # they will initially be disabled and the user will have to explicitly upgrade them.

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -44,18 +44,6 @@ computation_min_factor = 0.0
 _APIComputation = typing.Any
 
 
-class ComputationHandlerLike(typing.Protocol):
-    def execute(self, **kwargs: typing.Any) -> None: ...
-    def commit(self) -> None: ...
-
-
-class ComputationCommitterLike(typing.Protocol):
-    def commit(self) -> None: ...
-
-    @property
-    def _target_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]: raise NotImplementedError()
-
-
 def update_diff_notify(o: Observable.Observable, name: str, before_items: typing.List[Persistence.PersistentObject], after_items: typing.List[Persistence.PersistentObject]) -> None:
     assert all(bi is not None for bi in after_items)
     after_items = copy.copy(after_items)
@@ -1446,7 +1434,7 @@ class Computation(Persistence.PersistentObject):
         self._activity_lock = threading.RLock()
         self._activity: typing.Optional[ComputationActivity] = None
         self._do_commit = True
-        self._compute_obj: typing.Optional[ComputationCommitterLike] = None
+        self._compute_obj: typing.Optional[ComputeObject] = None
         self._pending_error_text: typing.Optional[str] = None
 
     @property
@@ -1789,147 +1777,55 @@ class Computation(Persistence.PersistentObject):
             is_resolved = is_resolved and result.is_resolved
         return kwargs, is_resolved
 
-    def evaluate(self, api: typing.Any) -> typing.Tuple[typing.Optional[ComputationCommitterLike], typing.Optional[str]]:
-        if self.expression:
+    class ComputationExec:
+        def __init__(self) -> None:
+            self.compute_obj: typing.Optional[ComputeObject] = None
+            self.error_string: typing.Optional[str] = None
 
-            class DataItemProtocol(typing.Protocol):
-                data_modified: datetime.datetime
+        def commit(self) -> None:
+            if self.compute_obj:
+                self.compute_obj.commit()
 
-                @property
-                def xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]: raise NotImplementedError()
+        @property
+        def _target_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+            return self.compute_obj._target_xdata if self.compute_obj else None
 
-                @xdata.setter
-                def xdata(self, value: typing.Optional[DataAndMetadata._DataAndMetadataLike]) -> None: ...
-
-                @property
-                def data(self) -> DataAndMetadata._ImageDataType: raise NotImplementedError()
-
-                @data.setter
-                def data(self, value: DataAndMetadata._ImageDataType) -> None: ...
-
-            class DataItemTarget(DataItemProtocol):
-                def __init__(self) -> None:
-                    self.__xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
-                    self.data_modified = datetime.datetime.min
-
-                @property
-                def xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-                    return self.__xdata
-
-                @xdata.setter
-                def xdata(self, value: typing.Optional[DataAndMetadata._DataAndMetadataLike]) -> None:
-                    self.__xdata = DataAndMetadata.promote_ndarray(value) if value is not None else None
-                    self.data_modified = DataItem.DataItem.utcnow()
-
-                @property
-                def data(self) -> DataAndMetadata._ImageDataType:
-                    return typing.cast(DataAndMetadata._ImageDataType, None)
-
-                @data.setter
-                def data(self, value: DataAndMetadata._ImageDataType) -> None:
-                    self.xdata = DataAndMetadata.new_data_and_metadata(value)
-
-            data_item = typing.cast(DataItem.DataItem, self.get_output("target"))
-            data_item_created = False
-            if not data_item:
-                data_item = DataItem.new_data_item(None)
-                data_item_created = True
-
-            data_item_target = DataItemTarget()
-            data_item_data_modified = data_item.data_modified or datetime.datetime.min
-            error_text = self.evaluate_with_target(api, data_item_target)
-
-            class ComputeObject(ComputationCommitterLike):
-                def __init__(self, data_item: DataItem.DataItem, data_item_clone: DataItemProtocol, do_close_data_item: bool) -> None:
-                    self.__data_item = data_item
-                    self.__data_item_clone = data_item_clone
-                    self.__do_close_data_item = do_close_data_item
-                    self.__xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
-
-                def commit(self) -> None:
-                    # commit the result item clones back into the document. this method is guaranteed to run at
-                    # periodic and shouldn't do anything too time-consuming.
-                    data_item_clone_data_modified = self.__data_item_clone.data_modified or datetime.datetime.min
-                    with self.__data_item.data_item_changes(), self.__data_item.data_source_changes():
-                        # note: use data_modified, but Windows doesn't have high enough time resolution
-                        # on fast machines, so ensure that any data_modified timestamp is created using
-                        # DataItem.utcnow() / Schema.utcnow().
-                        if data_item_clone_data_modified > data_item_data_modified:
-                            self.__data_item.set_xdata(self.__data_item_clone.xdata)
-                    if self.__do_close_data_item:
-                        self.__xdata = self.__data_item.xdata
-                        self.__data_item.close()
-                        self.__data_item = typing.cast(typing.Any, None)
-
-                @property
-                def _target_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-                    return self.__data_item.xdata if self.__data_item else self.__xdata
-
-            return ComputeObject(data_item, data_item_target, data_item_created), error_text
-        else:
-            compute_obj: typing.Optional[ComputationHandlerLike] = None
-            error_text = None
-            needs_update = self.needs_update
-            self.needs_update = False
-            if needs_update:
-                kwargs, is_resolved = self.__resolve_inputs(api)
-                if is_resolved:
-                    processing_id = self.processing_id
-                    compute_class = _computation_types.get(processing_id) if processing_id else None
-                    if compute_class:
-                        try:
-                            api_computation = api._new_api_object(self)
-                            api_computation.api = api
-                            compute_obj = compute_class(api_computation)
-                            compute_obj.execute(**kwargs)
-                        except Exception as e:
-                            # import sys, traceback
-                            # traceback.print_exc()
-                            # traceback.format_exception(*sys.exc_info())
-                            compute_obj = None
-                            error_text = str(e) or "Unable to evaluate script."  # a stack trace would be too much information right now
-                    else:
-                        compute_obj = None
-                        error_text = "Missing computation (" + (self.processing_id or "unknown") + ")."
-                else:
-                    error_text = "Missing parameters."
-                self._evaluation_count_for_test += 1
-                self.last_evaluate_data_time = time.perf_counter()
-            return typing.cast(ComputationCommitterLike, compute_obj), error_text
-
-    def evaluate_with_target(self, api: typing.Any, target: typing.Any) -> typing.Optional[str]:
-        assert target is not None
+    def evaluate(self, api: typing.Any) -> typing.Tuple[typing.Optional[ComputeObject], typing.Optional[str]]:
+        compute_obj: typing.Optional[ComputeObject] = None
         error_text = None
         needs_update = self.needs_update
         self.needs_update = False
         if needs_update:
-            variables, is_resolved = self.__resolve_inputs(api)
-            expression = self.original_expression
-            if expression:
-                error_text = self.__execute_code(api, expression, target, variables)
+            kwargs, is_resolved = self.__resolve_inputs(api)
+            if is_resolved:
+                try:
+                    api_computation = api._new_api_object(self)
+                    api_computation.api = api
+                    if self.expression:
+                        data_item = typing.cast(typing.Optional[DataItem.DataItem], self.get_output("target"))
+                        compute_obj = ScriptExpressionComputeObject(api, self.expression, data_item)
+                    else:
+                        processing_id = self.processing_id
+                        compute_class = _computation_types.get(processing_id) if processing_id else None
+                        if compute_class:
+                            compute_obj = RegisteredComputeObject(compute_class(api_computation))
+                    if compute_obj:
+                        compute_obj.execute(**kwargs)
+                    else:
+                        error_text = "Missing computation (" + (self.processing_id or "unknown") + ")."
+                except Exception as e:
+                    # import sys, traceback
+                    # traceback.print_exc()
+                    # traceback.format_exception(*sys.exc_info())
+                    if compute_obj:
+                        compute_obj.close()
+                        compute_obj = None
+                    error_text = str(e) or "Unable to evaluate script."  # a stack trace would be too much information right now
+            else:
+                error_text = "Missing parameters."
             self._evaluation_count_for_test += 1
             self.last_evaluate_data_time = time.perf_counter()
-        return error_text
-
-    def __execute_code(self, api: typing.Any, expression: str, target: typing.Any, variables: typing.Dict[str, typing.Any]) -> typing.Optional[str]:
-        code_lines = []
-        g = variables
-        g["api"] = api
-        g["target"] = target
-        l: typing.Dict[str, typing.Any] = dict()
-        expression_lines = expression.split("\n")
-        code_lines.extend(expression_lines)
-        code = "\n".join(code_lines)
-        try:
-            compiled = compile(code, "expr", "exec")
-            exec(compiled, g, l)
-        except Exception as e:
-            # print(code)
-            # import sys, traceback
-            # traceback.print_exc()
-            # traceback.format_exception(*sys.exc_info())
-            return str(e) or "Unable to evaluate script."  # a stack trace would be too much information right now
-        return None
+        return compute_obj, error_text
 
     @property
     def is_resolved(self) -> bool:
@@ -2132,6 +2028,90 @@ class Computation(Persistence.PersistentObject):
                 self._activity = None
 
 
+class ComputeObject(typing.Protocol):
+    def close(self) -> None: ...
+    def execute(self, **kwargs: typing.Any) -> None: ...
+    def commit(self) -> None: ...
+
+    @property
+    def _target_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]: raise NotImplementedError()
+
+
+class ScriptExpressionComputeObject(ComputeObject):
+    class DataItemTarget:
+        def __init__(self) -> None:
+            self.__xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
+            self.data_modified = datetime.datetime.min
+
+        @property
+        def xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+            return self.__xdata
+
+        @xdata.setter
+        def xdata(self, value: typing.Optional[DataAndMetadata._DataAndMetadataLike]) -> None:
+            self.__xdata = DataAndMetadata.promote_ndarray(value) if value is not None else None
+            self.data_modified = DataItem.DataItem.utcnow()
+
+        @property
+        def data(self) -> DataAndMetadata._ImageDataType:
+            return typing.cast(DataAndMetadata._ImageDataType, None)
+
+        @data.setter
+        def data(self, value: DataAndMetadata._ImageDataType) -> None:
+            self.xdata = DataAndMetadata.new_data_and_metadata(value)
+
+    def __init__(self, api: typing.Any, expression: str, data_item: typing.Optional[DataItem.DataItem]) -> None:
+        self.__api = api
+        self.__expression = expression
+        self.__data_item = data_item or DataItem.new_data_item(None)
+        self.__xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
+        self.__data_item_created = False
+        if not data_item:
+            self.__data_item_created = True
+        self.__data_item_target = ScriptExpressionComputeObject.DataItemTarget()
+        self.__data_item_data_modified = self.__data_item.data_modified or datetime.datetime.min
+
+    def close(self) -> None:
+        if self.__data_item_created:
+            self.__data_item.close()
+            self.__data_item = typing.cast(typing.Any, None)
+            self.__data_item_created = False
+
+    def execute(self, **kwargs: typing.Any) -> None:
+        assert self.__data_item_target is not None
+        if self.__expression:
+            code_lines = []
+            g = kwargs
+            g["api"] = self.__api
+            g["target"] = self.__data_item_target
+            l: typing.Dict[str, typing.Any] = dict()
+            expression_lines = self.__expression.split("\n")
+            code_lines.extend(expression_lines)
+            code = "\n".join(code_lines)
+            compiled = compile(code, "expr", "exec")
+            exec(compiled, g, l)
+
+    def commit(self) -> None:
+        # commit the result item clones back into the document. this method is guaranteed to run at
+        # periodic and shouldn't do anything too time-consuming.
+        data_item_clone_data_modified = self.__data_item_target.data_modified or datetime.datetime.min
+        with self.__data_item.data_item_changes(), self.__data_item.data_source_changes():
+            # note: use data_modified, but Windows doesn't have high enough time resolution
+            # on fast machines, so ensure that any data_modified timestamp is created using
+            # DataItem.utcnow() / Schema.utcnow().
+            if data_item_clone_data_modified > self.__data_item_data_modified:
+                self.__data_item.set_xdata(self.__data_item_target.xdata)
+        if self.__data_item_created:
+            self.__xdata = self.__data_item.xdata
+            self.__data_item.close()
+            self.__data_item = typing.cast(typing.Any, None)
+            self.__data_item_created = False
+
+    @property
+    def _target_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return self.__data_item.xdata if self.__data_item else self.__xdata
+
+
 class ComputationActivity(Activity.Activity):
     def __init__(self, computation: Computation) -> None:
         super().__init__("computation", computation.label or computation.processing_id or str())
@@ -2153,10 +2133,28 @@ class ComputationActivity(Activity.Activity):
         return self.title + " (" + self.state + ")"
 
 
+class RegisteredComputeObject(ComputeObject):
+
+    def __init__(self, computation_handler: ComputationHandlerLike) -> None:
+        self.__computation_handler = computation_handler
+
+    def close(self) -> None:
+        pass
+
+    def execute(self, **kwargs: typing.Any) -> None:
+        self.__computation_handler.execute(**kwargs)
+
+    def commit(self) -> None:
+        self.__computation_handler.commit()
+
+
 # for computations
 
-_computation_types: typing.Dict[str, typing.Callable[[_APIComputation], ComputationHandlerLike]] = dict()
+class ComputationHandlerLike(typing.Protocol):
+    def execute(self, **kwargs: typing.Any) -> None: ...
+    def commit(self) -> None: ...
 
+_computation_types: typing.Dict[str, typing.Callable[[_APIComputation], ComputationHandlerLike]] = dict()
 
 def register_computation_type(computation_type_id: str, compute_class: typing.Callable[[_APIComputation], ComputationHandlerLike]) -> None:
     _computation_types[computation_type_id] = compute_class

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4021,7 +4021,7 @@ class TestStorageClass(unittest.TestCase):
             with document_model.ref():
                 # for corrupt/missing created dates, a new one matching todays date should be assigned
                 self.assertIsNotNone(document_model.data_items[0].created)
-                self.assertEqual(document_model.data_items[0].created.date(), datetime.datetime.now().date())
+                self.assertEqual(document_model.data_items[0].created.date(), datetime.datetime.utcnow().date())
 
     def test_loading_library_with_two_copies_of_same_uuid_ignores_second_copy(self):
         with create_temp_profile_context() as profile_context:


### PR DESCRIPTION
- Fix utc date issue in test.
- Refactor to use exec/commit for script expression based computations too.
- Consolidate/combine computation queue item and computer merge objects into computations file.
- Merge computation queue item into computation for simplification.
- Put script and registered computation handlers into their own classes.
- Move executor functionality into ComputationExecutor (was minimal ComputeObject).
- Track computation executor in document model (full circle).
