### PR TITLE
ExportDialogDeclarative2

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -888,7 +888,7 @@ class DocumentController(Window.Window):
 
     def export_files(self, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
         if len(display_items) > 1:
-            export_dialog = ExportDialog.ExportDialog(self.ui, self, self, display_items)
+            ExportDialog.ExportDialog(self.ui, self, display_items)
         elif len(display_items) == 1:
             self.export_file(display_items[0])
 

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -888,9 +888,7 @@ class DocumentController(Window.Window):
 
     def export_files(self, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
         if len(display_items) > 1:
-            export_dialog = ExportDialog.ExportDialog(self.ui, self)
-            export_dialog.on_accept = functools.partial(export_dialog.do_export, display_items)
-            export_dialog.show()
+            export_dialog = ExportDialog.ExportDialog(self.ui, self, self, display_items)
         elif len(display_items) == 1:
             self.export_file(display_items[0])
 

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -72,10 +72,18 @@ class ExportDialog(Declarative.Handler):
         u = Declarative.DeclarativeUI()
         self._build_ui(u)
 
+        # perform export, but save the last used writer
+        def handle_export_clicked() -> bool:
+            selected_writer = self.viewmodel.writer.value
+            writer_id = selected_writer.io_handler_id if selected_writer else "png-io-handler"
+            self.export_clicked(display_items, self.viewmodel)
+            self.ui.set_persistent_string("export_io_handler_id", writer_id)
+            return True
+
         # create the dialog and show it.
         dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(self.ui_view, title=_("Export")), self))
         dialog.add_button(_("Cancel"), self.cancel)
-        dialog.add_button(_("Export"), functools.partial(self.export_clicked, display_items, self.viewmodel))
+        dialog.add_button(_("Export"), handle_export_clicked)
         dialog.show()
 
     def choose_directory(self, widget: Declarative.UIWidget) -> None:
@@ -178,7 +186,7 @@ class ExportDialog(Declarative.Handler):
         return test_filepath
 
     @staticmethod
-    def export_clicked(display_items: typing.Sequence[DisplayItem.DisplayItem], viewmodel: ExportDialogViewModel) -> bool:
+    def export_clicked(display_items: typing.Sequence[DisplayItem.DisplayItem], viewmodel: ExportDialogViewModel) -> None:
         directory_path = pathlib.Path(viewmodel.directory.value or str())
         writer = viewmodel.writer
         if directory_path.is_dir() and writer and writer.value:
@@ -207,7 +215,6 @@ class ExportDialog(Declarative.Handler):
                         logging.debug("Could not export image %s / %s", str(data_item), str(e))
                         traceback.print_exc()
                         traceback.print_stack()
-        return True
 
     def cancel(self) -> bool:
         return True

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -16,6 +16,7 @@ import unicodedata
 # None
 
 # local libraries
+from nion.swift.model import DisplayItem
 from nion.swift.model import ImportExportManager
 from nion.swift.model import Utility
 from nion.swift import DocumentController
@@ -34,167 +35,186 @@ if typing.TYPE_CHECKING:
 _ = gettext.gettext
 
 
-class ExportDialog(Dialog.OkCancelDialog):
-    def __init__(self, ui: UserInterface.UserInterface, parent_window: Window.Window):
-        super().__init__(ui, ok_title=_("Export"), parent_window=parent_window)
+class ExportDialogViewModel:
 
