### PR TITLE
Refactor Control Rendering Code in HeaderCanvasItem

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1778,11 +1778,12 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         self.__content_canvas_item.on_focus_changed = self.set_focused
         self.__content_canvas_item.on_context_menu_event = self.__handle_context_menu_event
 
-        self.__header_canvas_item = Panel.HeaderCanvasItem(DisplayPanelUISettings(document_controller.ui), display_close_control=True)
+        self.__header_canvas_item = Panel.HeaderCanvasItem(DisplayPanelUISettings(document_controller.ui), display_close_control=True, display_edit_control=True)
 
         def header_double_clicked(x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
             action_context = document_controller._get_action_context()
             action_context.display_panel = self
+            action_context.display_item = self.display_item
             document_controller.perform_action_in_context("window.open_title_edit", action_context)
             return True
 
@@ -1868,9 +1869,17 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 command = workspace_controller.remove_display_panel(self)
                 document_controller.push_undo_command(command)
 
+        def edit() -> None:
+            action_context = document_controller._get_action_context()
+            action_context.display_panel = self
+            action_context.display_item = self.display_item
+            document_controller.perform_action_in_context("window.open_title_edit", action_context)
+
+
         self.__header_canvas_item.on_select_pressed = self._select
         self.__header_canvas_item.on_drag_pressed = self.__handle_begin_drag
         self.__header_canvas_item.on_close_clicked = close
+        self.__header_canvas_item.on_edit_clicked = edit
 
         ui = document_controller.ui
 

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -404,7 +404,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
         control_margin_x = 7
         control_width_with_margin = 2 * control_margin_x + control_size
         canvas_size = self.canvas_size
-        close_rect: Geometry.IntRect = None
+        close_rect: typing.Optional[Geometry.IntRect] = None
         if canvas_size:
             # Variables containing the coordinates of the rendering locations, not the full clickable control
             close_box_left = canvas_size.width - control_width_with_margin + control_margin_x
@@ -435,7 +435,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
 
     def _draw_title_text(self, drawing_context: DrawingContext.DrawingContext) -> Geometry.IntRect:
         canvas_size = self.canvas_size
-        title_rect: Geometry.IntRect = None
+        title_rect: typing.Optional[Geometry.IntRect] = None
         if canvas_size:
             with drawing_context.saver():
                 drawing_context.font = self.__font
@@ -457,7 +457,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
         control_margin = 2
         control_width = 10
         canvas_size = self.canvas_size
-        control_rect: Geometry.IntRect = None
+        control_rect: typing.Optional[Geometry.IntRect] = None
         if canvas_size:
             with drawing_context.saver():
                 drawing_context.begin_path()

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -22,7 +22,7 @@ from nion.swift.model import Utility
 from nion.ui import Application
 from nion.ui import CanvasItem
 from nion.ui import Declarative
-from nion.ui import PyQtProxy
+from nion.ui.PyQtProxy import ParseFontString
 from nion.ui import UserInterface
 from nion.utils import Geometry
 from nion.utils import Registry
@@ -445,7 +445,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
                 drawing_context.fill_text(self.title, canvas_size.width // 2, canvas_size.height - self.__text_offset)
 
             font_string = self.__font
-            font = PyQtProxy.ParseFontString(font_string)
+            font = ParseFontString(font_string)
             fm = QtGui.QFontMetrics(font)
             text_size = fm.horizontalAdvance(self.title)
             title_rect = Geometry.IntRect.from_tlhw(canvas_size.height - self.__text_offset - (fm.height() / 2), (canvas_size.width // 2) - (text_size / 2), fm.height(), text_size)

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -399,7 +399,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
     def _draw_close_control_linux(self, drawing_context: DrawingContext.DrawingContext) -> None:
         self._draw_controls_windows(drawing_context)
 
-    def _draw_close_control_windows(self, drawing_context: DrawingContext.DrawingContext) -> Geometry.IntRect:
+    def _draw_close_control_windows(self, drawing_context: DrawingContext.DrawingContext) -> typing.Optional[Geometry.IntRect]:
         control_size = 6
         control_margin_x = 7
         control_width_with_margin = 2 * control_margin_x + control_size
@@ -433,7 +433,7 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
                 drawing_context.stroke()
         return close_rect
 
-    def _draw_title_text(self, drawing_context: DrawingContext.DrawingContext) -> Geometry.IntRect:
+    def _draw_title_text(self, drawing_context: DrawingContext.DrawingContext) -> typing.Optional[Geometry.IntRect]:
         canvas_size = self.canvas_size
         title_rect: typing.Optional[Geometry.IntRect] = None
         if canvas_size:
@@ -452,13 +452,13 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
         return title_rect
 
 
-    def _draw_edit_button(self, drawing_context: DrawingContext.DrawingContext, title_rect: Geometry.IntRect) -> Geometry.IntRect:
+    def _draw_edit_button(self, drawing_context: DrawingContext.DrawingContext, title_rect: typing.Optional[Geometry.IntRect]) -> typing.Optional[Geometry.IntRect]:
         control_title_margin = 3
         control_margin = 2
         control_width = 10
         canvas_size = self.canvas_size
         control_rect: typing.Optional[Geometry.IntRect] = None
-        if canvas_size:
+        if canvas_size and title_rect:
             with drawing_context.saver():
                 drawing_context.begin_path()
                 close_box_left = title_rect.right + control_margin + control_title_margin # canvas_size.width - (40 - 7)

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -404,50 +404,51 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
         control_margin_x = 7
         control_width_with_margin = 2 * control_margin_x + control_size
         canvas_size = self.canvas_size
+        close_rect: Geometry.IntRect = None
+        if canvas_size:
+            # Variables containing the coordinates of the rendering locations, not the full clickable control
+            close_box_left = canvas_size.width - control_width_with_margin + control_margin_x
+            close_box_right = canvas_size.width - control_margin_x
+            close_box_top = canvas_size.height // 2 - 3
+            close_box_bottom = canvas_size.height // 2 + 3
 
-        # Variables containing the coordinates of the rendering locations, not the full clickable control
-        close_box_left = canvas_size.width - control_width_with_margin + control_margin_x
-        close_box_right = canvas_size.width - control_margin_x
-        close_box_top = canvas_size.height // 2 - 3
-        close_box_bottom = canvas_size.height // 2 + 3
+            control_margin_y = canvas_size.height - (close_box_bottom - close_box_top) - 2
+            if control_margin_y > control_margin_x:
+                control_margin_y = control_margin_x
 
-        control_margin_y = canvas_size.height - (close_box_bottom - close_box_top) - 2
-        if control_margin_y > control_margin_x:
-            control_margin_y = control_margin_x
-
-        close_rect = Geometry.IntRect.from_tlhw(
-                             close_box_top - control_margin_y,
-                             close_box_left - control_margin_x,
-                             control_size + 2 * control_margin_y,
-                             control_width_with_margin) #  Rectangle containing bounds of the control
-
-        with drawing_context.saver():
-            drawing_context.begin_path()
-            drawing_context.move_to(close_box_left, close_box_top)
-            drawing_context.line_to(close_box_right, close_box_bottom)
-            drawing_context.move_to(close_box_left, close_box_bottom)
-            drawing_context.line_to(close_box_right, close_box_top)
-            drawing_context.line_width = 1.5
-            drawing_context.line_cap = "round"
-            drawing_context.stroke_style = self.__control_style
-            drawing_context.stroke()
-
+            close_rect = Geometry.IntRect.from_tlhw(
+                                 close_box_top - control_margin_y,
+                                 close_box_left - control_margin_x,
+                                 control_size + 2 * control_margin_y,
+                                 control_width_with_margin) #  Rectangle containing bounds of the control
+            with drawing_context.saver():
+                drawing_context.begin_path()
+                drawing_context.move_to(close_box_left, close_box_top)
+                drawing_context.line_to(close_box_right, close_box_bottom)
+                drawing_context.move_to(close_box_left, close_box_bottom)
+                drawing_context.line_to(close_box_right, close_box_top)
+                drawing_context.line_width = 1.5
+                drawing_context.line_cap = "round"
+                drawing_context.stroke_style = self.__control_style
+                drawing_context.stroke()
         return close_rect
 
     def _draw_title_text(self, drawing_context: DrawingContext.DrawingContext) -> Geometry.IntRect:
         canvas_size = self.canvas_size
-        with drawing_context.saver():
-            drawing_context.font = self.__font
-            drawing_context.text_align = 'center'
-            drawing_context.text_baseline = 'bottom'
-            drawing_context.fill_style = '#000'
-            drawing_context.fill_text(self.title, canvas_size.width // 2, canvas_size.height - self.__text_offset)
+        title_rect: Geometry.IntRect = None
+        if canvas_size:
+            with drawing_context.saver():
+                drawing_context.font = self.__font
+                drawing_context.text_align = 'center'
+                drawing_context.text_baseline = 'bottom'
+                drawing_context.fill_style = '#000'
+                drawing_context.fill_text(self.title, canvas_size.width // 2, canvas_size.height - self.__text_offset)
 
-        font_string = self.__font
-        font = PyQtProxy.ParseFontString(font_string)
-        fm = QtGui.QFontMetrics(font)
-        text_size = fm.horizontalAdvance(self.title)
-        title_rect = Geometry.IntRect.from_tlhw(canvas_size.height - self.__text_offset - (fm.height() / 2), (canvas_size.width // 2) - (text_size / 2), fm.height(), text_size)
+            font_string = self.__font
+            font = PyQtProxy.ParseFontString(font_string)
+            fm = QtGui.QFontMetrics(font)
+            text_size = fm.horizontalAdvance(self.title)
+            title_rect = Geometry.IntRect.from_tlhw(canvas_size.height - self.__text_offset - (fm.height() / 2), (canvas_size.width // 2) - (text_size / 2), fm.height(), text_size)
         return title_rect
 
 
@@ -456,29 +457,28 @@ class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
         control_margin = 2
         control_width = 10
         canvas_size = self.canvas_size
-        with drawing_context.saver():
-            drawing_context.begin_path()
-            close_box_left = title_rect.right + control_margin + control_title_margin # canvas_size.width - (40 - 7)
-            close_box_right = close_box_left + control_width # canvas_size.width - (40 - 13)
-            close_box_top = canvas_size.height // 2 - 5
-            close_box_bottom = canvas_size.height // 2 + 5
-            drawing_context.move_to(close_box_left, close_box_bottom)
-            drawing_context.line_to(close_box_left + 4, close_box_bottom - 1)
-            drawing_context.line_to(close_box_left + 10, close_box_bottom - 8)
-            drawing_context.line_to(close_box_left + 8, close_box_bottom - 10)
-            drawing_context.line_to(close_box_left + 1, close_box_bottom - 4)
-            drawing_context.line_to(close_box_left, close_box_bottom)
-            drawing_context.move_to(close_box_left + 4, close_box_bottom - 1)
-            drawing_context.line_to(close_box_left, close_box_bottom - 3)
-            #  drawing_context.line_to(close_box_right, close_box_bottom)
-            #  drawing_context.move_to(close_box_left, close_box_bottom)
-            #  drawing_context.line_to(close_box_right, close_box_top)
-            drawing_context.line_width = 1
-            drawing_context.line_cap = "round"
-            drawing_context.stroke_style = self.__control_style
-            drawing_context.stroke()
-        control_rect = Geometry.IntRect.from_tlhw(close_box_top - control_margin, close_box_left - control_margin, control_width + 2 * control_margin, control_width + 2 * control_margin)
-        self.__edit_control_rect = control_rect
+        control_rect: Geometry.IntRect = None
+        if canvas_size:
+            with drawing_context.saver():
+                drawing_context.begin_path()
+                close_box_left = title_rect.right + control_margin + control_title_margin # canvas_size.width - (40 - 7)
+                close_box_right = close_box_left + control_width # canvas_size.width - (40 - 13)
+                close_box_top = canvas_size.height // 2 - 5
+                close_box_bottom = canvas_size.height // 2 + 5
+                drawing_context.move_to(close_box_left, close_box_bottom)
+                drawing_context.line_to(close_box_left + 4, close_box_bottom - 1)
+                drawing_context.line_to(close_box_left + 10, close_box_bottom - 8)
+                drawing_context.line_to(close_box_left + 8, close_box_bottom - 10)
+                drawing_context.line_to(close_box_left + 1, close_box_bottom - 4)
+                drawing_context.line_to(close_box_left, close_box_bottom)
+                drawing_context.move_to(close_box_left + 4, close_box_bottom - 1)
+                drawing_context.line_to(close_box_left, close_box_bottom - 3)
+                drawing_context.line_width = 1
+                drawing_context.line_cap = "round"
+                drawing_context.stroke_style = self.__control_style
+                drawing_context.stroke()
+            control_rect = Geometry.IntRect.from_tlhw(close_box_top - control_margin, close_box_left - control_margin, control_width + 2 * control_margin, control_width + 2 * control_margin)
+            self.__edit_control_rect = control_rect
         return control_rect
     def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
         canvas_size = self.canvas_size


### PR DESCRIPTION
Added in a edit control, just to the right of the rendered title. Created local rectangles saving the location of the close and edit titles, and refactored the click handler to check the rectangles rather than absolute values. Broke out the rendering code into sections to allow easier refactoring for different display modes for platforms. Currently all platforms still use the windows rendering mode.