### PR TITLE
2024 09 10 pre compositor

### DIFF
--- a/nion/swift/DataItemThumbnailWidget.py
+++ b/nion/swift/DataItemThumbnailWidget.py
@@ -16,6 +16,7 @@ from nion.swift.model import DocumentModel
 from nion.ui import CanvasItem
 from nion.ui import UserInterface
 from nion.ui import Widgets
+from nion.ui import CanvasItem
 from nion.utils import Geometry
 from nion.utils import Process
 from nion.utils import ReferenceCounting
@@ -52,34 +53,41 @@ class AbstractThumbnailSource:
         return False, None
 
 
-class BitmapOverlayCanvasItem(CanvasItem.CanvasItemComposition):
-
+class BitmapOverlayCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
-        self.focusable = True
-        self.__dropping = False
-        self.__focused = False
-        self.wants_drag_events = True
-        self.wants_mouse_events = True
-        self.__drag_start: typing.Optional[Geometry.IntPoint] = None
-        self.on_drop_mime_data: typing.Optional[typing.Callable[[UserInterface.MimeData, int, int], str]] = None
-        self.on_delete: typing.Optional[typing.Callable[[], None]] = None
-        self.on_drag_pressed: typing.Optional[typing.Callable[[int, int, UserInterface.KeyboardModifiers], None]] = None
-        self.active = False
-
-    def close(self) -> None:
-        self.on_drop_mime_data = None
-        self.on_delete = None
-        self.on_drag_pressed = None
-        super().close()
+        self.__is_active = False
+        self.__is_focused = False
+        self.__is_dropping = False
 
     @property
-    def focused(self) -> bool:
-        return self.__focused
+    def is_active(self) -> bool:
+        return self.__is_active
 
-    def _set_focused(self, focused: bool) -> None:
-        if self.__focused != focused:
-            self.__focused = focused
+    @is_active.setter
+    def is_active(self, value: bool) -> None:
+        if value != self.__is_active:
+            self.__is_active = value
+            self.update()
+
+    @property
+    def is_focused(self) -> bool:
+        return self.__is_focused
+
+    @is_focused.setter
+    def is_focused(self, value: bool) -> None:
+        if value != self.__is_focused:
+            self.__is_focused = value
+            self.update()
+
+    @property
+    def is_dropping(self) -> bool:
+        return self.__is_dropping
+
+    @is_dropping.setter
+    def is_dropping(self, value: bool) -> None:
+        if value != self.__is_dropping:
+            self.__is_dropping = value
             self.update()
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
@@ -88,19 +96,19 @@ class BitmapOverlayCanvasItem(CanvasItem.CanvasItemComposition):
         canvas_size = self.canvas_size
         if canvas_size:
             focused_style = "#3876D6"  # TODO: platform dependent
-            if self.active:
+            if self.__is_active:
                 with drawing_context.saver():
                     drawing_context.begin_path()
                     drawing_context.round_rect(2, 2, 6, 6, 3)
                     drawing_context.fill_style = "rgba(0, 255, 0, 0.80)"
                     drawing_context.fill()
-            if self.__dropping:
+            if self.__is_dropping:
                 with drawing_context.saver():
                     drawing_context.begin_path()
                     drawing_context.rect(0, 0, canvas_size.width, canvas_size.height)
                     drawing_context.fill_style = "rgba(255, 0, 0, 0.10)"
                     drawing_context.fill()
-            if self.focused:
+            if self.__is_focused:
                 stroke_style = focused_style
                 drawing_context.begin_path()
                 drawing_context.rect(2, 2, canvas_size.width - 4, canvas_size.height - 4)
@@ -109,14 +117,52 @@ class BitmapOverlayCanvasItem(CanvasItem.CanvasItemComposition):
                 drawing_context.line_width = 4.0
                 drawing_context.stroke()
 