+    def __init__(self, title: bool, date: bool, dimensions: bool, sequence: bool, writer: typing.Optional[ImportExportManager.ImportExportHandler], prefix: str = "", directory: str = ""):
+        self.include_title = Model.PropertyModel(title)
+        self.include_date = Model.PropertyModel(date)
+        self.include_dimensions = Model.PropertyModel(dimensions)
+        self.include_sequence = Model.PropertyModel(sequence)
+        self.include_prefix = Model.PropertyModel(prefix is not None)
+        self.prefix = Model.PropertyModel(prefix)
+        self.directory = Model.PropertyModel(directory)
+        if writer:
+            self.writer = Model.PropertyModel(writer)
+
+
+class ExportDialog(Declarative.Handler):
+    writer: typing.Optional[ImportExportManager.ImportExportHandler] = None
+    def __init__(self, ui: UserInterface.UserInterface, parent_window: Window.Window, document_controller: DocumentController.DocumentController, display_items: typing.Sequence[DisplayItem.DisplayItem]):
+        super().__init__()
+
+        self.ui = ui
         io_handler_id = self.ui.get_persistent_string("export_io_handler_id", "png-io-handler")
-
+        self.__document_controller = document_controller
         self.directory = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
-        self.writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id)
-
-        directory_column = self.ui.create_column_widget()
-
-        title_row = self.ui.create_row_widget()
-        title_row.add_spacing(13)
-        title_row.add(self.ui.create_label_widget(_("Export Folder: "), properties={"font": "bold"}))
-        title_row.add_stretch()
-        title_row.add_spacing(13)
-
-        show_directory_row = self.ui.create_row_widget()
-        show_directory_row.add_spacing(26)
-        directory_label = self.ui.create_label_widget(self.directory)
-        show_directory_row.add(directory_label)
-        show_directory_row.add_stretch()
-        show_directory_row.add_spacing(13)
-
-        choose_directory_row = self.ui.create_row_widget()
-        choose_directory_row.add_spacing(26)
-        choose_directory_button = self.ui.create_push_button_widget(_("Choose..."))
-        choose_directory_row.add(choose_directory_button)
-        choose_directory_row.add_stretch()
-        choose_directory_row.add_spacing(13)
-
-        directory_column.add(title_row)
-        directory_column.add(show_directory_row)
-        directory_column.add(choose_directory_row)
-
-        file_types_column = self.ui.create_column_widget()
-
-        title_row = self.ui.create_row_widget()
-        title_row.add_spacing(13)
-        title_row.add(self.ui.create_label_widget(_("File Type: "), properties={"font": "bold"}))
-        title_row.add_stretch()
-        title_row.add_spacing(13)
-
-        file_types_row = self.ui.create_row_widget()
-        file_types_row.add_spacing(26)
-        writers = ImportExportManager.ImportExportManager().get_writers()
-        file_types_combo_box = self.ui.create_combo_box_widget(items=writers, item_getter=operator.attrgetter("name"))
-        file_types_combo_box.current_item = self.writer
-        file_types_row.add(file_types_combo_box)
-        file_types_row.add_stretch()
-        file_types_row.add_spacing(13)
-
-        file_types_column.add(title_row)
-        file_types_column.add(file_types_row)
-
-        option_descriptions = [
-            (_("Include Title"), "title", True),
-            (_("Include Date"), "date", True),
-            (_("Include Dimensions"), "dimensions", True),
-            (_("Include Sequence Number"), "sequence", True),
-            (_("Include Prefix:"), "prefix", False)
-        ]
-
-        self.options = dict()
-
-        options_column = self.ui.create_column_widget()
-
-        title_row = self.ui.create_row_widget()
-        title_row.add_spacing(13)
-        title_row.add(self.ui.create_label_widget(_("Filename: "), properties={"font": "bold"}))
-        title_row.add_stretch()
-        title_row.add_spacing(13)
-
-        individual_options_column = self.ui.create_column_widget()
-        for option_decription in option_descriptions:
-            label, option_id, default_value = option_decription
-            self.options[option_id] = self.ui.get_persistent_string("export_option_" + option_id,
-                                                                    str(default_value)).lower() == "true"
-            check_box_widget = self.ui.create_check_box_widget(label)
-            check_box_widget.checked = self.options[option_id]
-
-            def checked_changed(option_id_: str, checked: bool) -> None:
-                self.options[option_id_] = checked
-                self.ui.set_persistent_string("export_option_" + option_id_, str(checked))
-
-            check_box_widget.on_checked_changed = functools.partial(checked_changed, option_id)
-            individual_options_column.add_spacing(4)
-            individual_options_column.add(check_box_widget)
-            if option_id == "prefix":
-                self.prefix_edit_widget = self.ui.create_text_edit_widget(properties={"max-height": 35})
-                individual_options_column.add(self.prefix_edit_widget)
-
-        options_row = self.ui.create_row_widget()
-        options_row.add_spacing(26)
-        options_row.add(individual_options_column)
-        options_row.add_stretch()
-        options_row.add_spacing(13)
-
-        options_column.add(title_row)
-        options_column.add(options_row)
-
-        column = self.ui.create_column_widget()
-        column.add_spacing(12)
-        column.add(directory_column)
-        column.add_spacing(4)
-        column.add(options_column)
-        column.add_spacing(4)
-        column.add(file_types_column)
-        column.add_spacing(16)
-        column.add_stretch()
-
-        def choose() -> None:
-            existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Export Directory"),
-                                                                                  self.directory)
-            if existing_directory:
-                self.directory = existing_directory
-                directory_label.text = self.directory
-                self.ui.set_persistent_string("export_directory", self.directory)
-
-        choose_directory_button.on_clicked = choose
-
-        def writer_changed(writer: ImportExportManager.ImportExportHandler) -> None:
-            self.ui.set_persistent_string("export_io_handler_id", writer.io_handler_id)
+        writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id)
+        if writer:
             self.writer = writer
 
