### PR TITLE
file storage ds 2

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -527,7 +527,7 @@ class Application(UIApplication.BaseApplication):
             profile_path.write_text(profile_json, "utf-8")
         else:
             logging.getLogger("loader").info(f"Using existing profile {profile_path}")
-        storage_system = FileStorageSystem.FilePersistentStorageSystem(profile_path)
+        storage_system = FileStorageSystem.make_file_persistent_storage_system(profile_path)
         storage_system.load_properties()
         old_cache_path = profile_path.parent / pathlib.Path(profile_path.stem + " Cache").with_suffix(".nscache")
         if old_cache_path.exists():

--- a/nion/swift/ProjectPanel.py
+++ b/nion/swift/ProjectPanel.py
@@ -351,7 +351,7 @@ class ProjectTreeCanvasItemDelegate(Widgets.ListCanvasItemDelegate):
     def item_tool_tip(self, index: int) -> typing.Optional[str]:
         display_item = self.__tree_model.value[index]
         if isinstance(display_item, ProjectPanelProjectItem):
-            return str(display_item.project_reference.project.storage_system_path if display_item.project_reference.project else _("Missing"))
+            return display_item.project_reference.project.storage_location_str if display_item.project_reference.project else _("Missing")
         return None
 
     def context_menu_event(self, index: typing.Optional[int], x: int, y: int, gx: int, gy: int) -> bool:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1241,26 +1241,11 @@ def display_data_channel_factory(lookup_id: typing.Callable[[str], str]) -> Disp
 class DisplayLayer(Schema.Entity):
     def __init__(self, display_layer_properties: typing.Optional[Persistence.PersistentDictType] = None) -> None:
         super().__init__(Model.DisplayLayer)
-        self.__persistent_storage: typing.Optional[Persistence.PersistentStorageInterface] = None
+        self.persistent_storage: typing.Optional[Persistence.PersistentStorageInterface] = None
         self.display_data_channel: typing.Optional[DisplayDataChannel] = None
         display_layer_properties = display_layer_properties or dict()
         for k, v in display_layer_properties.items():
             setattr(self, k, v)
-
-    @property
-    def persistent_dict(self) -> typing.Optional[Persistence.PersistentDictType]:
-        return self.persistent_storage._get_persistent_dict(typing.cast(Persistence.PersistentObject, self)) if self.persistent_storage else None
-
-    @property
-    def persistent_storage(self) -> typing.Optional[Persistence.PersistentStorageInterface]:
-        return self.__persistent_storage
-
-    def _set_persistent_storage(self, persistent_dict: typing.Optional[Persistence.PersistentDictType], persistent_storage: typing.Optional[Persistence.PersistentStorageInterface]) -> None:
-        if persistent_storage:
-            persistent_storage._unregister_persistent_dict(typing.cast(Persistence.PersistentObject, self))
-        self.__persistent_storage = persistent_storage
-        if persistent_storage:
-            persistent_storage._register_persistent_dict(typing.cast(Persistence.PersistentObject, self), persistent_dict)
 
     @property
     def display_item(self) -> DisplayItem:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1241,11 +1241,26 @@ def display_data_channel_factory(lookup_id: typing.Callable[[str], str]) -> Disp
 class DisplayLayer(Schema.Entity):
     def __init__(self, display_layer_properties: typing.Optional[Persistence.PersistentDictType] = None) -> None:
         super().__init__(Model.DisplayLayer)
-        self.persistent_storage = None
+        self.__persistent_storage: typing.Optional[Persistence.PersistentStorageInterface] = None
         self.display_data_channel: typing.Optional[DisplayDataChannel] = None
         display_layer_properties = display_layer_properties or dict()
         for k, v in display_layer_properties.items():
             setattr(self, k, v)
+
+    @property
+    def persistent_dict(self) -> typing.Optional[Persistence.PersistentDictType]:
+        return self.persistent_storage._get_persistent_dict(typing.cast(Persistence.PersistentObject, self)) if self.persistent_storage else None
+
+    @property
+    def persistent_storage(self) -> typing.Optional[Persistence.PersistentStorageInterface]:
+        return self.__persistent_storage
+
+    def _set_persistent_storage(self, persistent_dict: typing.Optional[Persistence.PersistentDictType], persistent_storage: typing.Optional[Persistence.PersistentStorageInterface]) -> None:
+        if persistent_storage:
+            persistent_storage._unregister_persistent_dict(typing.cast(Persistence.PersistentObject, self))
+        self.__persistent_storage = persistent_storage
+        if persistent_storage:
+            persistent_storage._register_persistent_dict(typing.cast(Persistence.PersistentObject, self), persistent_dict)
 
     @property
     def display_item(self) -> DisplayItem:

--- a/nion/swift/model/Persistence.py
+++ b/nion/swift/model/Persistence.py
@@ -230,7 +230,13 @@ class PersistentRelationship:
         return self.key if self.key else self.name
 
 
