### PR TITLE
Refactor Control Rendering Code in HeaderCanvasItem

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1901,9 +1901,10 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         self.__content_canvas_item.on_context_menu_event = self.__handle_context_menu_event
 
         self.__header_canvas_item = Panel.HeaderCanvasItem(DisplayPanelUISettings(document_controller.ui),
-            display_close_control=True,
-            display_edit_control=True,
-            get_font_metrics_fn=typing.cast(typing.Callable[[str, str], UISettings.FontMetrics], self.ui.get_font_metrics))
+                                        display_close_control=True,
+                                        display_edit_control=True,
+                                        get_font_metrics_fn=typing.cast(typing.Callable[[str, str],
+                                        UISettings.FontMetrics], self.ui.get_font_metrics))
 
         def header_double_clicked(x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
             action_context = document_controller._get_action_context()
@@ -2009,7 +2010,6 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             action_context.display_panel = self
             action_context.display_item = self.display_item
             document_controller.perform_action_in_context("window.open_title_edit", action_context)
-
 
         self.__header_canvas_item.on_select_pressed = self._select
         self.__header_canvas_item.on_drag_pressed = self.__handle_begin_drag

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1900,11 +1900,15 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         self.__content_canvas_item.on_focus_changed = self.set_focused
         self.__content_canvas_item.on_context_menu_event = self.__handle_context_menu_event
 
-        self.__header_canvas_item = Panel.HeaderCanvasItem(DisplayPanelUISettings(document_controller.ui), display_close_control=True)
+        self.__header_canvas_item = Panel.HeaderCanvasItem(DisplayPanelUISettings(document_controller.ui),
+            display_close_control=True,
+            display_edit_control=True,
+            get_font_metrics_fn=typing.cast(typing.Callable[[str, str], UISettings.FontMetrics], self.ui.get_font_metrics))
 
         def header_double_clicked(x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
             action_context = document_controller._get_action_context()
             action_context.display_panel = self
+            action_context.display_item = self.display_item
             document_controller.perform_action_in_context("window.open_title_edit", action_context)
             return True
 
@@ -2000,9 +2004,17 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 command = workspace_controller.remove_display_panel(self)
                 document_controller.push_undo_command(command)
 
+        def edit() -> None:
+            action_context = document_controller._get_action_context()
+            action_context.display_panel = self
+            action_context.display_item = self.display_item
+            document_controller.perform_action_in_context("window.open_title_edit", action_context)
+
+
         self.__header_canvas_item.on_select_pressed = self._select
         self.__header_canvas_item.on_drag_pressed = self.__handle_begin_drag
         self.__header_canvas_item.on_close_clicked = close
+        self.__header_canvas_item.on_edit_clicked = edit
 
         ui = document_controller.ui
 

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -6,7 +6,7 @@ import dataclasses
 import functools
 import gettext
 import logging
-# import platform
+import platform
 import sys
 import threading
 import typing
@@ -360,7 +360,7 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__mouse_pressed_position: typing.Optional[Geometry.IntPoint] = None
         self.__edit_control_rect: typing.Optional[Geometry.IntRect] = None
         self.__close_control_rect: typing.Optional[Geometry.IntRect] = None
-        self.__get_font_metrics:typing.Optional[typing.Callable[[str, str], UISettings.FontMetrics]] = None
+        self.__get_font_metrics: typing.Optional[typing.Callable[[str, str], UISettings.FontMetrics]] = None
 
         if get_font_metrics_fn:
             self.__get_font_metrics = get_font_metrics_fn
@@ -498,7 +498,6 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
             return self.on_context_menu_clicked(x, y, gx, gy)
         return False
 
-
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> typing.Optional[CanvasItem.BaseComposer]:
         return HeaderCanvasItemComposer(self, self.sizing, composer_cache, self.title, self.__display_close_control, self.__start_header_color, self.__end_header_color)
 
@@ -511,9 +510,10 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
         else:
             self.__edit_control_rect = Geometry.IntRect.from_tlhw(0, 0, 0, 0)
 
-    def _draw_close_control_mac(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        self._draw_close_control_windows(drawing_context)
-    def _draw_close_control_linux(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _draw_controls_mac(self, drawing_context: DrawingContext.DrawingContext) -> None:
+        self._draw_controls_windows(drawing_context)
+
+    def _draw_controls_linux(self, drawing_context: DrawingContext.DrawingContext) -> None:
         self._draw_controls_windows(drawing_context)
 
     def _draw_close_control_windows(self, drawing_context: DrawingContext.DrawingContext) -> typing.Optional[Geometry.IntRect]:
@@ -537,7 +537,7 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
                                  close_box_top - control_margin_y,
                                  close_box_left - control_margin_x,
                                  control_size + 2 * control_margin_y,
-                                 control_width_with_margin) #  Rectangle containing bounds of the control
+                                 control_width_with_margin)  # Rectangle containing bounds of the control
             with drawing_context.saver():
                 drawing_context.begin_path()
                 drawing_context.move_to(close_box_left, close_box_top)
@@ -570,11 +570,10 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
                     font_metrics.height,
                     font_metrics.width)
             else:
-                 # Without knowing how big the text is, need to do a clunky fallback
-                 # Close button and pencil is roughly 40 pixels wide
+                # Without knowing how big the text is, need to do a clunky fallback
+                # Close button and pencil is roughly 40 pixels wide
                 title_rect = Geometry.IntRect.from_tlhw(0, 40, canvas_size.height, canvas_size.width - 80)
         return title_rect
-
 
     def _draw_edit_button(self, drawing_context: DrawingContext.DrawingContext, title_rect: typing.Optional[Geometry.IntRect]) -> typing.Optional[Geometry.IntRect]:
         control_title_margin = 3
@@ -585,8 +584,8 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
         if canvas_size and title_rect:
             with drawing_context.saver():
                 drawing_context.begin_path()
-                close_box_left = title_rect.right + control_margin + control_title_margin # canvas_size.width - (40 - 7)
-                close_box_right = close_box_left + control_width # canvas_size.width - (40 - 13)
+                close_box_left = title_rect.right + control_margin + control_title_margin  # canvas_size.width - (40 - 7)
+                close_box_right = close_box_left + control_width  # canvas_size.width - (40 - 13)
                 close_box_top = canvas_size.height // 2 - 5
                 close_box_bottom = canvas_size.height // 2 + 5
                 drawing_context.move_to(close_box_left, close_box_bottom)
@@ -604,6 +603,7 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
             control_rect = Geometry.IntRect.from_tlhw(close_box_top - control_margin, close_box_left - control_margin, control_width + 2 * control_margin, control_width + 2 * control_margin)
             self.__edit_control_rect = control_rect
         return control_rect
+
     def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
         canvas_size = self.canvas_size
         if canvas_size:
@@ -631,8 +631,8 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
             with drawing_context.saver():
                 drawing_context.begin_path()
                 # line is adjust 1/2 pixel down to align to pixel boundary
-                drawing_context.move_to(0, canvas_size.height-0.5)
-                drawing_context.line_to(canvas_size.width, canvas_size.height-0.5)
+                drawing_context.move_to(0, canvas_size.height - 0.5)
+                drawing_context.line_to(canvas_size.width, canvas_size.height - 0.5)
                 drawing_context.stroke_style = self.__bottom_stroke_style
                 drawing_context.stroke()
 
@@ -648,14 +648,12 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.stroke()
 
             if self.__display_close_control:
-                self._draw_controls_windows(drawing_context)
-                # match platform.system():
-                #    case "Darwin": #  MAC
-                #        self._draw_close_control_mac(drawing_context)
-                #    case "Linux":
-                #        self._draw_close_control_linux(drawing_context)
-                #    case _: #  Default to Windows
-                #        self._draw_controls_windows(drawing_context)
+                if platform.system() == "Darwin":  # Mac
+                    self._draw_controls_mac(drawing_context)
+                elif platform.system() == "Linux":
+                    self._draw_controls_linux(drawing_context)
+                else:
+                    self._draw_controls_windows(drawing_context)
 
 
 class PanelSectionFactory(typing.Protocol):

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -6,7 +6,6 @@ import dataclasses
 import functools
 import gettext
 import logging
-import platform
 import sys
 import threading
 import typing
@@ -498,25 +497,21 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
             return self.on_context_menu_clicked(x, y, gx, gy)
         return False
 
+
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> typing.Optional[CanvasItem.BaseComposer]:
         return HeaderCanvasItemComposer(self, self.sizing, composer_cache, self.title, self.__display_close_control, self.__start_header_color, self.__end_header_color)
 
 
-    def _draw_controls_windows(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        self.__close_control_rect = self._draw_close_control_windows(drawing_context)
+
+    def _draw_controls(self, drawing_context: DrawingContext.DrawingContext) -> None:
+        self.__close_control_rect = self._draw_close_control(drawing_context)
         title_rect = self._draw_title_text(drawing_context)
         if title_rect and title_rect.width > 0:
             self.__edit_control_rect = self._draw_edit_button(drawing_context, title_rect)
         else:
             self.__edit_control_rect = Geometry.IntRect.from_tlhw(0, 0, 0, 0)
 
-    def _draw_controls_mac(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        self._draw_controls_windows(drawing_context)
-
-    def _draw_controls_linux(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        self._draw_controls_windows(drawing_context)
-
-    def _draw_close_control_windows(self, drawing_context: DrawingContext.DrawingContext) -> typing.Optional[Geometry.IntRect]:
+    def _draw_close_control(self, drawing_context: DrawingContext.DrawingContext) -> typing.Optional[Geometry.IntRect]:
         control_size = 6
         control_margin_x = 7
         control_width_with_margin = 2 * control_margin_x + control_size
@@ -533,11 +528,10 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
             if control_margin_y > control_margin_x:
                 control_margin_y = control_margin_x
 
-            close_rect = Geometry.IntRect.from_tlhw(
-                                 close_box_top - control_margin_y,
-                                 close_box_left - control_margin_x,
-                                 control_size + 2 * control_margin_y,
-                                 control_width_with_margin)  # Rectangle containing bounds of the control
+            close_rect = Geometry.IntRect.from_tlhw(close_box_top - control_margin_y,
+                                                    close_box_left - control_margin_x,
+                                                    control_size + 2 * control_margin_y,
+                                                    control_width_with_margin)  # Rectangle containing bounds of the control
             with drawing_context.saver():
                 drawing_context.begin_path()
                 drawing_context.move_to(close_box_left, close_box_top)
@@ -648,12 +642,7 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.stroke()
 
             if self.__display_close_control:
-                if platform.system() == "Darwin":  # Mac
-                    self._draw_controls_mac(drawing_context)
-                elif platform.system() == "Linux":
-                    self._draw_controls_linux(drawing_context)
-                else:
-                    self._draw_controls_windows(drawing_context)
+                self._draw_controls(drawing_context)
 
 
 class PanelSectionFactory(typing.Protocol):

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -6,7 +6,7 @@ import dataclasses
 import functools
 import gettext
 import logging
-import platform
+# import platform
 import sys
 import threading
 import typing
@@ -648,13 +648,14 @@ class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.stroke()
 
             if self.__display_close_control:
-                match platform.system():
-                    case "Darwin": #  MAC
-                        self._draw_close_control_mac(drawing_context)
-                    case "Linux":
-                        self._draw_close_control_linux(drawing_context)
-                    case _: #  Default to Windows
-                        self._draw_controls_windows(drawing_context)
+                self._draw_controls_windows(drawing_context)
+                # match platform.system():
+                #    case "Darwin": #  MAC
+                #        self._draw_close_control_mac(drawing_context)
+                #    case "Linux":
+                #        self._draw_close_control_linux(drawing_context)
+                #    case _: #  Default to Windows
+                #        self._draw_controls_windows(drawing_context)
 
 
 class PanelSectionFactory(typing.Protocol):


### PR DESCRIPTION
re Issue #1028
Added in a edit control, just to the right of the rendered title. Created local rectangles saving the location of the close and edit titles, and refactored the click handler to check the rectangles rather than absolute values. Broke out the rendering code into sections to allow easier refactoring for different display modes for platforms. Currently all platforms still use the windows rendering mode.