-        file_types_combo_box.on_current_item_changed = writer_changed
+        self.viewmodel = ExportDialogViewModel(True, True, True, True, self.writer, "", self.directory)
+        u = Declarative.DeclarativeUI()
+        self._build_ui(u)
 
-        self.content.add(column)
+        dialog = typing.cast(Dialog.ActionDialog,
+                             Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(self.ui_view, title=_("Export")), self))
+        dialog.add_button(_("Cancel"), self.cancel)
+        dialog.add_button(_("Export"), functools.partial(self.export_clicked, display_items, self.viewmodel))
+        dialog.show()
 
-    def do_export(self, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
-        directory = self.directory
-        writer = self.writer
-        if directory and writer:
+    def choose_directory(self, widget: Declarative.UIWidget) -> None:
+        existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Export Directory"),
+                                                                              self.directory)
+        if existing_directory:
+            self.directory = existing_directory
+            self.viewmodel.directory.value = self.directory
+            self.ui.set_persistent_string("export_directory", self.directory)
+
+    def on_writer_changed(self, widget: Declarative.UIWidget, current_index: int) -> None:
+        writer = self.writers[current_index]
+        self.viewmodel.writer.value = writer
+
+    def _build_ui(self, u: Declarative.DeclarativeUI) -> None:
+        self.file_type_index = 0
+        self.writers = ImportExportManager.ImportExportManager().get_writers()
+        writers_names = [getattr(writer, "name") for writer in self.writers]
+        self.file_types = writers_names
+
+        # Export Folder
+        directory_label = u.create_row(u.create_label(text="Location:"))
+        directory_text = u.create_row(u.create_label(text=f"@binding(viewmodel.directory.value)"))
+        self.directory_text_label = directory_text
+        directory_button = u.create_row(u.create_push_button(text=_("Select Path..."), on_clicked="choose_directory"))
+
+        # Filename
+        filename_label = u.create_row(u.create_label(text="Filename:"))
+
+        # Title
+        title_checkbox = u.create_row(
+            u.create_check_box(text="Include Title", checked=f"@binding(viewmodel.include_title.value)"))
+
+        # Date
+        date_checkbox = u.create_row(
+            u.create_check_box(text="Include Date", checked=f"@binding(viewmodel.include_date.value)"))
+
+        # Dimensions
+        dimension_checkbox = u.create_row(
+            u.create_check_box(text="Include Dimensions", checked=f"@binding(viewmodel.include_dimensions.value)"))
+
+        # Sequence Number
+        sequence_checkbox = u.create_row(
+            u.create_check_box(text="Include Sequence Number", checked=f"@binding(viewmodel.include_sequence.value)"))
+
+        # Prefix
+        prefix_checkbox = u.create_row(
+            u.create_check_box(text="Include Prefix", checked=f"@binding(viewmodel.include_prefix.value)"))
+        prefix_textbox = u.create_row(u.create_text_edit(text=f"@binding(viewmodel.prefix.value)"))
+
+        # File Type
+        file_type_combobox = u.create_combo_box(
+            items=self.file_types,
+            current_index=f"@binding(file_type_index.value)",
+            on_current_index_changed="on_writer_changed")
+
+        # Build final ui column
+        column = u.create_column(directory_label,
+                                 directory_text,
+                                 directory_button,
+                                 filename_label,
+                                 title_checkbox,
+                                 date_checkbox,
+                                 dimension_checkbox,
+                                 sequence_checkbox,
+                                 prefix_checkbox,
+                                 prefix_textbox,
+                                 file_type_combobox,
+                                 spacing=12, margin=12)
+        self.ui_view = column
+
+    @staticmethod
+    def build_filename(components: typing.List[str], extension: str, path: str = "") -> str:
+        # if path doesn't end in a directory character, add one
+        if path:
+            if not (path.endswith('/') or path.endswith('\\')):
+                path = path + '/'
+
+        # if extension doesn't start with a '.', add one so we always know it is there
+        if not extension.startswith('.'):
+            extension = '.' + extension
+
+        # stick components together for the first part of the filename, underscore delimited excluding blank component
+        filename = "_".join(s for s in components if s)
+
+        # check to see if filename is available, if so return that
+        test_filename = filename + extension
+        if path:
+            test_filename = path + test_filename
+
+        if not os.path.exists(test_filename):
+            return test_filename
+
+        # file must already exist
+        suffix = "($)"
+        found_available = False
+        next_index = 1
+        max_index = 999
+        while not found_available and next_index <= max_index:
+            test_suffix = "({0})".format(next_index)
+            test_filename = filename + test_suffix + extension
+            if path:
+                test_filename = path + test_filename
+            if not os.path.exists(test_filename):
+                return test_filename
+            next_index = next_index + 1
+
+        # Well we have no option here but to just go with the overwrite, either we ran out of index options or had none to begin with
+        return test_filename
+
+    @staticmethod
+    def export_clicked(display_items: typing.Sequence[DisplayItem.DisplayItem], viewmodel: ExportDialogViewModel) -> bool:
+        directory = viewmodel.directory.value
+        writer = viewmodel.writer
+        if directory and writer and writer.value:
             for index, display_item in enumerate(display_items):
                 data_item = display_item.data_item
                 if data_item:
                     try:
                         components = list()
