### PR TITLE
2024 06 18 computation processor

### DIFF
--- a/nion/swift/ComputationPanel.py
+++ b/nion/swift/ComputationPanel.py
@@ -55,7 +55,7 @@ _ = gettext.gettext
 class AddVariableCommand(Undo.UndoableCommand):
 
     def __init__(self, document_model: DocumentModel.DocumentModel, computation: Symbolic.Computation,
-                 name: typing.Optional[str] = None, value_type: typing.Optional[str] = None, value: typing.Any = None,
+                 name: typing.Optional[str] = None, value_type: typing.Optional[Symbolic.ComputationVariableType] = None, value: typing.Any = None,
                  value_default: typing.Any = None, value_min: typing.Any = None, value_max: typing.Any = None,
                  control_type: typing.Optional[str] = None,
                  specified_item: typing.Optional[Persistence.PersistentObject] = None,
@@ -320,7 +320,7 @@ class ComputationModel:
     def set_display_item(self, display_item: typing.Optional[DisplayItem.DisplayItem]) -> None:
         self.__set_display_item(display_item)
 
-    def add_variable(self, name: typing.Optional[str] = None, value_type: typing.Optional[str] = None,
+    def add_variable(self, name: typing.Optional[str] = None, value_type: typing.Optional[Symbolic.ComputationVariableType] = None,
                      value: typing.Any = None, value_default: typing.Any = None, value_min: typing.Any = None,
                      value_max: typing.Any = None, control_type: typing.Optional[str] = None,
                      specified_item: typing.Optional[Persistence.PersistentObject] = None,
@@ -879,7 +879,7 @@ class EditComputationDialog(Dialog.ActionDialog):
         add_object_button.on_clicked = add_object_pressed
 
         def add_variable_pressed() -> None:
-            self.__computation_model.add_variable("".join([random.choice(string.ascii_lowercase) for _ in range(4)]), value_type="integral", value=0)
+            self.__computation_model.add_variable("".join([random.choice(string.ascii_lowercase) for _ in range(4)]), value_type=Symbolic.ComputationVariableType.INTEGRAL, value=0)
 
         add_variable_button.on_clicked = add_variable_pressed
 

--- a/nion/swift/Facade.py
+++ b/nion/swift/Facade.py
@@ -2722,15 +2722,15 @@ class Library(metaclass=SharedInstance):
         computation = self.__document_model.create_computation()
         for name, item in inputs.items():
             if isinstance(item, str):
-                computation.create_variable(name, value_type="string", value=item)
+                computation.create_variable(name, value_type=Symbolic.ComputationVariableType.STRING, value=item)
             elif isinstance(item, bool):
-                computation.create_variable(name, value_type="boolean", value=item)
+                computation.create_variable(name, value_type=Symbolic.ComputationVariableType.BOOLEAN, value=item)
             elif isinstance(item, numbers.Integral):
-                computation.create_variable(name, value_type="integral", value=item)
+                computation.create_variable(name, value_type=Symbolic.ComputationVariableType.INTEGRAL, value=item)
             elif isinstance(item, numbers.Real):
-                computation.create_variable(name, value_type="real", value=item)
+                computation.create_variable(name, value_type=Symbolic.ComputationVariableType.REAL, value=item)
             elif isinstance(item, numbers.Complex):
-                computation.create_variable(name, value_type="complex", value=item)
+                computation.create_variable(name, value_type=Symbolic.ComputationVariableType.COMPLEX, value=item)
             elif isinstance(item, dict) and item.get("object"):
                 object = item.get("object")
                 object_type = item.get("type")

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -3904,7 +3904,11 @@ class DataStructurePropertyVariableHandler(Declarative.Handler):
         self.ui_view = u.create_column(u.create_row(label, *([link] if computation_inspector_context.do_references else []), u.create_stretch()), line_edit, u.create_stretch(), spacing=8)
         self.__variable_listener = variable.property_changed_event.listen(ReferenceCounting.weak_partial(DataStructurePropertyVariableHandler.__property_changed, self))
         if variable.bound_item:
-            self.__bound_item_listener = variable.changed_event.listen(ReferenceCounting.weak_partial(DataStructurePropertyVariableHandler.__changed, self))
+            def handle_variable_event(handler: DataStructurePropertyVariableHandler, event_type: Symbolic.BoundDataEventType) -> None:
+                handler.__changed()
+
+            self.__bound_item_listener = variable.data_event.listen(
+                ReferenceCounting.weak_partial(handle_variable_event, self))
 
     @property
     def variable_value(self) -> str:

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -2179,7 +2179,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
 
         parameters = parameters or dict()
 
-        processors = Project.Project._processors
+        processors = Symbolic._processors
         processor = processors[processing_id]
 
         # first process the sources in the description. match them to the inputs (which are data item/crop graphic tuples)
@@ -2387,16 +2387,16 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
 
     @classmethod
     def register_processors(cls, processors: dict[str, Symbolic.ComputationProcessor]) -> None:
-        assert len(set(Project.Project._processors.keys()).intersection(set(processors.keys()))) == 0
+        assert len(set(Symbolic._processors.keys()).intersection(set(processors.keys()))) == 0
         for key, processor in processors.items():
-            assert key not in Project.Project._processors
-            Project.Project._processors[key] = processor
+            assert key not in Symbolic._processors
+            Symbolic._processors[key] = processor
 
     @classmethod
     def unregister_processors(cls, processing_ids: typing.Sequence[str]) -> None:
-        assert len(set(Project.Project._processors.keys()).intersection(set(processing_ids))) == len(processing_ids)
+        assert len(set(Symbolic._processors.keys()).intersection(set(processing_ids))) == len(processing_ids)
         for processing_id in processing_ids:
-            Project.Project._processors.pop(processing_id)
+            Symbolic._processors.pop(processing_id)
 
     @classmethod
     def register_processing_descriptions(cls, processing_descriptions: typing.Dict[str, typing.Any]) -> None:

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -2311,7 +2311,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
             if src.is_croppable:
                 secondary_item = graphic
             display_data_channel = in_display_item.get_display_data_channel_for_data_item(data_item) if data_item else None
-            computation.create_input_item(src.name, Symbolic.make_item(display_data_channel, secondary_item=secondary_item, type=src.type), label=src.label)
+            computation.create_input_item(src.name, Symbolic.make_item(display_data_channel, secondary_item=secondary_item), label=src.label)
         # process the regions
         for region_name, region, region_label in regions:
             computation.create_input_item(region_name, Symbolic.make_item(region), label=region_label)
@@ -2431,128 +2431,128 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                     # TODO: in appropriate places.
                     vs[processing_component.processing_id]["requirements"] = [requirement_4d]
 
-            vs["fft"] = {"title": _("FFT"), "expression": "xd.fft({src}.cropped_display_xdata)", "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+            vs["fft"] = {"title": _("FFT"), "expression": "xd.fft({src}.cropped_display_xdata)", "sources": [{"name": "src", "label": _("Source"), "croppable": True, "data_type": "cropped_display_xdata"}]}
             vs["inverse-fft"] = {"title": _("Inverse FFT"), "expression": "xd.ifft({src}.xdata)",
-                "sources": [{"name": "src", "label": _("Source")}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata"}]}
             vs["auto-correlate"] = {"title": _("Auto Correlate"), "expression": "xd.autocorrelate({src}.cropped_display_xdata)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["cross-correlate"] = {"title": _("Cross Correlate"), "expression": "xd.crosscorrelate({src1}.cropped_display_xdata, {src2}.cropped_display_xdata)",
-                "sources": [{"name": "src1", "label": _("Source 1"), "croppable": True}, {"name": "src2", "label": _("Source 2"), "croppable": True}]}
+                "sources": [{"name": "src1", "label": _("Source 1"), "data_type": "cropped_display_xdata", "croppable": True}, {"name": "src2", "label": _("Source 2"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["sobel"] = {"title": _("Sobel"), "expression": "xd.sobel({src}.cropped_display_xdata)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["laplace"] = {"title": _("Laplace"), "expression": "xd.laplace({src}.cropped_display_xdata)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
             sigma_param = {"name": "sigma", "label": _("Sigma"), "type": "real", "value": 3, "value_default": 3, "value_min": 0, "value_max": 100,
                 "control_type": "slider"}
             vs["gaussian-blur"] = {"title": _("Gaussian Blur"), "expression": "xd.gaussian_blur({src}.cropped_display_xdata, sigma)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [sigma_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [sigma_param]}
             filter_size_param = {"name": "filter_size", "label": _("Size"), "type": "integral", "value": 3, "value_default": 3, "value_min": 1, "value_max": 100}
             vs["median-filter"] = {"title": _("Median Filter"), "expression": "xd.median_filter({src}.cropped_display_xdata, filter_size)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [filter_size_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [filter_size_param]}
             vs["uniform-filter"] = {"title": _("Uniform Filter"), "expression": "xd.uniform_filter({src}.cropped_display_xdata, filter_size)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [filter_size_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [filter_size_param]}
             do_transpose_param = {"name": "do_transpose", "label": _("Transpose"), "type": "boolean", "value": False, "value_default": False}
             do_flip_v_param = {"name": "do_flip_v", "label": _("Flip Vertical"), "type": "boolean", "value": False, "value_default": False}
             do_flip_h_param = {"name": "do_flip_h", "label": _("Flip Horizontal"), "type": "boolean", "value": False, "value_default": False}
             vs["transpose-flip"] = {"title": _("Transpose/Flip"), "expression": "xd.transpose_flip({src}.cropped_display_xdata, do_transpose, do_flip_v, do_flip_h)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [do_transpose_param, do_flip_v_param, do_flip_h_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [do_transpose_param, do_flip_v_param, do_flip_h_param]}
             width_param = {"name": "width", "label": _("Width"), "type": "integral", "value": 256, "value_default": 256, "value_min": 1}
             height_param = {"name": "height", "label": _("Height"), "type": "integral", "value": 256, "value_default": 256, "value_min": 1}
             vs["rebin"] = {"title": _("Rebin"), "expression": "xd.rebin_image({src}.cropped_display_xdata, (height, width))",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [width_param, height_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [width_param, height_param]}
             vs["resample"] = {"title": _("Resample"), "expression": "xd.resample_image({src}.cropped_display_xdata, (height, width))",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [width_param, height_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [width_param, height_param]}
             vs["resize"] = {"title": _("Resize"), "expression": "xd.resize({src}.cropped_display_xdata, (height, width), 'mean')",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [width_param, height_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [width_param, height_param]}
             x_binning_param = {"name": "x_binning", "label": _("X Binning"), "type": "integral", "value": 2, "value_default": 2, "value_min": 1}
             y_binning_param = {"name": "y_binning", "label": _("Y Binning"), "type": "integral", "value": 2, "value_default": 2, "value_min": 1}
             vs["rebin_factor"] = {"title": _("Rebin"), "expression": "xd.rebin_factor({src}.cropped_display_xdata, (y_binning, x_binning))",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [x_binning_param, y_binning_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [x_binning_param, y_binning_param]}
             vs["rebin_factor_1d"] = {"title": _("Rebin"), "expression": "xd.rebin_factor({src}.cropped_display_xdata, (x_binning,))",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [x_binning_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [x_binning_param]}
             is_sequence_param = {"name": "is_sequence", "label": _("Sequence"), "type": "boolean", "value": False, "value_default": False}
             collection_dims_param = {"name": "collection_dims", "label": _("Collection Dimensions"), "type": "integral", "value": 0, "value_default": 0, "value_min": 0, "value_max": 0}
             datum_dims_param = {"name": "datum_dims", "label": _("Datum Dimensions"), "type": "integral", "value": 1, "value_default": 1, "value_min": 1, "value_max": 0}
             vs["redimension"] = {"title": _("Redimension"), "expression": "xd.redimension({src}.xdata, xd.data_descriptor(is_sequence=is_sequence, collection_dims=collection_dims, datum_dims=datum_dims))",
-                "sources": [{"name": "src", "label": _("Source")}], "parameters": [is_sequence_param, collection_dims_param, datum_dims_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata"}], "parameters": [is_sequence_param, collection_dims_param, datum_dims_param]}
             vs["squeeze"] = {"title": _("Squeeze"), "expression": "xd.squeeze({src}.xdata)",
-                "sources": [{"name": "src", "label": _("Source")}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata"}]}
             bins_param = {"name": "bins", "label": _("Bins"), "type": "integral", "value": 256, "value_default": 256, "value_min": 2}
             vs["histogram"] = {"title": _("Histogram"), "expression": "xd.histogram({src}.cropped_display_xdata, bins)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}], "parameters": [bins_param]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}], "parameters": [bins_param]}
             vs["add"] = {"title": _("Add"), "expression": "{src1}.cropped_display_xdata + {src2}.cropped_display_xdata",
-                "sources": [{"name": "src1", "label": _("Source 1"), "croppable": True}, {"name": "src2", "label": _("Source 2"), "croppable": True}]}
+                "sources": [{"name": "src1", "label": _("Source 1"), "data_type": "cropped_display_xdata", "croppable": True}, {"name": "src2", "label": _("Source 2"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["subtract"] = {"title": _("Subtract"), "expression": "{src1}.cropped_display_xdata - {src2}.cropped_display_xdata",
-                "sources": [{"name": "src1", "label": _("Source 1"), "croppable": True}, {"name": "src2", "label": _("Source 2"), "croppable": True}]}
+                "sources": [{"name": "src1", "label": _("Source 1"), "data_type": "cropped_display_xdata", "croppable": True}, {"name": "src2", "label": _("Source 2"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["multiply"] = {"title": _("Multiply"), "expression": "{src1}.cropped_display_xdata * {src2}.cropped_display_xdata",
-                "sources": [{"name": "src1", "label": _("Source 1"), "croppable": True}, {"name": "src2", "label": _("Source 2"), "croppable": True}]}
+                "sources": [{"name": "src1", "label": _("Source 1"), "data_type": "cropped_display_xdata", "croppable": True}, {"name": "src2", "label": _("Source 2"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["divide"] = {"title": _("Divide"), "expression": "{src1}.cropped_display_xdata / {src2}.cropped_display_xdata",
-                "sources": [{"name": "src1", "label": _("Source 1"), "croppable": True}, {"name": "src2", "label": _("Source 2"), "croppable": True}]}
-            vs["invert"] = {"title": _("Negate"), "expression": "xd.invert({src}.cropped_display_xdata)", "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
-            vs["masked"] = {"title": _("Masked"), "expression": "{src}.filtered_xdata", "sources": [{"name": "src", "label": _("Source")}]}
-            vs["mask"] = {"title": _("Mask"), "expression": "{src}.filter_xdata", "sources": [{"name": "src", "label": _("Source")}]}
+                "sources": [{"name": "src1", "label": _("Source 1"), "data_type": "cropped_display_xdata", "croppable": True}, {"name": "src2", "label": _("Source 2"), "data_type": "cropped_display_xdata", "croppable": True}]}
+            vs["invert"] = {"title": _("Negate"), "expression": "xd.invert({src}.cropped_display_xdata)", "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
+            vs["masked"] = {"title": _("Masked"), "expression": "{src}.filtered_xdata", "sources": [{"name": "src", "label": _("Source"), "data_type": "filtered_xdata"}]}
+            vs["mask"] = {"title": _("Mask"), "expression": "{src}.filter_xdata", "sources": [{"name": "src", "label": _("Source"), "data_type": "filter_xdata"}]}
             vs["convert-to-scalar"] = {"title": _("Scalar"), "expression": "{src}.cropped_display_xdata",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["crop"] = {"title": _("Crop"), "expression": "{src}.cropped_display_xdata",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True}]}
             vs["sum"] = {"title": _("Sum"), "expression": "xd.sum({src}.cropped_xdata, {src}.xdata.datum_dimension_indexes[0])",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True, "requirements": [requirement_2d_to_4d]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_xdata", "croppable": True, "requirements": [requirement_2d_to_4d]}]}
             slice_center_param = {"name": "center", "label": _("Center"), "type": "integral", "value": 0, "value_default": 0, "value_min": 0}
             slice_width_param = {"name": "width", "label": _("Width"), "type": "integral", "value": 1, "value_default": 1, "value_min": 1}
             vs["slice"] = {"title": _("Slice"), "expression": "xd.slice_sum({src}.cropped_xdata, center, width)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True, "requirements": [requirement_3d]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_xdata", "croppable": True, "requirements": [requirement_3d]}],
                 "parameters": [slice_center_param, slice_width_param]}
             pick_in_region = {"name": "pick_region", "type": "point", "params": {"label": _("Pick Point")}}
             pick_out_region = {"name": "interval_region", "type": "interval", "params": {"label": _("Display Slice"), "role": "slice"}}
             vs["pick-point"] = {"title": _("Pick"), "expression": "xd.pick({src}.xdata, pick_region.position)",
-                "sources": [{"name": "src", "label": _("Source"), "regions": [pick_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "regions": [pick_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
                 "out_regions": [pick_out_region]}
             pick_sum_in_region = {"name": "region", "type": "rectangle", "params": {"label": _("Pick Region")}}
             pick_sum_out_region = {"name": "interval_region", "type": "interval", "params": {"label": _("Display Slice"), "role": "slice"}}
             vs["pick-mask-sum"] = {"title": _("Pick Sum"), "expression": "xd.sum_region({src}.xdata, region.mask_xdata_with_shape({src}.xdata.data_shape[-3:-1]))",
-                "sources": [{"name": "src", "label": _("Source"), "regions": [pick_sum_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "regions": [pick_sum_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
                 "out_regions": [pick_sum_out_region]}
             vs["pick-mask-average"] = {"title": _("Pick Average"), "expression": "xd.average_region({src}.xdata, region.mask_xdata_with_shape({src}.xdata.data_shape[-3:-1]))",
-                "sources": [{"name": "src", "label": _("Source"), "regions": [pick_sum_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "regions": [pick_sum_in_region], "requirements": [requirement_4d_if_sequence_else_3d]}],
                 "out_regions": [pick_sum_out_region]}
             vs["subtract-mask-average"] = {"title": _("Subtract Average"), "expression": "{src}.xdata - xd.average_region({src}.xdata, region.mask_xdata_with_shape({src}.xdata.data_shape[0:2]))",
-                "sources": [{"name": "src", "label": _("Source"), "regions": [pick_sum_in_region], "requirements": [requirement_3d]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "regions": [pick_sum_in_region], "requirements": [requirement_3d]}],
                 "out_regions": [pick_sum_out_region]}
             line_profile_in_region = {"name": "line_region", "type": "line", "params": {"label": _("Line Profile")}}
             vs["line-profile"] = {"title": _("Line Profile"), "expression": "xd.line_profile(xd.absolute({src}.element_xdata) if {src}.element_xdata.is_data_complex_type else {src}.element_xdata, line_region.vector, line_region.line_width)",
-                "sources": [{"name": "src", "label": _("Source"), "regions": [line_profile_in_region]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "element_xdata", "regions": [line_profile_in_region]}]}
             vs["radial-profile"] = {"title": _("Radial Profile"), "expression": "xd.radial_profile({src}.cropped_display_xdata)",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True, "requirements": [requirement_2d]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True, "requirements": [requirement_2d]}]}
             vs["power-spectrum"] = {"title": _("Radial Power Spectrum"), "expression": "xd.radial_profile(xd.power(xd.absolute(xd.fft({src}.cropped_display_xdata)), 2))",
-                "sources": [{"name": "src", "label": _("Source"), "croppable": True, "requirements": [requirement_2d]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "cropped_display_xdata", "croppable": True, "requirements": [requirement_2d]}]}
             vs["filter"] = {"title": _("Filter"), "expression": "xd.real(xd.ifft({src}.filtered_xdata))",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_2d]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "filtered_xdata", "requirements": [requirement_2d]}]}
             vs["sequence-register"] = {"title": _("Shifts"), "expression": "xd.sequence_squeeze_measurement(xd.sequence_measure_relative_translation({src}.xdata, {src}.xdata[numpy.unravel_index(0, {src}.xdata.navigation_dimension_shape)], 100))",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_2d_to_3d]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_2d_to_3d]}]}
             vs["sequence-align"] = {"title": _("Alignment"), "expression": "xd.sequence_align({src}.xdata, 100)",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_2d_to_5d, requirement_is_navigable]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_2d_to_5d, requirement_is_navigable]}]}
             vs["sequence-fourier-align"] = {"title": _("Alignment"), "expression": "xd.sequence_fourier_align({src}.xdata, 100)",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_2d_to_5d, requirement_is_navigable]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_2d_to_5d, requirement_is_navigable]}]}
             vs["sequence-integrate"] = {"title": _("Integrate"), "expression": "xd.sequence_integrate({src}.xdata)",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_sequence]}]}
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_is_sequence]}]}
             trim_start_param = {"name": "start", "label": _("Start"), "type": "integral", "value": 0, "value_default": 0, "value_min": 0}
             trim_end_param = {"name": "end", "label": _("End"), "type": "integral", "value": 1, "value_default": 1, "value_min": 1}
             vs["sequence-trim"] = {"title": _("Trim"), "expression": "xd.sequence_trim({src}.xdata, start, end)",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_sequence]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_is_sequence]}],
                 "parameters": [trim_start_param, trim_end_param]}
             index_param = {"name": "index", "label": _("Index"), "type": "integral", "value": 1, "value_default": 1, "value_min": 1}
             vs["sequence-extract"] = {"title": _("Extract"), "expression": "xd.sequence_extract({src}.xdata, index)",
-                "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_sequence]}],
+                "sources": [{"name": "src", "label": _("Source"), "data_type": "xdata", "requirements": [requirement_is_sequence]}],
                 "parameters": [index_param]}
             vs["make-rgb"] = {"title": _("RGB"), "expression": "xd.rgb({src_red}.cropped_transformed_xdata, {src_green}.cropped_transformed_xdata, {src_blue}.cropped_transformed_xdata)",
-                "sources": [{"name": "src_red", "label": _("Red"), "croppable": True, "requirements": [requirement_2d]},
-                            {"name": "src_green", "label": _("Green"), "croppable": True, "requirements": [requirement_2d]},
-                            {"name": "src_blue", "label": _("Blue"), "croppable": True, "requirements": [requirement_2d]}]}
-            vs["extract-luminance"] = {"title": _("Luminance"), "expression": "xd.luminance({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_rgb_type]}]}
-            vs["extract-red"] = {"title": _("Red"), "expression": "xd.red({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_rgb_type]}]}
-            vs["extract-green"] = {"title": _("Green"), "expression": "xd.green({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_rgb_type]}]}
-            vs["extract-blue"] = {"title": _("Blue"), "expression": "xd.blue({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_rgb_type]}]}
-            vs["extract-alpha"] = {"title": _("Alpha"), "expression": "xd.alpha({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "requirements": [requirement_is_rgb_type]}]}
+                "sources": [{"name": "src_red", "label": _("Red"), "data_type": "cropped_transformed_xdata", "croppable": True, "requirements": [requirement_2d]},
+                            {"name": "src_green", "label": _("Green"), "data_type": "cropped_transformed_xdata", "croppable": True, "requirements": [requirement_2d]},
+                            {"name": "src_blue", "label": _("Blue"), "data_type": "cropped_transformed_xdata", "croppable": True, "requirements": [requirement_2d]}]}
+            vs["extract-luminance"] = {"title": _("Luminance"), "expression": "xd.luminance({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "data_type": "display_rgba", "requirements": [requirement_is_rgb_type]}]}
+            vs["extract-red"] = {"title": _("Red"), "expression": "xd.red({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "data_type": "display_rgba", "requirements": [requirement_is_rgb_type]}]}
+            vs["extract-green"] = {"title": _("Green"), "expression": "xd.green({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "data_type": "display_rgba", "requirements": [requirement_is_rgb_type]}]}
+            vs["extract-blue"] = {"title": _("Blue"), "expression": "xd.blue({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "data_type": "display_rgba", "requirements": [requirement_is_rgb_type]}]}
+            vs["extract-alpha"] = {"title": _("Alpha"), "expression": "xd.alpha({src}.display_rgba)", "sources": [{"name": "src", "label": _("Source"), "data_type": "display_rgba", "requirements": [requirement_is_rgb_type]}]}
             cls._builtin_processors = {k: Symbolic.ComputationProcessor.from_dict(v) for k, v in vs.items()}
         return cls._builtin_processors
 

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -2218,7 +2218,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
             for processor_region, region in zip(processor_regions, src_region_list):
                 region_params = processor_region.params
                 region_name = processor_region.name
-                region_label = region_params.get("label")
+                region_label = typing.cast(str, region_params["label"])
                 if processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.POINT:
                     if region:
                         assert isinstance(region, Graphics.PointGraphic)
@@ -2243,7 +2243,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(line_region, k, v)
                         if display_item:
                             display_item.add_graphic(line_region)
-                    regions.append((region_name, line_region, region_params.get("label")))
+                    regions.append((region_name, line_region, region_label))
                     region_map[region_name] = line_region
                 elif processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.RECTANGLE:
                     if region:
@@ -2257,7 +2257,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(rect_region, k, v)
                         if display_item:
                             display_item.add_graphic(rect_region)
-                    regions.append((region_name, rect_region, region_params.get("label")))
+                    regions.append((region_name, rect_region, region_label))
                     region_map[region_name] = rect_region
                 elif processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.ELLIPSE:
                     if region:
@@ -2271,7 +2271,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(ellipse_region, k, v)
                         if display_item:
                             display_item.add_graphic(ellipse_region)
-                    regions.append((region_name, ellipse_region, region_params.get("label")))
+                    regions.append((region_name, ellipse_region, region_label))
                     region_map[region_name] = ellipse_region
                 elif processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.SPOT:
                     if region:
@@ -2284,7 +2284,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(spot_region, k, v)
                         if display_item:
                             display_item.add_graphic(spot_region)
-                    regions.append((region_name, spot_region, region_params.get("label")))
+                    regions.append((region_name, spot_region, region_label))
                     region_map[region_name] = spot_region
                 elif processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.INTERVAL:
                     if region:
@@ -2296,7 +2296,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(interval_graphic, k, v)
                         if display_item:
                             display_item.add_graphic(interval_graphic)
-                    regions.append((region_name, interval_graphic, region_params.get("label")))
+                    regions.append((region_name, interval_graphic, region_label))
                     region_map[region_name] = interval_graphic
                 elif processor_region.region_type == Symbolic.ComputationProcsesorRegionTypeEnum.CHANNEL:
                     if region:
@@ -2308,7 +2308,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                             setattr(channel_region, k, v)
                         if display_item:
                             display_item.add_graphic(channel_region)
-                    regions.append((region_name, channel_region, region_params.get("label")))
+                    regions.append((region_name, channel_region, region_label))
                     region_map[region_name] = channel_region
 
         # now extract the script (full script) or expression (implied imports and return statement)

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -2337,9 +2337,9 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         # next process the parameters
         for param in processing_description.parameters:
             parameter_value = parameters.get(param.name, param.value)
-            computation.create_variable(param.name, param.type, parameter_value, value_default=param.value_default,
-                                        value_min=param.value_min, value_max=param.value_max,
-                                        control_type=param.control_type, label=param.label)
+            computation.create_variable(param.name, param.param_type, parameter_value,
+                                        value_default=param.value_default, value_min=param.value_min,
+                                        value_max=param.value_max, control_type=param.control_type, label=param.label)
 
         data_item0 = inputs[0][1]
         new_data_item = DataItem.new_data_item()

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -1676,9 +1676,6 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                 computation.is_initial_computation_complete.wait(timeout)
             await event_loop.run_in_executor(None, sync_recompute)
 
-    def get_object_specifier(self, object: Persistence.PersistentObject, object_type: typing.Optional[str] = None) -> typing.Optional[Persistence.PersistentDictType]:
-        return DataStructure.get_object_specifier(object, object_type)
-
     def get_graphic_by_uuid(self, object_uuid: uuid.UUID) -> typing.Optional[Graphics.Graphic]:
         for display_item in self.display_items:
             for graphic in display_item.graphics:

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -41,8 +41,6 @@ class Project(Persistence.PersistentObject):
 
     PROJECT_VERSION = 3
 
-    _processors = dict[str, Symbolic.ComputationProcessor]()
-
     def __init__(self, storage_system: Persistence.PersistentStorageInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
         super().__init__()
 
@@ -316,7 +314,7 @@ class Project(Persistence.PersistentObject):
                     if not self.get_item_by_uuid("computations", computation.uuid):
                         self.load_item("computations", len(self.computations), computation)
                         # TODO: handle update script and bind after reload in document model
-                        computation.update_script(Project._processors)
+                        computation.update_script()
                         computation.reset()
                     else:
                         computation.close()

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -41,7 +41,7 @@ class Project(Persistence.PersistentObject):
 
     PROJECT_VERSION = 3
 
-    _processing_descriptions = dict[str, Symbolic.ComputationProcessor]()
+    _processors = dict[str, Symbolic.ComputationProcessor]()
 
     def __init__(self, storage_system: Persistence.PersistentStorageInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
         super().__init__()
@@ -316,7 +316,7 @@ class Project(Persistence.PersistentObject):
                     if not self.get_item_by_uuid("computations", computation.uuid):
                         self.load_item("computations", len(self.computations), computation)
                         # TODO: handle update script and bind after reload in document model
-                        computation.update_script(Project._processing_descriptions)
+                        computation.update_script(Project._processors)
                         computation.reset()
                     else:
                         computation.close()

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -20,6 +20,7 @@ from nion.swift.model import DataStructure
 from nion.swift.model import DisplayItem
 from nion.swift.model import FileStorageSystem
 from nion.swift.model import Persistence
+from nion.swift.model import Symbolic
 from nion.swift.model import WorkspaceLayout
 from nion.utils import Converter
 from nion.utils import ListModel
@@ -40,7 +41,7 @@ class Project(Persistence.PersistentObject):
 
     PROJECT_VERSION = 3
 
-    _processing_descriptions: PersistentDictType = dict()
+    _processing_descriptions = dict[str, Symbolic.ComputationProcessor]()
 
     def __init__(self, storage_system: Persistence.PersistentStorageInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
         super().__init__()

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -2850,7 +2850,7 @@ class ComputationProcessorRequirementIsNavigable(ComputationProcessorRequirement
         return data_item.is_sequence or data_item.is_collection
 
 
-class ComputationProcessorRequirementBooleanOperator(enum.StrEnum):
+class ComputationProcessorRequirementBooleanOperator(enum.Enum):
     NOT = "not"
     AND = "and"
     OR = "or"
@@ -2902,7 +2902,7 @@ def create_computation_processor_requirement(d: PersistentDictType) -> Computati
     raise ValueError(f"Unknown requirement type: {requirement_type}")
 
 
-class ComputationProcsesorRegionTypeEnum(enum.StrEnum):
+class ComputationProcsesorRegionTypeEnum(enum.Enum):
     POINT = "point"
     LINE = "line"
     RECTANGLE = "rectangle"

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -2565,12 +2565,12 @@ class Computation(Persistence.PersistentObject):
             self.computation_mutated_event.fire()
             self.needs_update = True
 
-    def update_script(self, processing_descriptions: typing.Mapping[str, ComputationProcessor]) -> None:
+    def update_script(self, processors: typing.Mapping[str, ComputationProcessor]) -> None:
         processing_id = self.processing_id
-        processing_description = processing_descriptions.get(processing_id) if processing_id else None
-        if processing_description:
-            if expression := processing_description.expression:
-                src_names = [processing_description_source.name for processing_description_source in processing_description.sources]
+        processor = processors.get(processing_id) if processing_id else None
+        if processor:
+            if expression := processor.expression:
+                src_names = [processing_description_source.name for processing_description_source in processor.sources]
                 script = xdata_expression(expression)
                 script = script.format(**dict(zip(src_names, src_names)))
                 self._get_persistent_property("original_expression").value = script

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -2898,9 +2898,10 @@ class ComputationProcessorRegion:
 
 
 class ComputationProcessorSource:
-    def __init__(self, name: str, label: str, requirements: typing.Sequence[ComputationProcessorRequirement], regions: typing.Sequence[ComputationProcessorRegion], is_croppable: bool) -> None:
+    def __init__(self, name: str, label: str, type: typing.Optional[str], requirements: typing.Sequence[ComputationProcessorRequirement], regions: typing.Sequence[ComputationProcessorRegion], is_croppable: bool) -> None:
         self.name = name
         self.label = label
+        self.type = type
         self.requirements = list(requirements)
         self.regions = list(regions)
         self.is_croppable = is_croppable
@@ -2909,10 +2910,11 @@ class ComputationProcessorSource:
     def from_dict(cls, d: PersistentDictType) -> ComputationProcessorSource:
         name = d["name"]
         label = d["label"]
+        type = d.get("type", None)
         requirements = [create_computation_processor_requirement(requirement_d) for requirement_d in d.get("requirements", list())]
         regions = [ComputationProcessorRegion.from_dict(region_d) for region_d in d.get("regions", list())]
         is_croppable = d.get("croppable", False)
-        return cls(name, label, requirements, regions, is_croppable)
+        return cls(name, label, type, requirements, regions, is_croppable)
 
 
 class ComputationProcessorParameter:

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1288,7 +1288,7 @@ class MonitoredDataSource(DataSource):
                 property_changed_listener = None
                 if isinstance(graphic, (Graphics.PointTypeGraphic, Graphics.LineTypeGraphic, Graphics.RectangleTypeGraphic, Graphics.SpotGraphic, Graphics.WedgeGraphic, Graphics.RingGraphic, Graphics.LatticeGraphic)):
                     property_changed_listener = graphic.property_changed_event.listen(functools.partial(filter_property_changed, graphic))
-                    self.__changed_event.fire()
+                    filter_property_changed(graphic, "label")  # dummy non-role value
                 self.__graphic_property_changed_listeners.insert(before_index, property_changed_listener)
 
         # when a graphic is removed, untrack it
@@ -1297,7 +1297,7 @@ class MonitoredDataSource(DataSource):
                 property_changed_listener = self.__graphic_property_changed_listeners.pop(index)
                 if property_changed_listener:
                     property_changed_listener.close()
-                    self.__changed_event.fire()
+                    filter_property_changed(graphic, "label")  # dummy non-role value
 
         self.__graphic_inserted_event_listener = self.__display_item.item_inserted_event.listen(graphic_inserted) if self.__display_item else None
         self.__graphic_removed_event_listener = self.__display_item.item_removed_event.listen(graphic_removed) if self.__display_item else None

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -24,8 +24,6 @@ import traceback
 import typing
 import uuid
 
-import typing_extensions
-
 # local libraries
 from nion.data import Core
 from nion.data import DataAndMetadata
@@ -2565,9 +2563,9 @@ class Computation(Persistence.PersistentObject):
             self.computation_mutated_event.fire()
             self.needs_update = True
 
-    def update_script(self, processors: typing.Mapping[str, ComputationProcessor]) -> None:
+    def update_script(self) -> None:
         processing_id = self.processing_id
-        processor = processors.get(processing_id) if processing_id else None
+        processor = _processors.get(processing_id) if processing_id else None
         if processor:
             if expression := processor.expression:
                 src_names = [processing_description_source.name for processing_description_source in processor.sources]
@@ -3000,6 +2998,11 @@ class ComputationActivity(Activity.Activity):
     @property
     def displayed_title(self) -> str:
         return self.title + " (" + self.state + ")"
+
+
+# processors
+
+_processors = dict[str, ComputationProcessor]()
 
 
 # for computations

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -2465,7 +2465,7 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(len(document_model.data_items), 2)
                 computation = document_model.get_data_item_computation(document_model.data_items[1])
                 self.assertEqual(computation.processing_id, "line-profile")
-                self.assertEqual(computation.expression, Symbolic.xdata_expression(DocumentModel.DocumentModel._builtin_processing_descriptions["line-profile"]["expression"].replace("{src}", "src")))
+                self.assertEqual(computation.expression, Symbolic.xdata_expression(DocumentModel.DocumentModel._builtin_processors["line-profile"].expression.replace("{src}", "src")))
                 self.assertEqual(len(computation.variables), 2)
                 self.assertEqual(computation.get_input("src").data_item, document_model.data_items[0])
                 self.assertEqual(computation.get_input("line_region"), document_model.display_items[0].graphics[0])

--- a/nion/swift/test/Symbolic_test.py
+++ b/nion/swift/test/Symbolic_test.py
@@ -1696,6 +1696,23 @@ class TestSymbolicClass(unittest.TestCase):
             document_model.recompute_all()
             self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
 
+    def test_changing_display_slice_does_not_trigger_pick_recompute(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((8, 8, 8), numpy.uint32))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_panel = document_controller.selected_display_panel
+            display_panel.set_display_panel_display_item(display_item)
+            document_controller.perform_action("processing.pick")
+            # pick_display_item = document_model.display_items[-1]
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+            display_item.display_data_channels[0].slice_center += 1
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+
     def test_inserting_and_changing_unrelated_graphic_does_not_trigger_pick_recompute(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()

--- a/nion/swift/test/Symbolic_test.py
+++ b/nion/swift/test/Symbolic_test.py
@@ -994,7 +994,7 @@ class TestSymbolicClass(unittest.TestCase):
             self.assertTrue(numpy.array_equal(DocumentModel.evaluate_data(computation2).data, src_data + 5))
 
     def test_computation_variable_writes_and_reads(self):
-        with contextlib.closing(Symbolic.ComputationVariable("x", value_type="integral", value=5)) as variable:
+        with contextlib.closing(Symbolic.ComputationVariable("x", value_type=Symbolic.ComputationVariableType.INTEGRAL, value=5)) as variable:
             self.assertEqual(variable.name, "x")
             self.assertEqual(variable.value, 5)
             data_node_dict = variable.write_to_dict()
@@ -1004,9 +1004,9 @@ class TestSymbolicClass(unittest.TestCase):
                 self.assertEqual(variable.value, variable2.value)
 
     def test_computation_variable_change_type(self):
-        with contextlib.closing(Symbolic.ComputationVariable("x", value_type="integral", value=5)) as variable:
+        with contextlib.closing(Symbolic.ComputationVariable("x", value_type=Symbolic.ComputationVariableType.INTEGRAL, value=5)) as variable:
             variable.variable_type = "data_item"
-        with contextlib.closing(Symbolic.ComputationVariable("x", value_type="integral", value=5)) as variable:
+        with contextlib.closing(Symbolic.ComputationVariable("x", value_type=Symbolic.ComputationVariableType.INTEGRAL, value=5)) as variable:
             variable.variable_type = "graphic"
 
     def test_computation_reparsing_keeps_variables(self):

--- a/nion/swift/test/Symbolic_test.py
+++ b/nion/swift/test/Symbolic_test.py
@@ -1696,6 +1696,46 @@ class TestSymbolicClass(unittest.TestCase):
             document_model.recompute_all()
             self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
 
+    def test_inserting_and_changing_unrelated_graphic_does_not_trigger_pick_recompute(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((8, 8, 8), numpy.uint32))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_panel = document_controller.selected_display_panel
+            display_panel.set_display_panel_display_item(display_item)
+            document_controller.perform_action("processing.pick")
+            # pick_display_item = document_model.display_items[-1]
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+            rectangle = Graphics.RectangleGraphic()
+            display_item.add_graphic(rectangle)
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+            rectangle.center = 0.2, 0.2
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+
+    def test_removing_unrelated_graphic_does_not_trigger_pick_recompute(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((8, 8, 8), numpy.uint32))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            rectangle = Graphics.RectangleGraphic()
+            display_item.add_graphic(rectangle)
+            display_panel = document_controller.selected_display_panel
+            display_panel.set_display_panel_display_item(display_item)
+            document_controller.perform_action("processing.pick")
+            # pick_display_item = document_model.display_items[-1]
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+            display_item.remove_graphic(rectangle).close()
+            document_model.recompute_all()
+            self.assertEqual(1, document_model.computations[-1]._evaluation_count_for_test)
+
     def test_data_source_watches_correct_graphics(self):
         # this failed at one point due to improper use of local variable
         with TestContext.create_memory_context() as test_context:


### PR DESCRIPTION
- **Refactor processors from dict to objects for typing and programmatic access.**
- **Improve typing of processor variables.**
- **Add more typing to processors, and clean init methods.**
- **Store built-in processor instead of descriptions.**
- **Move _processors to computation module (Symbolic).**
- **Add 'type' to computation processor source objects.**
- **Ensure add/remove graphic does not trigger pick recompute.**
- **Remove unused object-specifier function.**
- **Fix #147. Introduce fine grained dependency check to computations.**