+
+class BitmapOverlayCanvasItemComposition(CanvasItem.CanvasItemComposition):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.focusable = True
+        self.wants_drag_events = True
+        self.wants_mouse_events = True
+        self.__drag_start: typing.Optional[Geometry.IntPoint] = None
+        self.on_drop_mime_data: typing.Optional[typing.Callable[[UserInterface.MimeData, int, int], str]] = None
+        self.on_delete: typing.Optional[typing.Callable[[], None]] = None
+        self.on_drag_pressed: typing.Optional[typing.Callable[[int, int, UserInterface.KeyboardModifiers], None]] = None
+        self.__overlay_canvas_item = BitmapOverlayCanvasItem()
+        self.add_canvas_item(self.__overlay_canvas_item)
+
+    def close(self) -> None:
+        self.on_drop_mime_data = None
+        self.on_delete = None
+        self.on_drag_pressed = None
+        super().close()
+
+    @property
+    def active(self) -> bool:
+        return self.__overlay_canvas_item.is_active
+
+    @active.setter
+    def active(self, value: bool) -> None:
+        self.__overlay_canvas_item.is_active = value
+
+    @property
+    def focused(self) -> bool:
+        return self.__overlay_canvas_item.focused
+
+    def _set_focused(self, focused: bool) -> None:
+        self.__overlay_canvas_item.is_focused = focused
+
+    def update_sizing(self, new_sizing: CanvasItem.Sizing) -> None:
+        super().update_sizing(new_sizing)
+        self.__overlay_canvas_item.update_sizing(new_sizing)
+
     def drag_enter(self, mime_data: UserInterface.MimeData) -> str:
-        self.__dropping = True
-        self.update()
+        self.__overlay_canvas_item.is_dropping = True
         return "ignore"
 
     def drag_leave(self) -> str:
-        self.__dropping = False
-        self.update()
+        self.__overlay_canvas_item.is_dropping = False
         return "ignore"
 
     def drop(self, mime_data: UserInterface.MimeData, x: int, y: int) -> str:
@@ -174,15 +220,16 @@ class ThumbnailCanvasItem(CanvasItem.CanvasItemComposition):
         self.on_delete: typing.Optional[typing.Callable[[], None]] = None
 
         # set up the initial bitmap and overlay canvas items.
-        bitmap_overlay_canvas_item = BitmapOverlayCanvasItem()
+        bitmap_overlay_canvas_item = BitmapOverlayCanvasItemComposition()
         bitmap_canvas_item = CanvasItem.BitmapCanvasItem(background_color="#CCC", border_color="#444")
-        bitmap_overlay_canvas_item.add_canvas_item(bitmap_canvas_item)
+        bitmap_overlay_canvas_item.insert_canvas_item(bitmap_overlay_canvas_item.canvas_items_count - 1, bitmap_canvas_item)
         if size is not None:
             bitmap_canvas_item.update_sizing(bitmap_canvas_item.sizing.with_fixed_size(size))
+            bitmap_overlay_canvas_item.update_sizing(bitmap_overlay_canvas_item.sizing.with_fixed_size(size))
             for overlay_canvas_item in thumbnail_source.overlay_canvas_items:
                 overlay_canvas_item.update_sizing(overlay_canvas_item.sizing.with_fixed_size(size))
         for overlay_canvas_item in thumbnail_source.overlay_canvas_items:
-            bitmap_overlay_canvas_item.add_canvas_item(overlay_canvas_item)
+            bitmap_overlay_canvas_item.insert_canvas_item(bitmap_overlay_canvas_item.canvas_items_count - 1, overlay_canvas_item)
 
         # handle overlay drop callback by forwarding to the callback set by the caller.
         def drop_mime_data(mime_data: UserInterface.MimeData, x: int, y: int) -> str:
@@ -236,9 +283,10 @@ class ThumbnailCanvasItem(CanvasItem.CanvasItemComposition):
         if self.__thumbnail_size is not None:
             for overlay_canvas_item in thumbnail_source.overlay_canvas_items:
                 overlay_canvas_item.update_sizing(overlay_canvas_item.sizing.with_fixed_size(self.__thumbnail_size))
-        self.__bitmap_overlay_canvas_item.remove_all_canvas_items()
+        while self.__bitmap_overlay_canvas_item.canvas_items_count > 1:
+            self.__bitmap_overlay_canvas_item.remove_canvas_item(self.__bitmap_overlay_canvas_item.canvas_items[0])
         for overlay_canvas_item in thumbnail_source.overlay_canvas_items:
-            self.__bitmap_overlay_canvas_item.add_canvas_item(overlay_canvas_item)
+            self.__bitmap_overlay_canvas_item.insert_canvas_item(self.__bitmap_overlay_canvas_item.canvas_items_count - 1, overlay_canvas_item)
         self.__thumbnail_source.on_thumbnail_data_changed = ReferenceCounting.weak_partial(ThumbnailCanvasItem.__thumbnail_data_changed, self)
         self.__thumbnail_data_changed(self.__thumbnail_source.thumbnail_data)
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -503,9 +503,9 @@ def create_display_canvas_item(display_item: DisplayItem.DisplayItem, ui_setting
     elif display_type == "image":
         return ImageCanvasItem.ImageCanvasItem(ui_settings, delegate, event_loop, draw_background)
     elif display_type == "display_script":
-        return DisplayScriptCanvasItem.DisplayScriptCanvasItem(ui_settings, delegate)
+        return DisplayScriptCanvasItem.ScriptDisplayCanvasItem(ui_settings, delegate)
     else:
-        return MissingDataCanvasItem(delegate)
+        return MissingDisplayCanvasItem(delegate)
 
 
 def is_valid_display_type(display_type: str) -> bool:
@@ -979,25 +979,9 @@ class RelatedIconsCanvasItem(CanvasItem.CanvasItemComposition):
                 self.__dependent_display_items.append(dependent_display_item)
 
 
-class MissingDataCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
-    """ Canvas item to draw background_color. """
-    def __init__(self, delegate: typing.Optional[DisplayCanvasItem.DisplayCanvasItemDelegate]) -> None:
+class MissingCanvasItem(CanvasItem.AbstractCanvasItem):
+    def __init__(self) -> None:
         super().__init__()
-        self.__delegate = delegate
-
-    def context_menu_event(self, x: int, y: int, gx: int, gy: int) -> bool:
-        return self.__delegate.show_display_context_menu(gx, gy) if self.__delegate else False
-
-    @property
-    def key_contexts(self) -> typing.Sequence[str]:
-        return ["display_panel"]
-
-    def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> None:
-        display_control_canvas_item.close()
-
-    def handle_auto_display(self) -> bool:
-        # enter key has been pressed
-        return False
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
         # canvas size
@@ -1016,6 +1000,28 @@ class MissingDataCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 drawing_context.line_to(canvas_size.width, 0)
                 drawing_context.stroke_style = "#444"
                 drawing_context.stroke()
+
+
+class MissingDisplayCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
+    """ Canvas item to draw background_color. """
+    def __init__(self, delegate: typing.Optional[DisplayCanvasItem.DisplayCanvasItemDelegate]) -> None:
+        super().__init__()
+        self.__delegate = delegate
+        self.add_canvas_item(MissingCanvasItem())
+
+    def context_menu_event(self, x: int, y: int, gx: int, gy: int) -> bool:
+        return self.__delegate.show_display_context_menu(gx, gy) if self.__delegate else False
+
+    @property
+    def key_contexts(self) -> typing.Sequence[str]:
+        return ["display_panel"]
+
+    def add_display_control(self, display_control_canvas_item: CanvasItem.AbstractCanvasItem, role: typing.Optional[str] = None) -> None:
+        display_control_canvas_item.close()
+
+    def handle_auto_display(self) -> bool:
+        # enter key has been pressed
+        return False
 
 
 class DisplayTracker:

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2038,7 +2038,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         def delete_display_item_adapters(display_item_adapters: typing.Sequence[DataPanel.DisplayItemAdapter]) -> None:
             document_controller.delete_display_items([display_item_adapter.display_item for display_item_adapter in display_item_adapters])
 
-        self.__horizontal_data_grid_controller = DataPanel.DataGridController(document_controller.event_loop, document_controller.ui, self.__filtered_display_item_adapters_model, self.__selection, direction=GridCanvasItem.Direction.Row, wrap=False)
+        self.__horizontal_data_grid_controller = DataPanel.DataGridController(document_controller.ui, self.__filtered_display_item_adapters_model, self.__selection, direction=GridCanvasItem.Direction.Row, wrap=False)
         self.__horizontal_data_grid_controller.on_context_menu_event = self.__handle_context_menu_for_display
         self.__horizontal_data_grid_controller.on_display_item_adapter_double_clicked = double_clicked
         self.__horizontal_data_grid_controller.on_focus_changed = focus_changed
@@ -2046,7 +2046,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         self.__horizontal_data_grid_controller.on_drag_started = data_list_drag_started
         self.__horizontal_data_grid_controller.on_key_pressed = key_pressed
 
-        self.__grid_data_grid_controller = DataPanel.DataGridController(document_controller.event_loop, document_controller.ui, self.__filtered_display_item_adapters_model, self.__selection)
+        self.__grid_data_grid_controller = DataPanel.DataGridController(document_controller.ui, self.__filtered_display_item_adapters_model, self.__selection)
         self.__grid_data_grid_controller.on_context_menu_event = self.__handle_context_menu_for_display
         self.__grid_data_grid_controller.on_display_item_adapter_double_clicked = double_clicked
         self.__grid_data_grid_controller.on_focus_changed = focus_changed

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -369,8 +369,10 @@ class ImageAreaCompositeCanvasItem(CanvasItem.CanvasItemComposition):
 
     @_data_shape.setter
     def _data_shape(self, value: typing.Optional[DataAndMetadata.Shape2dType]) -> None:
-        self.__data_shape = value
-        self.__update_screen_pixel_per_image()
+        if self.__data_shape != value:
+            self.__data_shape = value
+            self.__update_screen_pixel_per_image()
+            self.update()
 
     def __update_screen_pixel_per_image(self) -> None:
         screen_pixel_per_image_pixel = 0.0
@@ -386,7 +388,49 @@ class ImageAreaCompositeCanvasItem(CanvasItem.CanvasItemComposition):
 class ImageAreaCanvasItem(CanvasItem.CanvasItemComposition):
     def __init__(self, content: CanvasItem.AbstractCanvasItem) -> None:
         super().__init__()
+        self.__scroll_area_layout = ImageAreaCanvasItemLayout()
+        self.layout = self.__scroll_area_layout
         self.add_canvas_item(content)
+
+    @property
+    def _data_shape(self) -> typing.Optional[DataAndMetadata.Shape2dType]:
+        return self.__scroll_area_layout._data_shape
+
+    @_data_shape.setter
+    def _data_shape(self, value: typing.Optional[DataAndMetadata.Shape2dType]) -> None:
+        if self.__scroll_area_layout._data_shape != value:
+            self.__scroll_area_layout._data_shape = value
+            self.update()
+
+    @property
+    def _image_zoom(self) -> float:
+        return self.__scroll_area_layout._image_zoom
+
+    @_image_zoom.setter
+    def _image_zoom(self, value: float) -> None:
+        if self.__scroll_area_layout._image_zoom != value:
+            self.__scroll_area_layout._image_zoom = value
+            self.update()
+
+    @property
+    def _image_position(self) -> Geometry.FloatPoint:
+        return self.__scroll_area_layout._image_position
+
+    @_image_position.setter
+    def _image_position(self, value: Geometry.FloatPoint) -> None:
+        if self.__scroll_area_layout._image_position != value:
+            self.__scroll_area_layout._image_position = value
+            self.update()
+
+    @property
+    def _image_canvas_mode(self) -> str:
+        return self.__scroll_area_layout._image_canvas_mode
+
+    @_image_canvas_mode.setter
+    def _image_canvas_mode(self, value: str) -> None:
+        if self.__scroll_area_layout._image_canvas_mode != value:
+            self.__scroll_area_layout._image_canvas_mode = value
+            self.update()
 
     def _repaint_children(self, drawing_context: DrawingContext.DrawingContext, *, immediate: bool = False) -> None:
         # paint the children with the content origin and a clip rect.
@@ -841,9 +885,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__composite_canvas_item.add_canvas_item(self.__bitmap_canvas_item)
         self.__composite_canvas_item.add_canvas_item(self.__graphics_canvas_item)
         # and put the composition into a scroll area
-        self.__scroll_area_layout = ImageAreaCanvasItemLayout()
         self.scroll_area_canvas_item = ImageAreaCanvasItem(self.__composite_canvas_item)
-        self.scroll_area_canvas_item.layout = self.__scroll_area_layout
         # info overlay (scale marker, etc.)
         self.__scale_marker_canvas_item = ScaleMarkerCanvasItem(self.__composite_canvas_item.screen_pixel_per_image_pixel_stream, ui_settings.get_font_metrics)
         info_overlay_row = CanvasItem.CanvasItemComposition()
@@ -946,13 +988,13 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 if self.__image_zoom != image_zoom or self.__image_position != image_position or self.__image_canvas_mode != image_canvas_mode:
                     if image_zoom is not None:
                         self.__image_zoom = image_zoom
-                        self.__scroll_area_layout._image_zoom = self.__image_zoom
+                        self.scroll_area_canvas_item._image_zoom = self.__image_zoom
                     if image_position is not None:
                         self.__image_position = image_position
-                        self.__scroll_area_layout._image_position = self.__image_position
+                        self.scroll_area_canvas_item._image_position = self.__image_position
                     if image_canvas_mode is not None:
                         self.__image_canvas_mode = image_canvas_mode
-                        self.__scroll_area_layout._image_canvas_mode = self.__image_canvas_mode
+                        self.scroll_area_canvas_item._image_canvas_mode = self.__image_canvas_mode
 
                 # if the data changes, update the display.
                 data_shape = display_calibration_info.display_data_shape
@@ -961,7 +1003,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                     self.__display_properties_dirty = False
                     self.__display_calibration_info_dirty = False
                     self.__data_shape = data_shape[0], data_shape[1]
-                    self.__scroll_area_layout._data_shape = self.__data_shape
+                    self.scroll_area_canvas_item._data_shape = self.__data_shape
                     self.__composite_canvas_item._data_shape = self.__data_shape
                     self.__coordinate_system = display_calibration_info.datum_calibrations
                     self.__frame_rate_canvas_item.frame_tick(frame_info.frame_index)

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -4835,7 +4835,7 @@ class DeclarativeImageChooserConstructor:
 
         return None
 
-class CroppedOverlayGraphicCanvasItem(CanvasItem.CanvasItemComposition):
+class CroppedOverlayGraphicCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self, handle_clicked: typing.Callable[[], None]) -> None:
         super().__init__()
         self.wants_mouse_events = True

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -251,6 +251,8 @@ class LinePlotDisplayInfo:
 
             xdata_list = self.xdata_list
 