-                        if self.options.get("prefix", False):
-                            components.append(str(self.prefix_edit_widget.text))
-                        if self.options.get("title", False):
+                        if viewmodel.include_prefix.value: # self.options.get("prefix", False):
+                            components.append(str(viewmodel.prefix.value)) # prefix_edit_widget.text))
+                        if viewmodel.include_title.value:
                             title = unicodedata.normalize('NFKC', data_item.title)
                             title = re.sub(r'[^\w\s-]', '', title, flags=re.U).strip()
                             title = re.sub(r'[-\s]+', '-', title, flags=re.U)
                             components.append(title)
-                        if self.options.get("date", False):
+                        if viewmodel.include_date.value:
                             components.append(data_item.created_local.isoformat().replace(':', ''))
-                        if self.options.get("dimensions", False):
+                        if viewmodel.include_dimensions.value:
                             components.append(
                                 "x".join([str(shape_n) for shape_n in data_item.dimensional_shape]))
-                        if self.options.get("sequence", False):
+                        if viewmodel.include_sequence.value:
                             components.append(str(index))
-                        filename = "_".join(components)
-                        extension = writer.extensions[0]
-                        path = os.path.join(directory, "{0}.{1}".format(filename, extension))
-                        ImportExportManager.ImportExportManager().write_display_item_with_writer(writer, display_item, pathlib.Path(path))
+                        filename = ExportDialog.build_filename(components, writer.value.extensions[0], path=directory)
+                        ImportExportManager.ImportExportManager().write_display_item_with_writer(writer.value, display_item, pathlib.Path(filename))
                     except Exception as e:
                         logging.debug("Could not export image %s / %s", str(data_item), str(e))
                         traceback.print_exc()
                         traceback.print_stack()