-class PersistentStorageInterface(abc.ABC):
+class PersistentStorageInterface(typing.Protocol):
+
+    @abc.abstractmethod
+    def close(self) -> None: ...
+
+    @abc.abstractmethod
+    def load_properties(self) -> None: ...
 
     @abc.abstractmethod
     def get_storage_properties(self) -> typing.Optional[PersistentDictType]: ...
@@ -273,6 +279,12 @@ class PersistentStorageInterface(abc.ABC):
 
     @abc.abstractmethod
     def rewrite_item(self, item: PersistentObject) -> None: ...
+
+    @abc.abstractmethod
+    def enter_transaction(self) -> None: ...
+
+    @abc.abstractmethod
+    def exit_transaction(self) -> None: ...
 
 
 class PersistentObjectContext:
@@ -788,9 +800,23 @@ class PersistentObject(Observable.Observable):
         return self.persistent_dict[key] if self.persistent_dict is not None else None
 
     def _get_relationship_persistent_dict(self, item: PersistentObject, key: str, index: int) -> typing.Optional[PersistentDictType]:
+        # by using inner and outer functions, allows subclasses to override the outer method, delegate it,
+        # and have the delegate call back to the inner method. hopefully this is temporary as the file system is refactored.
+        return self._get_relationship_persistent_dict_inner(item, key, index)
+
+    def _get_relationship_persistent_dict_inner(self, item: PersistentObject, key: str, index: int) -> typing.Optional[PersistentDictType]:
+        # by using inner and outer functions, allows subclasses to override the outer method, delegate it,
+        # and have the delegate call back to the inner method. hopefully this is temporary as the file system is refactored.
         return self.persistent_dict[key][index] if self.persistent_dict is not None else None
 
     def _get_relationship_persistent_dict_by_uuid(self, item: PersistentObject, key: str) -> typing.Optional[PersistentDictType]:
+        # by using inner and outer functions, allows subclasses to override the outer method, delegate it,
+        # and have the delegate call back to the inner method. hopefully this is temporary as the file system is refactored.
+        return self._get_relationship_persistent_dict_by_uuid_inner(item, key)
+
+    def _get_relationship_persistent_dict_by_uuid_inner(self, item: PersistentObject, key: str) -> typing.Optional[PersistentDictType]:
+        # by using inner and outer functions, allows subclasses to override the outer method, delegate it,
+        # and have the delegate call back to the inner method. hopefully this is temporary as the file system is refactored.
         if self.persistent_dict:
             item_uuid = str(item.uuid)
             for item_d in self.persistent_dict.get(key, list()):

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -248,14 +248,6 @@ class Project(Persistence.PersistentObject):
     def __data_group_removed(self, name: str, index: int, data_group: DataGroup.DataGroup) -> None:
         self.notify_remove_item("data_groups", data_group, index)
 
-    def _get_relationship_persistent_dict(self, item: Persistence.PersistentObject, key: str, index: int) -> typing.Optional[PersistentDictType]:
-        # note: this delegates to storage system. the storage system must only call the inner version of this function to avoid recursion.
-        return self.__storage_system._get_relationship_persistent_dict(self, item, key, index)
-
-    def _get_relationship_persistent_dict_by_uuid(self, item: Persistence.PersistentObject, key: str) -> typing.Optional[PersistentDictType]:
-        # note: this delegates to storage system. the storage system must only call the inner version of this function to avoid recursion.
-        return self.__storage_system._get_relationship_persistent_dict_by_uuid(self, item, key)
-
     def prepare_read_project(self) -> None:
         logging.getLogger("loader").info(f"Loading project {self.__storage_system.get_identifier()}")
         self._raw_properties, self.__reader_errors = self.__storage_system.read_project_properties()  # combines library and data item properties

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -41,7 +41,7 @@ class Project(Persistence.PersistentObject):
 
     _processing_descriptions: PersistentDictType = dict()
 