+            axes = self.axes
+
             for index, display_layer in enumerate(self.__display_layers[0:MAX_LAYER_COUNT]):
                 fill_color_str = display_layer.get("fill_color")
                 stroke_color_str = display_layer.get("stroke_color")
@@ -269,7 +271,7 @@ class LinePlotDisplayInfo:
                             displayed_dimensional_calibration = xdata.dimensional_calibrations[-1]
                             xdata = DataAndMetadata.new_data_and_metadata(scalar_data, intensity_calibration, [displayed_dimensional_calibration])
                     line_graph_layers.append(
-                        LineGraphCanvasItem.LineGraphLayer(xdata, fill_color, stroke_color, stroke_width))
+                        LineGraphCanvasItem.LineGraphLayer(xdata, axes, fill_color, stroke_color, stroke_width))
                     self._has_valid_drawn_graph_data = xdata is not None
             self.__line_graph_layers = line_graph_layers
         return self.__line_graph_layers
@@ -556,23 +558,22 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
             # tell the other canvas items to update
             line_plot_display_info = self.__line_plot_display_info
-            axes = line_plot_display_info.axes
             line_graph_layers = line_plot_display_info.line_graph_layers
             legend_entries = line_plot_display_info.legend_entries
-            self.__line_graph_layers_canvas_item.update_line_graph_layers(line_graph_layers, axes)
+            self.__line_graph_layers_canvas_item.update_line_graph_layers(line_graph_layers)
+            self.__line_graph_regions_canvas_item.update_line_graph_layers(line_graph_layers)
 
             # update the canvas items
             self.__update_legend_origin()