+        return True
 
+
+    def cancel(self) -> bool:
+        return True
 
 class ExportSVGHandler:
     def __init__(self, display_item: DisplayItem.DisplayItem, display_size: Geometry.IntSize) -> None:

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -51,7 +51,7 @@ class ExportDialogViewModel:
 
 class ExportDialog(Declarative.Handler):
     writer: typing.Optional[ImportExportManager.ImportExportHandler] = None
-    def __init__(self, ui: UserInterface.UserInterface, parent_window: Window.Window, document_controller: DocumentController.DocumentController, display_items: typing.Sequence[DisplayItem.DisplayItem]):
+    def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController, display_items: typing.Sequence[DisplayItem.DisplayItem]):
         super().__init__()
 
         self.ui = ui
@@ -66,8 +66,7 @@ class ExportDialog(Declarative.Handler):
         u = Declarative.DeclarativeUI()
         self._build_ui(u)
 
-        dialog = typing.cast(Dialog.ActionDialog,
-                             Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(self.ui_view, title=_("Export")), self))
+        dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(self.ui_view, title=_("Export")), self))
         dialog.add_button(_("Cancel"), self.cancel)
         dialog.add_button(_("Export"), functools.partial(self.export_clicked, display_items, self.viewmodel))
         dialog.show()

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -56,17 +56,17 @@ class ExportDialog(Declarative.Handler):
         self.ui = ui
         self.__document_controller = document_controller
 
-        # set up values needed for the viewmodel
+        # configure the writers. ensure that the writer is set to the last used writer or the first writer if no last used.
+        self.__writers = ImportExportManager.ImportExportManager().get_writers()
         io_handler_id = self.ui.get_persistent_string("export_io_handler_id", "png-io-handler")
-        writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id)
+        writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id) or self.__writers[0]
+        self.writer_index = self.__writers.index(writer)
+
+        # set up directory needed for the viewmodel
         directory = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
 
         # the viewmodel is the data model for the dialog. no other variables are needed.
         self.viewmodel = ExportDialogViewModel(True, True, True, True, writer, "", directory)
-
-        # use this in the UI to display the current directory
-        self.writer_index = 0
-        self.__writers = ImportExportManager.ImportExportManager().get_writers()
 
         # build the UI
         u = Declarative.DeclarativeUI()

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -45,49 +45,52 @@ class ExportDialogViewModel:
         self.include_prefix = Model.PropertyModel(prefix is not None)
         self.prefix = Model.PropertyModel(prefix)
         self.directory = Model.PropertyModel(directory)
-        if writer:
-            self.writer = Model.PropertyModel(writer)
+        self.writer = Model.PropertyModel(writer)
 
 
 class ExportDialog(Declarative.Handler):
-    writer: typing.Optional[ImportExportManager.ImportExportHandler] = None
+
     def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController, display_items: typing.Sequence[DisplayItem.DisplayItem]):
         super().__init__()
 
         self.ui = ui
-        io_handler_id = self.ui.get_persistent_string("export_io_handler_id", "png-io-handler")
         self.__document_controller = document_controller
-        self.directory = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
-        writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id)
-        if writer:
-            self.writer = writer
 
