### PR TITLE
Fix 1104 and only split panels two

### DIFF
--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -934,6 +934,7 @@ class Workspace:
         index = container.canvas_items.index(display_panel)
         if isinstance(container, CanvasItem.SplitterCanvasItem):
             # modify the existing splitter
+            splits = list(container.splits)
             old_split = container.splits[index] if not new_splits else 0.0
             new_index_adj = 1 if region == "right" or region == "bottom" else 0
             new_display_panel = DisplayPanel.DisplayPanel(self.document_controller, dict(), new_uuid)
@@ -948,7 +949,9 @@ class Workspace:
             if new_splits:
                 container.splits = copy.copy(new_splits)
             else:
-                splits = list(container.splits)
+                # splits = list(container.splits)
+                splits[index] = old_split * 0.5
+                splits.insert(index, old_split * 0.5)
                 splits[index] = old_split * 0.5
                 splits[index + 1] = old_split * 0.5
                 container.splits = splits

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -922,15 +922,12 @@ class Workspace:
         assert container
         # record old splits for undo if modifying an existing splitter; otherwise removing the display panel is trivial
         old_splits = list(container.splits) if isinstance(container, CanvasItem.SplitterCanvasItem) and container.orientation == orientation else None
-        # if not modifying an existing splitter or if modifying in the other orientation, wrap panel in new splitter
-        if not isinstance(container, CanvasItem.SplitterCanvasItem) or container.orientation != orientation:
-            # check if trying to drag on non-axis edge of splitter
-            # special case where top level item is the image panel
-            splitter_canvas_item = CanvasItem.SplitterCanvasItem(orientation=orientation)
-            splitter_canvas_item.on_splits_will_change = functools.partial(self._splits_will_change, splitter_canvas_item)
-            splitter_canvas_item.on_splits_changed = functools.partial(self._splits_did_change, splitter_canvas_item)
-            container.wrap_canvas_item(display_panel, splitter_canvas_item)
-            container = splitter_canvas_item
+        # always wrap target panel in new splitter. this makes it easier to close splitters without affecting other layout.
+        splitter_canvas_item = CanvasItem.SplitterCanvasItem(orientation=orientation)
+        splitter_canvas_item.on_splits_will_change = functools.partial(self._splits_will_change, splitter_canvas_item)
+        splitter_canvas_item.on_splits_changed = functools.partial(self._splits_did_change, splitter_canvas_item)
+        container.wrap_canvas_item(display_panel, splitter_canvas_item)
+        container = splitter_canvas_item
         index = container.canvas_items.index(display_panel)
         if isinstance(container, CanvasItem.SplitterCanvasItem):
             # modify the existing splitter

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1658,6 +1658,41 @@ class TestWorkspaceClass(unittest.TestCase):
         finally:
             DisplayPanel.DisplayPanelManager().unregister_display_panel_controller_factory("test")
 
+    def test_split_within_split_keeps_parent_splits(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
+            root_canvas_item.layout_immediate(Geometry.IntSize(width=100, height=100))
+            workspace_controller = document_controller.workspace_controller
+            display_panel = workspace_controller.display_panels[0]
+            document_controller.selected_display_panel = display_panel
+            document_controller.perform_action("workspace.split_2x2")
+            root_canvas_item.layout_immediate(Geometry.IntSize(width=100, height=100))
+            expected_bounds = [
+                Geometry.IntRect.from_tlhw(0, 0, 50, 50),
+                Geometry.IntRect.from_tlhw(0, 50, 50, 50),
+                Geometry.IntRect.from_tlhw(50, 0, 50, 50),
+                Geometry.IntRect.from_tlhw(50, 50, 50, 50)
+            ]
+            for bounds, display_panel in zip(expected_bounds, workspace_controller.display_panels):
+                self.assertEqual(bounds.size, display_panel.canvas_bounds.size)
+                self.assertEqual(bounds.origin, display_panel.map_to_root_container(display_panel.canvas_bounds.origin))
+            document_controller.selected_display_panel = workspace_controller.display_panels[3]
+            document_controller.perform_action("workspace.split_2x2")
+            root_canvas_item.layout_immediate(Geometry.IntSize(width=100, height=100))
+            expected_bounds = [
+                Geometry.IntRect.from_tlhw(0, 0, 50, 50),
+                Geometry.IntRect.from_tlhw(0, 50, 50, 50),
+                Geometry.IntRect.from_tlhw(50, 0, 50, 50),
+                Geometry.IntRect.from_tlhw(50, 50, 25, 25),
+                Geometry.IntRect.from_tlhw(50, 75, 25, 25),
+                Geometry.IntRect.from_tlhw(75, 50, 25, 25),
+                Geometry.IntRect.from_tlhw(75, 75, 25, 25),
+            ]
+            for bounds, display_panel in zip(expected_bounds, workspace_controller.display_panels):
+                self.assertEqual(bounds.size, display_panel.canvas_bounds.size)
+                self.assertEqual(bounds.origin, display_panel.map_to_root_container(display_panel.canvas_bounds.origin))
+
     # def test_display_panel_controller_initially_displays_existing_data(self):
     #     # cannot implement until common code for display controllers is moved into document model
     #     pass


### PR DESCRIPTION
- **Fix split issue by keeping splits when inserting new panel.**
- **Always split the target display panel rather than adding to row/column.**

This addresses #1104.

It also addresses a longstanding request to not make closing a display panel affect other display panels in same column/row, which was the case if you dragged a new item into a display panel such that it extended a row/column and then immediately closed it, in which case it would expand the remaining panels in a non-intuitive way. For instance, before this fix, make a 2x2, then drag an image to the left side of the top-left panel, then close the panel with the image. Resulting layout is not the original 2x2. In new version with this PR, it is. I think this is much more intuitive for arranging layouts, but may have unintended behavior that I haven't thought of yet.

This PR also fixes an issue with the workspace not updating properly when closing panels in some cases (also described in #1104). However, I encountered at least one case where the layout got completely messed up - maybe as the result of undo.

NOTE: requires the latest `nionui` with commits nion-software/nionui@61d936f0c5ecdc448bb44496cb1424b154a16a3f and nion-software/nionui@9ed8105e7d9691e4ec1ba7dd4332b61b7b0a79cf