### PR TITLE
Moved slice section of inspector over to declarative UI

### DIFF
--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -549,12 +549,10 @@ class TestInspectorClass(unittest.TestCase):
             display_data_channel.slice_width = 4
             slice_inspector_section = Inspector.SliceInspectorSection(document_controller, display_item.display_data_channels[0])
             with contextlib.closing(slice_inspector_section):
-                self.assertEqual(slice_inspector_section._slice_center_slider_widget.value, 16)
-                self.assertEqual(slice_inspector_section._slice_center_slider_widget.maximum, 31)
-                self.assertEqual(slice_inspector_section._slice_width_slider_widget.value, 4)
-                self.assertEqual(slice_inspector_section._slice_width_slider_widget.maximum, 31)
-                self.assertEqual(slice_inspector_section._slice_center_line_edit_widget.text, "16")
-                self.assertEqual(slice_inspector_section._slice_width_line_edit_widget.text, "4")
+                self.assertEqual(slice_inspector_section._slice_model.slice_center, 16)
+                self.assertEqual(slice_inspector_section._slice_model.slice_center_maximum, 31)
+                self.assertEqual(slice_inspector_section._slice_model.slice_width, 4)
+                self.assertEqual(slice_inspector_section._slice_model.slice_width_maximum, 31)
 
     def test_image_display_inspector_shows_empty_fields_for_none_display_limits(self):
         with TestContext.create_memory_context() as test_context:


### PR DESCRIPTION
This is to address one of the tasks on https://github.com/nion-software/nionswift/issues/1093

Specifically the slice section