### PR TITLE
Updates to the export results dialog

### DIFF
--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -363,7 +363,9 @@ class ExportResultDialog(Declarative.Handler):
         error_column = u.create_column(*error_children, spacing=5)
 
         # Build main ui row
-        data_row = u.create_row(file_name_column, status_column, error_column, spacing=10)
+        data_row = u.create_scroll_area(u.create_row(u.create_spacing(5), file_name_column, status_column,
+                                                     error_column, u.create_spacing(5), spacing=10),
+                                        height=250, width=1000)
 
         path_title = u.create_label(text=_('Directory:'), font='bold')
 

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -234,7 +234,8 @@ class ExportDialog(Declarative.Handler):
                 else:
                     export_results.append(ExportResult(display_item.displayed_title, _('Failed'), _('Cannot export items with multiple data items')))
 
-            ExportResultDialog(ui, document_controller, export_results, directory_path)
+            if any(e.status == 'Failed' for e in export_results):
+                ExportResultDialog(ui, document_controller, export_results, directory_path)
 
     def cancel(self) -> bool:
         return True


### PR DESCRIPTION
Following the discussions we had about the export results dialog, I have made a few changes:

- Added a scrollable area for when there are more exports than can fit on the screen

- Only display the dialog if there are some failed exports