### PR TITLE
Add keyboard shortcut for 'Add ellipse graphic'.

### DIFF
--- a/nion/swift/resources/key_config.json
+++ b/nion/swift/resources/key_config.json
@@ -169,5 +169,8 @@
     },
     "window.set_tool_mode.rectangle": {
         "display_panel": "c"
-    }
+    },
+	"graphics.add_ellipse_graphic": {
+		"window": "Ctrl+Alt+E"
+	}
 }


### PR DESCRIPTION
Adding an ellipse is freuqently needed when looking at the ronchigram camera, so a built-in keyboard shortcut would be usefeful.