-    def __init__(self, storage_system: FileStorageSystem.ProjectStorageSystemInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
+    def __init__(self, storage_system: Persistence.PersistentStorageInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
         super().__init__()
 
         self.define_type("project")
@@ -65,7 +65,7 @@ class Project(Persistence.PersistentObject):
         self.__has_been_read = False
 
         self._raw_properties: typing.Optional[PersistentDictType] = None
-        self.__reader_errors: typing.Sequence[FileStorageSystem.ReaderError] = list()
+        self.__reader_errors: typing.Sequence[Persistence.ReaderError] = list()
 
         self.__storage_system = storage_system
 
@@ -209,7 +209,7 @@ class Project(Persistence.PersistentObject):
         return ListModel.PredicateFilter(functools.partial(is_display_item_active, weakref.ref(self)))
 
     @property
-    def project_storage_system(self) -> FileStorageSystem.ProjectStorageSystemInterface:
+    def project_storage_system(self) -> Persistence.PersistentStorageInterface:
         return self.__storage_system
 
     def __data_item_inserted(self, name: str, before_index: int, data_item: DataItem.DataItem) -> None:

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -917,14 +917,14 @@ class TestStorageClass(unittest.TestCase):
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 data_item = document_model.data_items[0]
-                write_count = data_item.persistent_storage._data_properties_map[data_item.uuid].storage_handler._write_count
+                write_count = data_item._get_persistence_write_count()
                 self.assertTrue(numpy.array_equal(ones.data, data_item.data))
                 data_item.set_data_and_metadata_partial(zeros.data_metadata,
                                                   zeros, (slice(0,8), slice(0, 8)),
                                                   (slice(0,8), slice(0, 8)))
                 self.assertTrue(numpy.array_equal(zeros.data, data_item.data))
                 # ensure no explicit writes took place. the data copy will be memory mapped.
-                self.assertEqual(write_count, data_item.persistent_storage._data_properties_map[data_item.uuid].storage_handler._write_count)
+                self.assertEqual(write_count, data_item._get_persistence_write_count())
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 data_item = document_model.data_items[0]

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -79,7 +79,7 @@ class TempProfileContext:
             project_uuid = uuid.uuid4()
             project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": [project_data_name or "Data"]})
             project_path.write_text(project_data_json, "utf-8")
-            storage_system = FileStorageSystem.FilePersistentStorageSystem(profile_path)
+            storage_system = FileStorageSystem.make_file_persistent_storage_system(profile_path)
             storage_system.load_properties()
             profile = Profile.Profile(storage_system=storage_system, cache_factory=Cache.DbCacheFactory(self.profiles_dir, "X"))
             profile.storage_system = storage_system
@@ -90,7 +90,7 @@ class TempProfileContext:
             return profile
         else:
             profile_path = self.profiles_dir / pathlib.Path(profile_name or "Profile").with_suffix(".nsprof")
-            storage_system = FileStorageSystem.FilePersistentStorageSystem(profile_path)
+            storage_system = FileStorageSystem.make_file_persistent_storage_system(profile_path)
             storage_system.load_properties()
             profile = Profile.Profile(storage_system=storage_system, cache_factory=Cache.DbCacheFactory(self.profiles_dir, "X"))
             profile.storage_system = storage_system

--- a/nion/swift/test/TestContext.py
+++ b/nion/swift/test/TestContext.py
@@ -218,12 +218,12 @@ class MemoryProjectReference(Profile.ProjectReference):
     def project_reference_parts(self) -> typing.Tuple[str]:
         return ("memory",)
 
-    def make_storage(self, profile_context: typing.Optional[MemoryProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystem]:
+    def make_storage(self, profile_context: typing.Optional[MemoryProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystemInterface]:
         if self.__make_storage_error:
             raise Exception("make_storage_error")
         return FileStorageSystem.make_memory_project_storage_system(profile_context, self.project_uuid, self.__d)
 
-    def _upgrade_project_storage_system(self, project_storage_system: FileStorageSystem.ProjectStorageSystem) -> Profile.ProjectReference:
+    def _upgrade_project_storage_system(self, project_storage_system: FileStorageSystem.ProjectStorageSystemInterface) -> Profile.ProjectReference:
         new_project_reference = MemoryProjectReference()
         new_project_reference.project_uuid = uuid.uuid4()
         return new_project_reference

--- a/nion/swift/test/TestContext.py
+++ b/nion/swift/test/TestContext.py
@@ -218,12 +218,12 @@ class MemoryProjectReference(Profile.ProjectReference):
     def project_reference_parts(self) -> typing.Tuple[str]:
         return ("memory",)
 
-    def make_storage(self, profile_context: typing.Optional[MemoryProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystemInterface]:
+    def make_storage(self, profile_context: typing.Optional[MemoryProfileContext]) -> typing.Optional[Persistence.PersistentStorageInterface]:
         if self.__make_storage_error:
             raise Exception("make_storage_error")
         return FileStorageSystem.make_memory_project_storage_system(profile_context, self.project_uuid, self.__d)
 
-    def _upgrade_project_storage_system(self, project_storage_system: FileStorageSystem.ProjectStorageSystemInterface) -> Profile.ProjectReference:
+    def _upgrade_project_storage_system(self, project_storage_system: Persistence.PersistentStorageInterface) -> Profile.ProjectReference:
         new_project_reference = MemoryProjectReference()
         new_project_reference.project_uuid = uuid.uuid4()
         return new_project_reference


### PR DESCRIPTION
- Refactor file system classes to use interfaces. Prep for more refactoring.
- Refactor to move persistent_dict inside persistent_storage class.
- Simplify persistent storage interface / persistent object interaction.
- Continue refactor to reduce footprint of FileStorageSystem classes.
