### PR TITLE
Changed UI state and geometry to only load at startup

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -613,6 +613,7 @@ class Application(UIApplication.BaseApplication):
                 display_panel.set_display_panel_display_item(display_item)
         setattr(document_controller, "_dynamic_recent_project_actions", list())
         document_controller.show()
+        document_controller.restore_ui_state_and_geometry()
         return document_controller
 
     def _set_profile_for_test(self, profile: typing.Optional[Profile.Profile]) -> None:

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -353,6 +353,9 @@ class DocumentController(Window.Window):
         self.__last_activity = time.time()
 
     def about_to_show(self) -> None:
+        pass  # Previously this contained UI state/geometry loading which has now been moved.
+
+    def restore_ui_state_and_geometry(self) -> None:
         workspace_controller = self.workspace_controller
         if workspace_controller:
             geometry, state = workspace_controller.restore_geometry_state()


### PR DESCRIPTION
Moved the UI restore to a separate function from the standard Show event handler.  Added a call to that separate function only on first software load (creation of document controller) and removed it from the Show event handling. Functionality now should be it restores the last saved state only once, on software load. State during software running should be handled entirely by the windowing manager and not reloaded again.