-            self.__line_graph_regions_canvas_item.set_calibrated_data(self.line_graph_layers_canvas_item.calibrated_data)
             if self.__legend_entries != legend_entries:
                 self.__legend_entries = legend_entries
                 self.__line_graph_legend_canvas_item.set_legend_entries(legend_entries)
                 self.__line_graph_outer_left_legend.set_legend_entries(legend_entries)
                 self.__line_graph_outer_right_legend.set_legend_entries(legend_entries)
+            axes = line_plot_display_info.axes
             if not are_axes_equal(self.__axes, axes):
                 self.__axes = axes
                 self.__line_graph_background_canvas_item.set_axes(axes)
-                self.__line_graph_regions_canvas_item.set_axes(axes)
                 self.__line_graph_frame_canvas_item.set_draw_frame(bool(axes))
                 self.__line_graph_vertical_axis_label_canvas_item.set_axes(axes)
                 self.__line_graph_vertical_axis_scale_canvas_item.set_axes(axes)

--- a/nion/swift/Panel.py
+++ b/nion/swift/Panel.py
@@ -230,7 +230,7 @@ class OutputPanel(Panel):
         super().close()
 
 
-class HeaderCanvasItem(CanvasItem.CanvasItemComposition):
+class HeaderCanvasItem(CanvasItem.AbstractCanvasItem):
 
     # header_height = 20 if sys.platform == "win32" else 22
 

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1168,7 +1168,7 @@ class TestDisplayPanelClass(unittest.TestCase):
     def test_1d_data_with_zero_dimensions_display_fails_without_exception(self):
         self.data_item.set_data(numpy.zeros((0, )))
         # display panel should not have any display_canvas_item now since data is not valid
