### PR TITLE
Refactor export svg to isolate actual file writing code.

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -53,6 +53,7 @@ from nion.swift.model import Processing
 from nion.swift.model import Profile
 from nion.swift.model import Project
 from nion.swift.model import Symbolic
+from nion.swift.model import UISettings
 from nion.swift.model import Utility
 from nion.swift.model import WorkspaceLayout
 from nion.ui import CanvasItem
@@ -870,12 +871,12 @@ class DocumentController(Window.Window):
             filter_line = writer_name + " files (" + writer_extensions + ")"
             filter_lines.append(filter_line)
             filter_line_to_writer_map[filter_line] = writer
-        filter = ";;".join(filter_lines)
-        filter += ";;All Files (*.*)"
+        filter_str = ";;".join(filter_lines)
+        filter_str += ";;All Files (*.*)"
         export_dir = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
         export_dir = os.path.join(export_dir, display_item.displayed_title)
         selected_filter = self.ui.get_persistent_string("export_filter")
-        path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter, selected_filter)
+        path, selected_filter, selected_directory = self.get_save_file_path(_("Export File"), export_dir, filter_str, selected_filter)
         selected_writer = filter_line_to_writer_map.get(selected_filter)
         if path and not os.path.splitext(path)[1]:
             if selected_writer:
@@ -892,6 +893,14 @@ class DocumentController(Window.Window):
             export_dialog.show()
         elif len(display_items) == 1:
             self.export_file(display_items[0])
+
+    def export_svg_file(self, ui_settings: UISettings.UISettings, display_item: DisplayItem.DisplayItem, display_shape: Geometry.IntSize, path: pathlib.Path) -> None:
+        path = path.with_suffix(".svg")
+        drawing_context, shape = DisplayPanel.preview(ui_settings, display_item, display_shape.width, display_shape.height)
+        view_box = Geometry.IntRect(Geometry.IntPoint(), shape)
+        svg = drawing_context.to_svg(shape, view_box)
+        with Utility.AtomicFileWriter(path) as fp:
+            fp.write(svg)
 
     def export_svg(self, display_item: DisplayItem.DisplayItem) -> None:
         ExportDialog.ExportSVGDialog(self, display_item)

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -253,18 +253,8 @@ class ExportSVGDialog:
                 path = path + os.path.extsep + "svg"
             if path:
                 ui.set_persistent_string("export_directory", selected_directory)
-
                 display_shape = Geometry.IntSize(height=height_px, width=width_px)
-
-                drawing_context, shape = DisplayPanel.preview(DisplayPanel.DisplayPanelUISettings(ui), display_item, display_shape.width, display_shape.height)
-
-                view_box = Geometry.IntRect(Geometry.IntPoint(), shape)
-
-                svg = drawing_context.to_svg(shape, view_box)
-
-                with Utility.AtomicFileWriter(pathlib.Path(path)) as fp:
-                    fp.write(svg)
-
+                document_controller.export_svg_file(DisplayPanel.DisplayPanelUISettings(ui), display_item, display_shape, pathlib.Path(path))
             return True
 
         def cancel_clicked() -> bool:


### PR DESCRIPTION
This is minor refactoring to isolate the actual code which exports the SVG file. Refactoring like this allows for tests to run SVG exports easily. This was part of my attempt to evaluate #874 which attempts to fix #591. However, I've decided to abandon #874 for now - and I'm planning to add more notes to #591.

References:
- #591 
- #874 