-        self.viewmodel = ExportDialogViewModel(True, True, True, True, self.writer, "", self.directory)
+        # set up values needed for the viewmodel
+        io_handler_id = self.ui.get_persistent_string("export_io_handler_id", "png-io-handler")
+        writer = ImportExportManager.ImportExportManager().get_writer_by_id(io_handler_id)
+        directory = self.ui.get_persistent_string("export_directory", self.ui.get_document_location())
+
+        # the viewmodel is the data model for the dialog. no other variables are needed.
+        self.viewmodel = ExportDialogViewModel(True, True, True, True, writer, "", directory)
+
+        # use this in the UI to display the current directory
+        self.writer_index = 0
+        self.__writers = ImportExportManager.ImportExportManager().get_writers()
+
+        # build the UI
         u = Declarative.DeclarativeUI()
         self._build_ui(u)
 
+        # create the dialog and show it.
         dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(self.ui_view, title=_("Export")), self))
         dialog.add_button(_("Cancel"), self.cancel)
         dialog.add_button(_("Export"), functools.partial(self.export_clicked, display_items, self.viewmodel))
         dialog.show()
 
     def choose_directory(self, widget: Declarative.UIWidget) -> None:
-        existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Export Directory"),
-                                                                              self.directory)
+        directory = self.viewmodel.directory.value or str()
+        existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Export Directory"), directory)
         if existing_directory:
-            self.directory = existing_directory
-            self.viewmodel.directory.value = self.directory
-            self.ui.set_persistent_string("export_directory", self.directory)
+            self.viewmodel.directory.value = directory
+            self.ui.set_persistent_string("export_directory", directory)
 
     def on_writer_changed(self, widget: Declarative.UIWidget, current_index: int) -> None:
-        writer = self.writers[current_index]
+        writer = self.__writers[current_index]
         self.viewmodel.writer.value = writer
 
     def _build_ui(self, u: Declarative.DeclarativeUI) -> None:
-        self.file_type_index = 0
-        self.writers = ImportExportManager.ImportExportManager().get_writers()
-        writers_names = [getattr(writer, "name") for writer in self.writers]
-        self.file_types = writers_names
+        writers_names = [getattr(writer, "name") for writer in self.__writers]
 
         # Export Folder
         directory_label = u.create_row(u.create_label(text="Location:"))
@@ -121,8 +124,8 @@ class ExportDialog(Declarative.Handler):
 
         # File Type
         file_type_combobox = u.create_combo_box(
-            items=self.file_types,
-            current_index=f"@binding(file_type_index.value)",
+            items=writers_names,
+            current_index=f"@binding(writer_index)",
             on_current_index_changed="on_writer_changed")
 
         # Build final ui column
@@ -211,9 +214,9 @@ class ExportDialog(Declarative.Handler):
                         traceback.print_stack()
         return True
 
-
     def cancel(self) -> bool:
         return True
+
 
 class ExportSVGHandler:
     def __init__(self, display_item: DisplayItem.DisplayItem, display_size: Geometry.IntSize) -> None:

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -162,6 +162,7 @@ class ExportDialog(Declarative.Handler):
 
         # stick components together for the first part of the filename, underscore delimited excluding blank component
         filename = "_".join(s for s in components if s)
+        filename.replace(".", "_")
 
         # check to see if filename is available, if so return that
         test_filepath = directory_path / pathlib.Path(filename).with_suffix(extension)
@@ -203,7 +204,7 @@ class ExportDialog(Declarative.Handler):
                             title = re.sub(r'[-\s]+', '-', title, flags=re.U)
                             components.append(title)
                         if viewmodel.include_date.value:
-                            components.append(data_item.created_local.isoformat().replace(':', ''))
+                            components.append(data_item.created_local.isoformat().replace(':', '').replace('.', '_'))
                         if viewmodel.include_dimensions.value:
                             components.append(
                                 "x".join([str(shape_n) for shape_n in data_item.dimensional_shape]))

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -93,53 +93,54 @@ class ExportDialog(Declarative.Handler):
         writers_names = [getattr(writer, "name") for writer in self.__writers]
 
         # Export Folder