-        self.assertIsInstance(self.display_panel.display_canvas_item, DisplayPanel.MissingDataCanvasItem)
+        self.assertIsInstance(self.display_panel.display_canvas_item, DisplayPanel.MissingDisplayCanvasItem)
         # thumbnails and processors
         thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.document_controller.ui, self.display_item)
         with thumbnail_source.ref():
@@ -1180,7 +1180,7 @@ class TestDisplayPanelClass(unittest.TestCase):
     def test_2d_data_with_zero_dimensions_display_fails_without_exception(self):
         self.data_item.set_data(numpy.zeros((0, 0)))
         # display panel should not have any display_canvas_item now since data is not valid
-        self.assertIsInstance(self.display_panel.display_canvas_item, DisplayPanel.MissingDataCanvasItem)
+        self.assertIsInstance(self.display_panel.display_canvas_item, DisplayPanel.MissingDisplayCanvasItem)
         # thumbnails and processors
         thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.document_controller.ui, self.display_item)
         with thumbnail_source.ref():

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1126,7 +1126,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         width, height = 640, 480
         display_panel = TestDisplayPanel()
         def get_font_metrics(a, b): return UserInterface.FontMetrics(0, 0, 0, 0, 0)
-        overlay = DisplayPanel.DisplayPanelOverlayCanvasItem(get_font_metrics)
+        overlay = DisplayPanel.DisplayPanelOverlayCanvasItemComposition(get_font_metrics)
         overlay.on_drag_enter = display_panel.handle_drag_enter
         overlay.on_drag_move = display_panel.handle_drag_move
         overlay.on_drop = display_panel.handle_drop
@@ -1150,7 +1150,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         width, height = 640, 480
         display_panel = TestDisplayPanel()
         def get_font_metrics(a, b): return UserInterface.FontMetrics(0, 0, 0, 0, 0)
-        overlay = DisplayPanel.DisplayPanelOverlayCanvasItem(get_font_metrics)
+        overlay = DisplayPanel.DisplayPanelOverlayCanvasItemComposition(get_font_metrics)
         overlay.on_drag_enter = display_panel.handle_drag_enter
         overlay.on_drag_move = display_panel.handle_drag_move
         overlay.on_drop = display_panel.handle_drop

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -306,8 +306,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes
             drawing_context = DrawingContext.DrawingContext()
-            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.set_axes(axes)
+            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
             line_graph_layer.draw_fills(drawing_context)
             line_graph_layer.draw_strokes(drawing_context)
@@ -330,8 +329,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             axes = display_panel.display_canvas_item._axes
             self.assertEqual(axes.data_style, "log")
             drawing_context = DrawingContext.DrawingContext()
-            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.set_axes(axes)
+            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
             line_graph_layer.draw_fills(drawing_context)
             line_graph_layer.draw_strokes(drawing_context)
@@ -410,8 +408,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes
             drawing_context = DrawingContext.DrawingContext()
-            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.set_axes(axes)
+            line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
             line_graph_layer.draw_fills(drawing_context)
             line_graph_layer.draw_strokes(drawing_context)


### PR DESCRIPTION
- **Refactor thumnail overlay to draw adornments separately from composition.**
- **Change HeaderCanvasItem to subclass AbstractCanvasItem to prepare for switch to composer.**
- **Refactor display panel overlay to draw adornments separately from composition.**
- **Eliminate repaint methods from display panel canvas items by moving into non-composition items.**
- **Consolidate layout into ImageAreaCanvasItem.**
- **Simplify axes and legend handling to avoid unnecessary measuring/sizing/updates.**
- **Make LineGraphLayer read-only. Preparation for compositor style drawing.**
- **Simplify line plot channel graphic to not be dependent on data.**
- **Simplify data panel again to thread-safe update instead of using main thread.**

I'm planning on merging these refactorings required for upcoming canvas drawing changes soon - please review if you want.
