### PR TITLE
Export dialog

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -887,10 +887,8 @@ class DocumentController(Window.Window):
             ImportExportManager.ImportExportManager().write_display_item_with_writer(selected_writer, display_item, pathlib.Path(path))
 
     def export_files(self, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
-        if len(display_items) > 1:
+        if len(display_items) > 0:
             ExportDialog.ExportDialog(self.ui, self, display_items)
-        elif len(display_items) == 1:
-            self.export_file(display_items[0])
 
     def export_svg_file(self, ui_settings: UISettings.UISettings, display_item: DisplayItem.DisplayItem, display_shape: Geometry.IntSize, path: pathlib.Path) -> None:
         # take a snapshot so to modify the display properties for the proper image zoom, position, and canvas mode.
@@ -3023,10 +3021,8 @@ class ExportAction(Window.Action):
         window = typing.cast(DocumentController, context.window)
         selected_display_item = context.display_item
         selected_display_items = context.display_items
-        if len(selected_display_items) > 1:
+        if len(selected_display_items) > 0:
             window.export_files(selected_display_items)
-        elif selected_display_item:
-            window.export_file(selected_display_item)
         return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def is_enabled(self, context: Window.ActionContext) -> bool:

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -101,13 +101,13 @@ class ExportDialog(Declarative.Handler):
         writers_names = [getattr(writer, "name") for writer in self.__writers]
 
         # Export Folder
-        directory_label = u.create_row(u.create_label(text="Location:"), u.create_stretch())
-        directory_text = u.create_row(u.create_label(text=f"@binding(viewmodel.directory.value)", width=480), u.create_stretch())
+        directory_label = u.create_row(u.create_label(text="Location:", font='bold'), u.create_stretch())
+        directory_text = u.create_row(u.create_label(text=f"@binding(viewmodel.directory.value)", width=280, height=40, word_wrap=True), u.create_stretch())
         self.directory_text_label = directory_text
         directory_button = u.create_row(u.create_push_button(text=_("Select Path..."), on_clicked="choose_directory"), u.create_stretch())
 
         # Filename
-        filename_label = u.create_row(u.create_label(text="Filename:"), u.create_stretch())
+        filename_label = u.create_row(u.create_label(text="Filename:", font='bold'), u.create_stretch())
 
         # Title
         title_checkbox = u.create_row(
@@ -126,29 +126,30 @@ class ExportDialog(Declarative.Handler):
             u.create_check_box(text="Include Sequence Number", checked=f"@binding(viewmodel.include_sequence.value)"), u.create_stretch())
 
         # Prefix
-        prefix_checkbox = u.create_row(
-            u.create_check_box(text="Include Prefix", checked=f"@binding(viewmodel.include_prefix.value)"), u.create_stretch())
-        prefix_textbox = u.create_row(u.create_line_edit(text=f"@binding(viewmodel.prefix.value)", placeholder_text=_("None"), width=280), u.create_stretch())
+        prefix_label = u.create_label(text=_("Prefix:"))
+        prefix_textbox = u.create_line_edit(text=f"@binding(viewmodel.prefix.value)", placeholder_text=_("None"), width=230)
+        prefix_row = u.create_row(prefix_label, prefix_textbox, u.create_stretch(), spacing=10)
 
         # File Type
         file_type_combobox = u.create_combo_box(
             items=writers_names,
             current_index=f"@binding(writer_index)",
             on_current_index_changed="on_writer_changed")
-        file_type_row = u.create_row(u.create_label(text=_("File Format")), file_type_combobox, u.create_stretch())
+        file_type_label = u.create_label(text=_("File Format:"), font='bold')
+        file_type_row = u.create_row(file_type_combobox, u.create_stretch())
 
         # Build final ui column
         column = u.create_column(directory_label,
                                  directory_text,
                                  directory_button,
                                  filename_label,
-                                 file_type_row,
+                                 prefix_row,
                                  title_checkbox,
                                  date_checkbox,
                                  dimension_checkbox,
                                  sequence_checkbox,
-                                 prefix_checkbox,
-                                 prefix_textbox,
+                                 file_type_label,
+                                 file_type_row,
                                  spacing=12, margin=12)
         self.ui_view = column
 
@@ -196,7 +197,7 @@ class ExportDialog(Declarative.Handler):
                 if data_item:
                     try:
                         components = list()
-                        if viewmodel.include_prefix.value:
+                        if viewmodel.prefix.value is not None and viewmodel.prefix.value != '':
                             components.append(str(viewmodel.prefix.value))
                         if viewmodel.include_title.value:
                             title = unicodedata.normalize('NFKC', data_item.title)


### PR DESCRIPTION
This is to solve issue: https://github.com/nion-software/nionswift/issues/932

I have given a single export the same workflow as multiple exports and tidied up the UI for the multiple exports as well:

- Emboldened sections titles for clearer separation
- Allowed the folder path to wrap to a second line to stop the dialog looking unbalanced
- Reordered the different options so the order matched the order in the output filename
- Removed the redundant prefix checkbox