-        directory_label = u.create_row(u.create_label(text="Location:"))
-        directory_text = u.create_row(u.create_label(text=f"@binding(viewmodel.directory.value)"))
+        directory_label = u.create_row(u.create_label(text="Location:"), u.create_stretch())
+        directory_text = u.create_row(u.create_label(text=f"@binding(viewmodel.directory.value)", width=480), u.create_stretch())
         self.directory_text_label = directory_text
-        directory_button = u.create_row(u.create_push_button(text=_("Select Path..."), on_clicked="choose_directory"))
+        directory_button = u.create_row(u.create_push_button(text=_("Select Path..."), on_clicked="choose_directory"), u.create_stretch())
 
         # Filename
-        filename_label = u.create_row(u.create_label(text="Filename:"))
+        filename_label = u.create_row(u.create_label(text="Filename:"), u.create_stretch())
 
         # Title
         title_checkbox = u.create_row(
-            u.create_check_box(text="Include Title", checked=f"@binding(viewmodel.include_title.value)"))
+            u.create_check_box(text="Include Title", checked=f"@binding(viewmodel.include_title.value)"), u.create_stretch())
 
         # Date
         date_checkbox = u.create_row(
-            u.create_check_box(text="Include Date", checked=f"@binding(viewmodel.include_date.value)"))
+            u.create_check_box(text="Include Date", checked=f"@binding(viewmodel.include_date.value)"), u.create_stretch())
 
         # Dimensions
         dimension_checkbox = u.create_row(
-            u.create_check_box(text="Include Dimensions", checked=f"@binding(viewmodel.include_dimensions.value)"))
+            u.create_check_box(text="Include Dimensions", checked=f"@binding(viewmodel.include_dimensions.value)"), u.create_stretch())
 
         # Sequence Number
         sequence_checkbox = u.create_row(
-            u.create_check_box(text="Include Sequence Number", checked=f"@binding(viewmodel.include_sequence.value)"))
+            u.create_check_box(text="Include Sequence Number", checked=f"@binding(viewmodel.include_sequence.value)"), u.create_stretch())
 
         # Prefix
         prefix_checkbox = u.create_row(
-            u.create_check_box(text="Include Prefix", checked=f"@binding(viewmodel.include_prefix.value)"))
-        prefix_textbox = u.create_row(u.create_text_edit(text=f"@binding(viewmodel.prefix.value)"))
+            u.create_check_box(text="Include Prefix", checked=f"@binding(viewmodel.include_prefix.value)"), u.create_stretch())
+        prefix_textbox = u.create_row(u.create_line_edit(text=f"@binding(viewmodel.prefix.value)", placeholder_text=_("None"), width=280), u.create_stretch())
 
         # File Type
         file_type_combobox = u.create_combo_box(
             items=writers_names,
             current_index=f"@binding(writer_index)",
             on_current_index_changed="on_writer_changed")
+        file_type_row = u.create_row(u.create_label(text=_("File Format")), file_type_combobox, u.create_stretch())
 
         # Build final ui column
         column = u.create_column(directory_label,
                                  directory_text,
                                  directory_button,
                                  filename_label,
+                                 file_type_row,
                                  title_checkbox,
                                  date_checkbox,
                                  dimension_checkbox,
                                  sequence_checkbox,
                                  prefix_checkbox,
                                  prefix_textbox,
-                                 file_type_combobox,
                                  spacing=12, margin=12)
         self.ui_view = column
 


### PR DESCRIPTION
- **Refactored Export Dialog in Declarative Mode**
- **Do not pass redundant/unused 'parent_window'. Do not assign export dialog to unused variable.**
- **Clean up instance variables in export dialog and its model.**
- **Ensure that correct writer index is initialized.**
- **Change export filename building to use pathlib.**
- **Improve dialog box with default width and stretches.**
- **Ensure selected writer is saved in preferences when export is pressed.**
- **Fix issue where filename has a '.' (isodate on mac/linux).**
