### PR TITLE
2024 09 10 compositor

### DIFF
--- a/nion/swift/DisplayCanvasItem.py
+++ b/nion/swift/DisplayCanvasItem.py
@@ -119,6 +119,39 @@ class DisplayCanvasItem(CanvasItem.CanvasItemComposition):
     def update_display_data_delta(self, display_data_delta: DisplayItem.DisplayDataDelta) -> None: ...
 
 
+class FrameRateCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, fps: str, fps2: str, fps3: str) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__fps = fps
+        self.__fps2 = fps2
+        self.__fps3 = fps3
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        fps = self.__fps
+        fps2 = self.__fps2
+        fps3 = self.__fps3
+        with drawing_context.saver():
+            drawing_context.translate(canvas_bounds.left, canvas_bounds.top)
+            font = "normal 11px serif"
+            text_pos = canvas_bounds.top_left
+            drawing_context.begin_path()
+            drawing_context.move_to(text_pos.x, text_pos.y)
+            drawing_context.line_to(text_pos.x + 200, text_pos.y)
+            drawing_context.line_to(text_pos.x + 200, text_pos.y + 60)
+            drawing_context.line_to(text_pos.x, text_pos.y + 60)
+            drawing_context.close_path()
+            drawing_context.fill_style = "rgba(255, 255, 255, 0.6)"
+            drawing_context.fill()
+            drawing_context.font = font
+            drawing_context.text_baseline = "middle"
+            drawing_context.text_align = "left"
+            drawing_context.fill_style = "#000"
+            drawing_context.fill_text("display:" + fps, text_pos.x + 8, text_pos.y + 10)
+            drawing_context.fill_text("frame:" + fps2, text_pos.x + 8, text_pos.y + 30)
+            drawing_context.fill_text("update:" + fps3, text_pos.x + 8, text_pos.y + 50)
+            drawing_context.statistics("display")
+
+
 class FrameRateCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
@@ -149,31 +182,11 @@ class FrameRateCanvasItem(CanvasItem.AbstractCanvasItem):
             Utility.fps_tick("update_" + self.__display_frame_rate_id)
             self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        super()._repaint(drawing_context)
-        display_frame_rate_id = self.__display_frame_rate_id
-        canvas_bounds = self.canvas_bounds
-        if canvas_bounds and display_frame_rate_id:
-            Utility.fps_tick("display_" + display_frame_rate_id)
-            fps = Utility.fps_get("display_" + display_frame_rate_id)
-            fps2 = Utility.fps_get("frame_" + display_frame_rate_id)
-            fps3 = Utility.fps_get("update_" + display_frame_rate_id)
-            with drawing_context.saver():
-                font = "normal 11px serif"
-                text_pos = canvas_bounds.top_left
-                drawing_context.begin_path()
-                drawing_context.move_to(text_pos.x, text_pos.y)
-                drawing_context.line_to(text_pos.x + 200, text_pos.y)
-                drawing_context.line_to(text_pos.x + 200, text_pos.y + 60)
-                drawing_context.line_to(text_pos.x, text_pos.y + 60)
-                drawing_context.close_path()
-                drawing_context.fill_style = "rgba(255, 255, 255, 0.6)"
-                drawing_context.fill()
-                drawing_context.font = font
-                drawing_context.text_baseline = "middle"
-                drawing_context.text_align = "left"
-                drawing_context.fill_style = "#000"
-                drawing_context.fill_text("display:" + fps, text_pos.x + 8, text_pos.y + 10)
-                drawing_context.fill_text("frame:" + fps2, text_pos.x + 8, text_pos.y + 30)
-                drawing_context.fill_text("update:" + fps3, text_pos.x + 8, text_pos.y + 50)
-                drawing_context.statistics("display")
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> typing.Optional[CanvasItem.BaseComposer]:
+        if self.__display_frame_rate_id:
+            fps = Utility.fps_get("display_" + self.__display_frame_rate_id)
+            fps2 = Utility.fps_get("frame_" + self.__display_frame_rate_id)
+            fps3 = Utility.fps_get("update_" + self.__display_frame_rate_id)
+            return FrameRateCanvasItemComposer(self, self.sizing, composer_cache, fps, fps2, fps3)
+        return CanvasItem.EmptyCanvasItemComposer(self, self.sizing, composer_cache)
+

--- a/nion/swift/DisplayCanvasItem.py
+++ b/nion/swift/DisplayCanvasItem.py
@@ -153,6 +153,14 @@ class FrameRateCanvasItemComposer(CanvasItem.BaseComposer):
 
 
 class FrameRateCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Display frame rate in the display canvas item.
+
+    There are three rates that are tracked. The "display" rate is the rate at which the display is updated and is
+    "ticked" when low level repaint occurs, which generally happens once per update. The "frame" rate is the rate at
+    the frame index changes. The "update" rate is the rate at which the display is updated and is "ticked" when the
+    display is updated. It is different from the "display" since it is just a request to update; whereas the "display"
+    is the actual repaint being performed.
+    """
     def __init__(self) -> None:
         super().__init__()
         self.__display_frame_rate_id: typing.Optional[str] = None

--- a/nion/swift/DisplayScriptCanvasItem.py
+++ b/nion/swift/DisplayScriptCanvasItem.py
@@ -10,7 +10,6 @@ import typing
 # local libraries
 from nion.swift import DisplayCanvasItem
 from nion.swift.model import UISettings
-from nion.swift.model import Utility
 from nion.ui import CanvasItem
 from nion.ui import DrawingContext
 from nion.utils import Geometry
@@ -43,6 +42,18 @@ class DisplayScriptCanvasItemDelegate(typing.Protocol):
     def tool_mode(self) -> str: return str()
 
 
+class DrawingContextCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, drawing_context: typing.Optional[DrawingContext.DrawingContext]) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__drawing_context = drawing_context
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        if self.__drawing_context:
+            with drawing_context.saver():
+                drawing_context.translate(canvas_bounds.left, canvas_bounds.top)
+                drawing_context.add(self.__drawing_context)
+
+
 class DrawingContextCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
@@ -52,9 +63,8 @@ class DrawingContextCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__drawing_context = drawing_context
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        if self.__drawing_context:
-            drawing_context.add(self.__drawing_context)
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> typing.Optional[CanvasItem.BaseComposer]:
+        return DrawingContextCanvasItemComposer(self, self.sizing, composer_cache, self.__drawing_context)
 
 
 class ScriptDisplayCanvasItem(DisplayCanvasItem.DisplayCanvasItem):

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -506,7 +506,7 @@ class ImageAreaCanvasItem(CanvasItem.CanvasItemComposition):
     @_image_zoom.setter
     def _image_zoom(self, value: float) -> None:
         if self.__scroll_area_layout.image_zoom != value:
-            self.__scroll_area_layout_image_zoom = value
+            self.__scroll_area_layout.image_zoom = value
             self.update()
 
     @property

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -759,8 +759,11 @@ class LineGraphLayerCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__is_fill = False
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
-        assert self.__line_graph_layer
-        return LineGraphLayerCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__line_graph_layer, self.__is_fill)
+        # the line graph can be in a partially updated state, so check if the layer is valid yet.
+        if self.__line_graph_layer:
+            return LineGraphLayerCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__line_graph_layer, self.__is_fill)
+        else:
+            return CanvasItem.EmptyCanvasItemComposer(self, self.layout_sizing, composer_cache)
 
     @property
     def _xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -590,7 +590,6 @@ class LineGraphBackgroundCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
-        self._invalidate_composer()
         self.update()
 
 
@@ -777,7 +776,6 @@ class LineGraphLayerCanvasItem(CanvasItem.AbstractCanvasItem):
         if self.__line_graph_layer != line_graph_layer or self.__is_fill != is_fill:
             self.__line_graph_layer = line_graph_layer
             self.__is_fill = is_fill
-            self._invalidate_composer()
             self.update()
 
     @property
@@ -930,13 +928,11 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
         axes = line_graph_layers[0].axes if line_graph_layers else None
         if self.__axes != axes:
             self.__axes = axes
-            self._invalidate_composer()
             self.update()
 
     def set_regions(self, regions: typing.Sequence[RegionInfo]) -> None:
         if (self.__regions is None and regions is not None) or (self.__regions != regions):
             self.__regions = list(regions)
-            self._invalidate_composer()
             self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -963,7 +959,6 @@ class LineGraphFrameCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_draw_frame(self, draw_frame: bool) -> None:
         if self.__draw_frame != draw_frame:
             self.__draw_frame = draw_frame
-            self._invalidate_composer()
             self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1007,7 +1002,6 @@ class LineGraphHorizontalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1049,7 +1043,6 @@ class LineGraphHorizontalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1099,13 +1092,11 @@ class LineGraphHorizontalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
                 new_sizing = new_sizing.with_minimum_height(self.__font_size + 4)
                 new_sizing = new_sizing.with_maximum_height(self.__font_size + 4)
         self.update_sizing(new_sizing)
-        self._invalidate_composer()
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
         self.size_to_content()
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1148,7 +1139,6 @@ class LineGraphVerticalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1287,13 +1277,11 @@ class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
             new_sizing = new_sizing.with_maximum_width(max_width)
 
         self.update_sizing(new_sizing)
-        self._invalidate_composer()
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
         self.size_to_content()
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1349,13 +1337,11 @@ class LineGraphVerticalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
                 new_sizing = new_sizing.with_minimum_width(self.__font_size + 4)
                 new_sizing = new_sizing.with_maximum_width(self.__font_size + 4)
         self.update_sizing(new_sizing)
-        self._invalidate_composer()
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
         self.size_to_content()
-        self._invalidate_composer()
         self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
@@ -1544,7 +1530,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
 
             new_sizing = self.copy_sizing().with_fixed_width(legend_width).with_fixed_height(legend_height)
             self.update_sizing(new_sizing)
-            self._invalidate_composer()
 
             self.__needs_size_to_content = False
 
@@ -1555,7 +1540,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         # assume this is only called when legend entries changes
         self.__legend_entries = list(legend_entries)
         self.__generate_effective_entries()
-        self._invalidate_composer()
         self.update()
 
     def __get_legend_index(self, x: int, y: int, ignore_y: bool = False, insertion: bool = False) -> int:
@@ -1633,7 +1617,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         if old_entry != self.__entry_to_insert:
             # update effective entries and the display if it changed
             self.__generate_effective_entries()
-            self._invalidate_composer()
             self.update()
         return "ignore"
 
@@ -1648,7 +1631,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
                 self.__dragging_index = i
                 self._drag_start_position = Geometry.IntPoint(x=x, y=y)
                 self.__entry_to_insert = i
-                self._invalidate_composer()
                 self.update()
                 return True
         return False
@@ -1659,7 +1641,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self._drag_start_position = None
         self.__entry_to_insert = None
         self.__generate_effective_entries()
-        self._invalidate_composer()
         self.update()
         return True
 
@@ -1673,7 +1654,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__foreign_legend_uuid_and_index = None
         # when we leave the drag area, update the effective entries because we're no longer previewing a shift
         self.__generate_effective_entries()
-        self._invalidate_composer()
         self.update()
         return "ignore"
 
@@ -1687,14 +1667,12 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
                 self.__dragging_index = legend_data["index"]
                 self.__mouse_pressed_for_dragging = True
                 self.__generate_effective_entries()
-                self._invalidate_composer()
                 self.update()
             else:
                 # if we aren't the source, setup foreign_legend_* and update the display
                 assert display_item
                 self.__foreign_legend_entry = LegendEntry(label=legend_data["label"], fill_color=legend_data["fill_color"], stroke_color=legend_data["stroke_color"])
                 self.__foreign_legend_uuid_and_index = (display_item, typing.cast(int, legend_data["index"]))
-                self._invalidate_composer()
                 self.update()
             return "move"
         return "ignore"
@@ -1704,7 +1682,6 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self._drag_start_position = None
         self.__mouse_pressed_for_dragging = False
         self.__mouse_dragging = False
-        self._invalidate_composer()
 
         if mime_data.has_format(MimeTypes.LAYER_MIME_TYPE):
             legend_data, source_display_item = MimeTypes.mime_data_get_layer(mime_data, self.__delegate.get_document_model())

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -15,6 +15,7 @@ import gettext
 import math
 import re
 import typing
+import weakref
 
 # third party libraries
 import numpy
@@ -173,6 +174,22 @@ class LineGraphAxes:
 
     def __repr__(self) -> str:
         return f"Axes {self.drawn_left_channel}:{self.drawn_right_channel} [{self.calibrated_data_min},{self.calibrated_data_max} {self.x_calibration} {self.y_calibration} {self.data_style} {self.data_scale}"
+
+    def __eq__(self, other: typing.Any) -> bool:
+        if not isinstance(other, LineGraphAxes):
+            return False
+        return (self.data_scale == other.data_scale and
+                self.__uncalibrated_left_channel == other.__uncalibrated_left_channel and
+                self.__uncalibrated_right_channel == other.__uncalibrated_right_channel and
+                self.x_calibration == other.x_calibration and
+                self.y_calibration == other.y_calibration and
+                self.data_style == other.data_style and
+                self.__calibrated_data_min == other.__calibrated_data_min and
+                self.__calibrated_data_max == other.__calibrated_data_max and
+                self.__y_ticker == other.__y_ticker)
+
+    def __hash__(self) -> int:
+        return hash((self.data_scale, self.__uncalibrated_left_channel, self.__uncalibrated_right_channel, self.x_calibration, self.y_calibration, self.data_style, self.__calibrated_data_min, self.__calibrated_data_max, self.__y_ticker))
 
     @property
     def y_ticker(self) -> Geometry.Ticker:
@@ -530,24 +547,16 @@ def draw_marker(drawing_context: DrawingContext.DrawingContext, p: Geometry.Floa
             drawing_context.stroke()
 
 
-class LineGraphBackgroundCanvasItem(CanvasItem.AbstractCanvasItem):
-    """Canvas item to draw the line plot background and grid lines."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.__axes: typing.Optional[LineGraphAxes] = None
-        self.draw_grid = True
-        self.background_color = "#FFF"
-
-    def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
+class LineGraphBackgroundCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], draw_grid: bool, background_color: typing.Optional[typing.Union[str, DrawingContext.LinearGradient]]) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
         self.__axes = axes
-        self.update()
+        self.__draw_grid = draw_grid
+        self.__background_color = background_color
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
         axes = self.__axes
-        canvas_bounds = self.canvas_bounds
         if axes and canvas_bounds:
             plot_width = canvas_bounds.width - 1
             plot_height = canvas_bounds.height - 1
@@ -558,73 +567,61 @@ class LineGraphBackgroundCanvasItem(CanvasItem.AbstractCanvasItem):
             y_ticks = axes.calculate_y_ticks(plot_height)
             x_ticks = axes.calculate_x_ticks(plot_width)
 
-            draw_background(drawing_context, canvas_bounds, self.background_color)
+            draw_background(drawing_context, canvas_bounds, self.__background_color)
 
             # draw the horizontal grid lines
-            if self.draw_grid:
+            if self.__draw_grid:
                 draw_horizontal_grid_lines(drawing_context, plot_width, plot_origin_x, y_ticks)
-
-            # draw the vertical grid lines
-            if self.draw_grid:
                 draw_vertical_grid_lines(drawing_context, plot_height, plot_origin_y, x_ticks)
 
 
-class LineGraphLayer:
-    """Represents a layer of the line graph.
+class LineGraphBackgroundCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Canvas item to draw the line plot background and grid lines."""
 
-    xdata is calibrated data.
+    def __init__(self) -> None:
+        super().__init__()
+        self.__axes: typing.Optional[LineGraphAxes] = None
+        self.draw_grid = True
+        self.background_color = "#FFF"
 
-    Tracks the data, calibrated data, axes. Provides methods to calculate the segments and draw fills/strokes separately.
-    """
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphBackgroundCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.draw_grid, self.background_color)
 
-    def __init__(self,
-                 xdata: typing.Optional[DataAndMetadata.DataAndMetadata],
-                 axes: typing.Optional[LineGraphAxes],
-                 fill_color: typing.Optional[Color.Color],
-                 stroke_color: typing.Optional[Color.Color],
-                 stroke_width: typing.Optional[float]) -> None:
-        self.__xdata = xdata
-        self.__fill_color = fill_color
-        self.__stroke_color = stroke_color
-        self.__stroke_width = stroke_width or 0.5
-        self.__canvas_bounds: typing.Optional[Geometry.IntRect] = None
-        self.__calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
-        self.__retained_rebin_1d: typing.Dict[str, typing.Any] = dict()
+    def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
+        # assume this is only called when axes changes
         self.__axes = axes
-        self.__segments: typing.List[LineGraphSegment] = list()
-        self.__baseline = 0.0
+        self._invalidate_composer()
+        self.update()
 
-    @property
-    def fill_color(self) -> typing.Optional[Color.Color]:
-        return self.__fill_color
 
-    @property
-    def stroke_color(self) -> typing.Optional[Color.Color]:
-        return self.__stroke_color
+@dataclasses.dataclass(frozen=True)
+class CalibratedDataAndMetadataCacheItem:
+    xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
+    axes: typing.Optional[LineGraphAxes]
 
-    @property
-    def stroke_width(self) -> float:
-        return self.__stroke_width
+    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LineGraphAxes]]:
+        return id(self.xdata.data) if self.xdata else None, self.axes
 
-    @property
-    def axes(self) -> typing.Optional[LineGraphAxes]:
-        return self.__axes
+    def calculate(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return self.axes.calculate_calibrated_xdata(self.xdata) if self.axes and self.xdata else None
 
-    @property
-    def calibrated_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        if self.__axes and self.__xdata and not self.__calibrated_xdata:
-            self.__calibrated_xdata = self.__axes.calculate_calibrated_xdata(self.__xdata)
-        return self.__calibrated_xdata
 
-    def calculate(self, canvas_bounds: Geometry.IntRect) -> None:
-        # this class is read-only, so we can only calculate once.
-        assert self.__canvas_bounds is None or self.__canvas_bounds == canvas_bounds
+@dataclasses.dataclass(frozen=True)
+class SegmentsCacheItem:
+    calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
+    axes: typing.Optional[LineGraphAxes]
+    canvas_bounds: Geometry.IntRect
+
+    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LineGraphAxes], Geometry.IntRect]:
+        return id(self.calibrated_xdata.data) if self.calibrated_xdata else None, self.axes, self.canvas_bounds
+
+    def calculate(self) -> typing.Tuple[typing.List[LineGraphSegment], float]:
         calibrated_xdata = self.calibrated_xdata
+        axes = self.axes
+        canvas_bounds = self.canvas_bounds
         segments: typing.List[LineGraphSegment] = list()
         baseline = 0.0
-        if calibrated_xdata is not None and self.__axes:
-            axes = self.__axes
-
+        if calibrated_xdata is not None and axes:
             plot_width = canvas_bounds.width - 1
             plot_height = canvas_bounds.height - 1
             plot_origin_x = canvas_bounds.left
@@ -647,19 +644,89 @@ class LineGraphLayer:
                                                           calibrated_data_min, calibrated_data_range,
                                                           calibrated_left_channel,
                                                           calibrated_right_channel, x_calibration,
-                                                          self.__retained_rebin_1d, axes.data_style)
-        self.__segments = segments
-        self.__baseline = baseline
+                                                          None, axes.data_style)
+        return segments, baseline
 
-    def draw_fills(self, drawing_context: DrawingContext.DrawingContext) -> None:
+
+class LineGraphLayer:
+    """Represents a layer of the line graph.
+
+    xdata is calibrated data.
+
+    Tracks the data, calibrated data, axes. Provides methods to calculate the segments and draw fills/strokes separately.
+    """
+
+    def __init__(self,
+                 xdata: typing.Optional[DataAndMetadata.DataAndMetadata],
+                 axes: typing.Optional[LineGraphAxes],
+                 fill_color: typing.Optional[Color.Color],
+                 stroke_color: typing.Optional[Color.Color],
+                 stroke_width: typing.Optional[float]) -> None:
+        self.__xdata = xdata
+        self.__fill_color = fill_color
+        self.__stroke_color = stroke_color
+        self.__stroke_width = stroke_width or 0.5
+        self.__canvas_bounds: typing.Optional[Geometry.IntRect] = None
+        self.__calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
+        self.__axes = axes
+
+    @property
+    def xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return self.__xdata
+
+    @property
+    def fill_color(self) -> typing.Optional[Color.Color]:
+        return self.__fill_color
+
+    @property
+    def stroke_color(self) -> typing.Optional[Color.Color]:
+        return self.__stroke_color
+
+    @property
+    def stroke_width(self) -> float:
+        return self.__stroke_width
+
+    @property
+    def axes(self) -> typing.Optional[LineGraphAxes]:
+        return self.__axes
+
+    def draw_fills(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> typing.Tuple[CanvasItem.CacheValue, ...]:
         if self.fill_color:
-            for segment in self.__segments:
-                segment.fill(drawing_context, self.__baseline, Color.Color(self.fill_color))
+            calibrated_xdata_cache_value = composer_cache.get_cache_value(CalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes))
+            calibrated_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], calibrated_xdata_cache_value.value)
+            segments_cache_value = composer_cache.get_cache_value(SegmentsCacheItem(calibrated_xdata, self.__axes, canvas_bounds))
+            segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
+            for segment in segments:
+                segment.fill(drawing_context, baseline, Color.Color(self.fill_color))
+            return calibrated_xdata_cache_value, segments_cache_value
+        return tuple()
 
-    def draw_strokes(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def draw_strokes(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> typing.Tuple[CanvasItem.CacheValue, ...]:
         if self.stroke_color:
-            for segment in self.__segments:
-                segment.stroke(drawing_context, self.__baseline, Color.Color(self.stroke_color), self.stroke_width)
+            calibrated_xdata_cache_value = composer_cache.get_cache_value(CalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes))
+            calibrated_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], calibrated_xdata_cache_value.value)
+            segments_cache_value = composer_cache.get_cache_value(SegmentsCacheItem(calibrated_xdata, self.__axes, canvas_bounds))
+            segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
+            for segment in segments:
+                segment.stroke(drawing_context, baseline, Color.Color(self.stroke_color), self.stroke_width)
+            return calibrated_xdata_cache_value, segments_cache_value
+        return tuple()
+
+
+class LineGraphLayersCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, line_graph_layers: typing.Sequence[LineGraphLayer]) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__line_graph_layers = list(line_graph_layers)
+        self.__cache_values = list[typing.Tuple[CanvasItem.CacheValue, ...]]()
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        cache_values = list[typing.Tuple[CanvasItem.CacheValue, ...]]()
+        line_graph_layers = list(self.__line_graph_layers)
+        for line_graph_layer in reversed(line_graph_layers):
+            cache_values.append(line_graph_layer.draw_fills(drawing_context, canvas_bounds, composer_cache))
+        for line_graph_layer in reversed(line_graph_layers):
+            cache_values.append(line_graph_layer.draw_strokes(drawing_context, canvas_bounds, composer_cache))
+        self.__cache_values = cache_values
 
 
 class LineGraphLayersCanvasItem(CanvasItem.AbstractCanvasItem):
@@ -672,6 +739,13 @@ class LineGraphLayersCanvasItem(CanvasItem.AbstractCanvasItem):
         super().__init__()
         self.__line_graph_layers: typing.List[LineGraphLayer] = list()
 
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphLayersCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__line_graph_layers)
+
+    @property
+    def _xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return self.__line_graph_layers[0].xdata if self.__line_graph_layers else None
+
     @property
     def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
         return self.__line_graph_layers[0].axes if self.__line_graph_layers else None
@@ -680,70 +754,31 @@ class LineGraphLayersCanvasItem(CanvasItem.AbstractCanvasItem):
         if self.__line_graph_layers != line_graph_layers:
             self.__line_graph_layers.clear()
             self.__line_graph_layers.extend(line_graph_layers)
+            self._invalidate_composer()
             self.update()
 
     @property
     def calibrated_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        # convenience function make older tests run
-        return self.__line_graph_layers[0].calibrated_xdata if len(self.__line_graph_layers) > 0 else None
-
-    @property
-    def calibrated_data(self) -> typing.Optional[DataAndMetadata._ImageDataType]:
-        # convenience function make older tests run
-        calibrated_xdata = self.calibrated_xdata
-        return calibrated_xdata.data if calibrated_xdata else None
-
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        canvas_bounds = self.canvas_bounds
-        if canvas_bounds:
-            line_graph_layers = list(self.__line_graph_layers)
-            for line_graph_layer in reversed(line_graph_layers):
-                line_graph_layer.calculate(canvas_bounds)
-            for line_graph_layer in reversed(line_graph_layers):
-                line_graph_layer.draw_fills(drawing_context)
-            for line_graph_layer in reversed(line_graph_layers):
-                line_graph_layer.draw_strokes(drawing_context)
+        return CalibratedDataAndMetadataCacheItem(self._xdata, self._axes).calculate()
 
 
-class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
-    """Canvas item to draw the line plot itself."""
+class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], regions: typing.Sequence[RegionInfo]) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__cache_values = list[typing.Tuple[CanvasItem.CacheValue, ...]]()
+        self.__axes = axes
+        self.__regions = regions
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.font_size = 12
-        self.__regions: typing.List[RegionInfo] = list()
-        self.__line_graph_layers: typing.List[LineGraphLayer] = list()
-
-    @property
-    def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
-        return self.__line_graph_layers[0].axes if self.__line_graph_layers else None
-
-    def update_line_graph_layers(self, line_graph_layers: typing.Sequence[LineGraphLayer]) -> None:
-        if self.__line_graph_layers != line_graph_layers:
-            self.__line_graph_layers.clear()
-            self.__line_graph_layers.extend(line_graph_layers)
-            self.update()
-
-    def set_regions(self, regions: typing.Sequence[RegionInfo]) -> None:
-        if (self.__regions is None and regions is not None) or (self.__regions != regions):
-            self.__regions = list(regions)
-            self.update()
-
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
-        canvas_size = self.canvas_size
-        if not canvas_size:
-            return
-        assert canvas_size
+        canvas_size = canvas_bounds.size
 
         regions = self.__regions
-        font_size = self.font_size
+        font_size = 12
 
-        axes = self._axes
+        axes = self.__axes
         if axes:
             # extract the data we need for drawing y-axis
-            calibrated_data_min = axes.calibrated_data_min
-            calibrated_data_max = axes.calibrated_data_max
             data_left = axes.drawn_left_channel
             data_right = axes.drawn_right_channel
             data_scale = axes.data_scale
@@ -753,8 +788,6 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
 
             plot_height = canvas_size.height - 1
             plot_origin_y = 0
-
-            calibrated_data_range = calibrated_data_max - calibrated_data_min
 
             def convert_coordinate_to_pixel(canvas_size: Geometry.IntSize, c: float, data_scale: float, data_left: float, data_right: float) -> float:
                 px = c * data_scale
@@ -822,6 +855,45 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
                         drawing_context.fill_text(label, mid_x, level + 6)
 
 
+class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Canvas item to draw the line plot itself."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__regions: typing.List[RegionInfo] = list()
+        self.__axes: typing.Optional[LineGraphAxes] = None
+
+    @property
+    def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
+        return self.__axes
+
+    def update_line_graph_layers(self, line_graph_layers: typing.Sequence[LineGraphLayer]) -> None:
+        axes = line_graph_layers[0].axes if line_graph_layers else None
+        if self.__axes != axes:
+            self.__axes = axes
+            self._invalidate_composer()
+            self.update()
+
+    def set_regions(self, regions: typing.Sequence[RegionInfo]) -> None:
+        if (self.__regions is None and regions is not None) or (self.__regions != regions):
+            self.__regions = list(regions)
+            self._invalidate_composer()
+            self.update()
+
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphRegionsCanvasItemComposer(self, self.layout_sizing, composer_cache, self._axes, self.__regions)
+
+
+class LineGraphFrameCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, draw_frame: bool) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__draw_frame = draw_frame
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        if self.__draw_frame:
+            draw_frame(drawing_context, canvas_bounds.height - 1, canvas_bounds.left, canvas_bounds.top, canvas_bounds.width - 1)
+
+
 class LineGraphFrameCanvasItem(CanvasItem.AbstractCanvasItem):
     """Canvas item to draw the line plot frame."""
 
@@ -832,33 +904,24 @@ class LineGraphFrameCanvasItem(CanvasItem.AbstractCanvasItem):
     def set_draw_frame(self, draw_frame: bool) -> None:
         if self.__draw_frame != draw_frame:
             self.__draw_frame = draw_frame
+            self._invalidate_composer()
             self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        canvas_bounds = self.canvas_bounds
-        if canvas_bounds and self.__draw_frame:
-            draw_frame(drawing_context, canvas_bounds.height - 1, canvas_bounds.left, canvas_bounds.top, canvas_bounds.width - 1)
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphFrameCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__draw_frame)
 
 
-class LineGraphHorizontalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
-    """Canvas item to draw the horizontal tick marks."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.__axes: typing.Optional[LineGraphAxes] = None
-        self.tick_height = 4
-        self.update_sizing(self.sizing.with_fixed_height(self.tick_height))
-
-    def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
+class LineGraphHorizontalAxisTicksCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], tick_height: int) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
         self.__axes = axes
-        self.update()
+        self.tick_height = tick_height
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
+        canvas_size = canvas_bounds.size
         axes = self.__axes
-        canvas_size = self.canvas_size
-        if axes and canvas_size:
+        if axes:
             plot_width = canvas_size.width - 1
             # extract the data we need for drawing x-axis
             x_ticks = axes.calculate_x_ticks(plot_width)
@@ -873,32 +936,41 @@ class LineGraphHorizontalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.stroke()
 
 
-class LineGraphHorizontalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
-    """Canvas item to draw the horizontal scale."""
+class LineGraphHorizontalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Canvas item to draw the horizontal tick marks."""
 
     def __init__(self) -> None:
         super().__init__()
         self.__axes: typing.Optional[LineGraphAxes] = None
-        self.font_size = 12
-        self.update_sizing(self.sizing.with_fixed_height(self.font_size + 4))
+        self.__tick_height = 4
+        self.update_sizing(self.sizing.with_fixed_height(self.__tick_height))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
+        self._invalidate_composer()
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        # draw the data, if any
-        axes = self.__axes
-        canvas_size = self.canvas_size
-        if axes and canvas_size:
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphHorizontalAxisTicksCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__tick_height)
 
+
+class LineGraphHorizontalAxisScaleCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], font_size: int) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__axes = axes
+        self.__font_size = font_size
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        # draw the data, if any
+        canvas_size = canvas_bounds.size
+        axes = self.__axes
+        if axes:
             # extract the data we need for drawing x-axis
             x_ticks = axes.calculate_x_ticks(canvas_size.width - 1)
-
             # draw the tick marks
             with drawing_context.saver():
-                drawing_context.font = "{0:d}px".format(self.font_size)
+                drawing_context.font = "{0:d}px".format(self.__font_size)
                 for x, label in x_ticks:
                     drawing_context.text_align = "center"
                     drawing_context.text_baseline = "middle"
@@ -906,37 +978,35 @@ class LineGraphHorizontalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.fill_text(label, x, canvas_size.height * 0.5)
 
 
-class LineGraphHorizontalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
-    """Canvas item to draw the horizontal label."""
+class LineGraphHorizontalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Canvas item to draw the horizontal scale."""
 
     def __init__(self) -> None:
         super().__init__()
         self.__axes: typing.Optional[LineGraphAxes] = None
-        self.font_size = 12
-        self.update_sizing(self.sizing.with_fixed_height(self.font_size + 4))
-
-    def size_to_content(self) -> None:
-        """ Size the canvas item to the proper height. """
-        new_sizing = self.copy_sizing()
-        new_sizing = new_sizing.with_minimum_height(0)
-        new_sizing = new_sizing.with_maximum_height(0)
-        axes = self.__axes
-        if axes:
-            if axes.x_calibration and axes.x_calibration.units:
-                new_sizing = new_sizing.with_minimum_height(self.font_size + 4)
-                new_sizing = new_sizing.with_maximum_height(self.font_size + 4)
-        self.update_sizing(new_sizing)
+        self.__font_size = 12
+        self.update_sizing(self.sizing.with_fixed_height(self.__font_size + 4))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
-        self.size_to_content()
+        self._invalidate_composer()
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphHorizontalAxisScaleCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)
+
+
+class LineGraphHorizontalAxisLabelCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], font_size: int) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__axes = axes
+        self.__font_size = font_size
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
         axes = self.__axes
-        canvas_size = self.canvas_size
+        canvas_size = canvas_bounds.size
         if axes and canvas_size:
             # draw the horizontal axis
             if axes.x_calibration and axes.x_calibration.units:
@@ -946,8 +1016,65 @@ class LineGraphHorizontalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
                     drawing_context.text_baseline = "middle"
                     drawing_context.fill_style = "#000"
                     value_str = u"({0})".format(axes.x_calibration.units)
-                    drawing_context.font = "{0:d}px".format(self.font_size)
+                    drawing_context.font = "{0:d}px".format(self.__font_size)
                     drawing_context.fill_text(value_str, plot_width * 0.5, canvas_size.height * 0.5)
+
+
+class LineGraphHorizontalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
+    """Canvas item to draw the horizontal label."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__axes: typing.Optional[LineGraphAxes] = None
+        self.__font_size = 12
+        self.update_sizing(self.sizing.with_fixed_height(self.__font_size + 4))
+
+    def size_to_content(self) -> None:
+        """ Size the canvas item to the proper height. """
+        new_sizing = self.copy_sizing()
+        new_sizing = new_sizing.with_minimum_height(0)
+        new_sizing = new_sizing.with_maximum_height(0)
+        axes = self.__axes
+        if axes:
+            if axes.x_calibration and axes.x_calibration.units:
+                new_sizing = new_sizing.with_minimum_height(self.__font_size + 4)
+                new_sizing = new_sizing.with_maximum_height(self.__font_size + 4)
+        self.update_sizing(new_sizing)
+        self._invalidate_composer()
+
+    def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
+        # assume this is only called when axes changes
+        self.__axes = axes
+        self.size_to_content()
+        self._invalidate_composer()
+        self.update()
+
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphHorizontalAxisLabelCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)
+
+
+class LineGraphVerticalAxisTicksCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], tick_width: int) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__axes = axes
+        self.__tick_width = tick_width
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        # draw the data, if any
+        axes = self.__axes
+        canvas_size = canvas_bounds.size
+        if axes:
+            # extract the data we need for drawing y-axis
+            y_ticks = axes.calculate_y_ticks(canvas_size.height - 1)
+            # draw the y_ticks and labels
+            with drawing_context.saver():
+                for y, _, _ in y_ticks:
+                    drawing_context.begin_path()
+                    drawing_context.move_to(canvas_size.width, y)
+                    drawing_context.line_to(canvas_size.width - self.__tick_width, y)
+                    drawing_context.line_width = 1
+                    drawing_context.stroke_style = '#888'
+                    drawing_context.stroke()
 
 
 class LineGraphVerticalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
@@ -956,30 +1083,17 @@ class LineGraphVerticalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
         self.__axes: typing.Optional[LineGraphAxes] = None
-        self.tick_width = 4
-        self.update_sizing(self.sizing.with_fixed_width(self.tick_width))
+        self.__tick_width = 4
+        self.update_sizing(self.sizing.with_fixed_width(self.__tick_width))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
+        self._invalidate_composer()
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        # draw the data, if any
-        axes = self.__axes
-        canvas_size = self.canvas_size
-        if axes and canvas_size:
-            # extract the data we need for drawing y-axis
-            y_ticks = axes.calculate_y_ticks(canvas_size.height - 1)
-            # draw the y_ticks and labels
-            with drawing_context.saver():
-                for y, _, _ in y_ticks:
-                    drawing_context.begin_path()
-                    drawing_context.move_to(canvas_size.width, y)
-                    drawing_context.line_to(canvas_size.width - self.tick_width, y)
-                    drawing_context.line_width = 1
-                    drawing_context.stroke_style = '#888'
-                    drawing_context.stroke()
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphVerticalAxisTicksCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__tick_width)
 
 
 class Exponenter:
@@ -1037,6 +1151,53 @@ def calculate_scientific_notation_drawing_width(ui_settings: UISettings.UISettin
                for font, label in zip(fonts, labels))
 
 
+class LineGraphVerticalAxisScaleCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], font_size: int, fonts: typing.Tuple[str, str], ui_settings: UISettings.UISettings) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__axes = axes
+        self.__font_size = font_size
+        self.__fonts = fonts
+        self.__ui_settings = ui_settings
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        # draw the data, if any
+        axes = self.__axes
+        canvas_size = canvas_bounds.size
+        if axes:
+            label: typing.Optional[str] = None
+            y: typing.Optional[float] = None
+
+            # canvas size
+            width = canvas_size.width
+            plot_height = canvas_size.height - 1
+
+            # extract the data we need for drawing y-axis
+            y_ticks = axes.calculate_y_ticks(plot_height, flag_minor=True)
+            include_minor_ticks = plot_height / self.__font_size > 2.5 * axes.y_ticker.ticks
+            at_least_one = False
+
+            e = Exponenter()
+            for y, label, is_minor in y_ticks:
+                if include_minor_ticks or not is_minor:
+                    e.add_label(label)
+                    at_least_one = True
+
+            # draw the y_ticks and labels
+            with drawing_context.saver():
+                drawing_context.text_baseline = "middle"
+                drawing_context.font = "{0:d}px".format(self.__font_size)
+                for y, label, is_minor in y_ticks:
+                    drawing_context.begin_path()
+                    drawing_context.stroke_style = '#888'
+                    drawing_context.stroke()
+                    if (include_minor_ticks or not is_minor) and self.__ui_settings:
+                        drawing_context.fill_style = "#000"
+                        e.draw_scientific_notation(drawing_context, self.__ui_settings, self.__fonts, label, width, y)
+                        at_least_one = True
+                if not at_least_one and y_ticks and y is not None and label is not None and self.__ui_settings:
+                    drawing_context.fill_style = "#000"
+                    e.draw_scientific_notation(drawing_context, self.__ui_settings, self.__fonts, label, width, y)
+
 
 class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
     """Canvas item to draw the vertical scale."""
@@ -1044,8 +1205,8 @@ class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self, ui_settings: UISettings.UISettings) -> None:
         super().__init__()
         self.__axes: typing.Optional[LineGraphAxes] = None
-        self.font_size = 12
-        self.__fonts = ("{0:d}px".format(self.font_size), "{0:d}px".format(int(self.font_size * 0.8)))
+        self.__font_size = 12
+        self.__fonts = ("{0:d}px".format(self.__font_size), "{0:d}px".format(int(self.__font_size * 0.8)))
         self.__ui_settings = ui_settings
 
     def size_to_content(self) -> None:
@@ -1067,51 +1228,46 @@ class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
             new_sizing = new_sizing.with_maximum_width(max_width)
 
         self.update_sizing(new_sizing)
+        self._invalidate_composer()
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
         self.size_to_content()
+        self._invalidate_composer()
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphVerticalAxisScaleCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size, self.__fonts, self.__ui_settings)
+
+
+class LineGraphVerticalAxisLabelCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], font_size: int) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__axes = axes
+        self.__font_size = font_size
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
         axes = self.__axes
-        canvas_size = self.canvas_size
-        if canvas_size and axes:
-            label: typing.Optional[str] = None
-            y: typing.Optional[float] = None
-
-            # canvas size
-            width = canvas_size.width
-            plot_height = canvas_size.height - 1
-
-            # extract the data we need for drawing y-axis
-            y_ticks = axes.calculate_y_ticks(plot_height, flag_minor=True)
-            include_minor_ticks = plot_height / self.font_size > 2.5 * axes.y_ticker.ticks
-            at_least_one = False
-
-            e = Exponenter()
-            for y, label, is_minor in y_ticks:
-                if include_minor_ticks or not is_minor:
-                    e.add_label(label)
-                    at_least_one = True
-
-            # draw the y_ticks and labels
-            with drawing_context.saver():
-                drawing_context.text_baseline = "middle"
-                drawing_context.font = "{0:d}px".format(self.font_size)
-                for y, label, is_minor in y_ticks:
-                    drawing_context.begin_path()
-                    drawing_context.stroke_style = '#888'
-                    drawing_context.stroke()
-                    if (include_minor_ticks or not is_minor) and self.__ui_settings:
-                        drawing_context.fill_style = "#000"
-                        e.draw_scientific_notation(drawing_context, self.__ui_settings, self.__fonts, label, width, y)
-                        at_least_one = True
-                if not at_least_one and y_ticks and y is not None and label is not None and self.__ui_settings:
+        canvas_size = canvas_bounds.size
+        if axes:
+            if axes.y_calibration and axes.y_calibration.units:
+                with drawing_context.saver():
+                    drawing_context.font = "{0:d}px".format(self.__font_size)
+                    drawing_context.text_align = "center"
+                    drawing_context.text_baseline = "middle"
                     drawing_context.fill_style = "#000"
-                    e.draw_scientific_notation(drawing_context, self.__ui_settings, self.__fonts, label, width, y)
+                    x = canvas_size.width * 0.5
+                    y = (canvas_size.height - 1) // 2
+                    drawing_context.translate(x, y)
+                    drawing_context.rotate(-math.pi*0.5)
+                    drawing_context.translate(-x, -y)
+                    drawing_context.font = "{0:d}px".format(self.__font_size)
+                    drawing_context.fill_text(axes.y_calibration.units, x, y)
+                    drawing_context.translate(x, y)
+                    drawing_context.rotate(+math.pi*0.5)
+                    drawing_context.translate(-x, -y)
 
 
 class LineGraphVerticalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
@@ -1120,8 +1276,8 @@ class LineGraphVerticalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
     def __init__(self) -> None:
         super().__init__()
         self.__axes: typing.Optional[LineGraphAxes] = None
-        self.font_size = 12
-        self.update_sizing(self.sizing.with_fixed_width(self.font_size + 4))
+        self.__font_size = 12
+        self.update_sizing(self.sizing.with_fixed_width(self.__font_size + 4))
 
     def size_to_content(self) -> None:
         """ Size the canvas item to the proper width. """
@@ -1131,37 +1287,20 @@ class LineGraphVerticalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
         axes = self.__axes
         if axes:
             if axes.y_calibration and axes.y_calibration.units:
-                new_sizing = new_sizing.with_minimum_width(self.font_size + 4)
-                new_sizing = new_sizing.with_maximum_width(self.font_size + 4)
+                new_sizing = new_sizing.with_minimum_width(self.__font_size + 4)
+                new_sizing = new_sizing.with_maximum_width(self.__font_size + 4)
         self.update_sizing(new_sizing)
+        self._invalidate_composer()
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
         # assume this is only called when axes changes
         self.__axes = axes
         self.size_to_content()
+        self._invalidate_composer()
         self.update()
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        # draw the data, if any
-        axes = self.__axes
-        canvas_size = self.canvas_size
-        if axes and canvas_size:
-            if axes.y_calibration and axes.y_calibration.units:
-                with drawing_context.saver():
-                    drawing_context.font = "{0:d}px".format(self.font_size)
-                    drawing_context.text_align = "center"
-                    drawing_context.text_baseline = "middle"
-                    drawing_context.fill_style = "#000"
-                    x = canvas_size.width * 0.5
-                    y = (canvas_size.height - 1) // 2
-                    drawing_context.translate(x, y)
-                    drawing_context.rotate(-math.pi*0.5)
-                    drawing_context.translate(-x, -y)
-                    drawing_context.font = "{0:d}px".format(self.font_size)
-                    drawing_context.fill_text(axes.y_calibration.units, x, y)
-                    drawing_context.translate(x, y)
-                    drawing_context.rotate(+math.pi*0.5)
-                    drawing_context.translate(-x, -y)
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphVerticalAxisLabelCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)
 
 
 class LineGraphLegendCanvasItemDelegate(typing.Protocol):
@@ -1181,6 +1320,87 @@ class LineGraphLegendCanvasItemDelegate(typing.Protocol):
     def get_document_model(self) -> DocumentModel.DocumentModel: ...
 
     def create_rgba_image(self, drawing_context: DrawingContext.DrawingContext, width: int, height: int) -> _NDArray: ...
+
+
+class LineGraphLegendCanvasItemComposer(CanvasItem.BaseComposer):
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache,
+                 legend_entries: typing.Sequence[LegendEntry], effective_legend_entries: typing.Sequence[LegendEntry],
+                 foreign_legend_entry: typing.Optional[LegendEntry], mouse_pressed_for_dragging: bool,
+                 entry_to_insert: typing.Optional[int], font_size: int, ui_settings: UISettings.UISettings) -> None:
+        super().__init__(canvas_item, layout_sizing, cache)
+        self.__legend_entries = list(legend_entries)
+        self.__effective_entries = list(effective_legend_entries)
+        self.__foreign_legend_entry = foreign_legend_entry
+        self.__mouse_pressed_for_dragging = mouse_pressed_for_dragging
+        self.__entry_to_insert = entry_to_insert
+        self.__font_size = font_size
+        self.__ui_settings = ui_settings
+
+    def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
+        legend_entries = self.__legend_entries
+        effective_entries = self.__effective_entries
+        foreign_legend_entry = self.__foreign_legend_entry
+        mouse_pressed_for_dragging = self.__mouse_pressed_for_dragging
+        entry_to_insert = self.__entry_to_insert
+        font_size = self.__font_size
+        ui_settings = self.__ui_settings
+
+        # don't display the canvas item if there are less than two items
+        if legend_entries is None or len(legend_entries) < 2:
+            return
+
+        font = "{0:d}px".format(font_size)
+
+        legend_width = 0
+        for index, legend_entry in enumerate(effective_entries):
+            legend_width = max(legend_width, ui_settings.get_font_metrics(font, legend_entry.label).width)
+
+        line_height = font_size + 4
+        border = 4
+        font = "{0:d}px".format(font_size)
+
+        effective_entries_and_foreign = list(effective_entries)
+        if foreign_legend_entry is not None and entry_to_insert is not None:
+            effective_entries_and_foreign.insert(entry_to_insert, foreign_legend_entry)
+
+        legend_height = len(effective_entries_and_foreign) * line_height
+
+        with drawing_context.saver():
+            drawing_context.begin_path()
+            drawing_context.rect(0,
+                                 0,
+                                 legend_width + border * 2 + line_height,
+                                 legend_height + border * 2)
+            drawing_context.fill_style = "rgba(192, 192, 192, 0.5)"
+            drawing_context.fill()
+
+        if mouse_pressed_for_dragging or foreign_legend_entry is not None:
+            with drawing_context.saver():
+                drawing_context.begin_path()
+                entry_to_insert = entry_to_insert or 0  # for type checking
+                drawing_context.rect(0,
+                                     entry_to_insert * line_height + border,
+                                     legend_width + border * 2 + line_height,
+                                     line_height)
+                drawing_context.fill_style = "rgba(192, 192, 192, 0.5)"
+                drawing_context.fill()
+
+        for index, legend_entry in enumerate(effective_entries_and_foreign):
+            with drawing_context.saver():
+                drawing_context.font = font
+                drawing_context.text_align = "right"
+                drawing_context.text_baseline = "bottom"
+                drawing_context.fill_style = "#000"
+                drawing_context.fill_text(legend_entry.label, legend_width + border, line_height * (index + 1) - 4 + border)
+
+                drawing_context.begin_path()
+                drawing_context.rect(legend_width + border + 3, line_height * index + 3 + border, line_height - 6, line_height - 6)
+                if legend_entry.fill_color:
+                    drawing_context.fill_style = legend_entry.fill_color
+                    drawing_context.fill()
+                if legend_entry.stroke_color:
+                    drawing_context.stroke_style = legend_entry.stroke_color
+                    drawing_context.stroke()
 
 
 class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
@@ -1222,7 +1442,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self.wants_mouse_events = True
         self.wants_drag_events = True
         self.__ui_settings = ui_settings
-        self.font_size: typing.Final = 12
+        self.__font_size: typing.Final = 12
 
         # caching
         self.__needs_size_to_content = True
@@ -1245,7 +1465,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
 
     def size_to_content(self) -> None:
         if self.__needs_size_to_content:
-            line_height = self.font_size + 4
+            line_height = self.__font_size + 4
             border = 4
 
             effective_entries = self.effective_entries
@@ -1256,7 +1476,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
                 legend_height = 0
 
             text_width = 0
-            font = "{0:d}px".format(self.font_size)
+            font = "{0:d}px".format(self.__font_size)
 
             for index, legend_entry in enumerate(effective_entries):
                 text_width = max(text_width, self.__ui_settings.get_font_metrics(font, legend_entry.label).width)
@@ -1265,6 +1485,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
 
             new_sizing = self.copy_sizing().with_fixed_width(legend_width).with_fixed_height(legend_height)
             self.update_sizing(new_sizing)
+            self._invalidate_composer()
 
             self.__needs_size_to_content = False
 
@@ -1275,6 +1496,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         # assume this is only called when legend entries changes
         self.__legend_entries = list(legend_entries)
         self.__generate_effective_entries()
+        self._invalidate_composer()
         self.update()
 
     def __get_legend_index(self, x: int, y: int, ignore_y: bool = False, insertion: bool = False) -> int:
@@ -1286,9 +1508,9 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         legend_entries = self.__legend_entries
 
         legend_width = 0
-        line_height = self.font_size + 4
+        line_height = self.__font_size + 4
         border = 4
-        font = "{0:d}px".format(self.font_size)
+        font = "{0:d}px".format(self.__font_size)
 
         for index, legend_entry in enumerate(legend_entries):
             legend_width = max(legend_width, self.__ui_settings.get_font_metrics(font, legend_entry.label).width)
@@ -1352,6 +1574,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         if old_entry != self.__entry_to_insert:
             # update effective entries and the display if it changed
             self.__generate_effective_entries()
+            self._invalidate_composer()
             self.update()
         return "ignore"
 
@@ -1366,8 +1589,8 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
                 self.__dragging_index = i
                 self._drag_start_position = Geometry.IntPoint(x=x, y=y)
                 self.__entry_to_insert = i
+                self._invalidate_composer()
                 self.update()
-
                 return True
         return False
 
@@ -1377,6 +1600,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self._drag_start_position = None
         self.__entry_to_insert = None
         self.__generate_effective_entries()
+        self._invalidate_composer()
         self.update()
         return True
 
@@ -1390,6 +1614,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__foreign_legend_uuid_and_index = None
         # when we leave the drag area, update the effective entries because we're no longer previewing a shift
         self.__generate_effective_entries()
+        self._invalidate_composer()
         self.update()
         return "ignore"
 
@@ -1403,12 +1628,14 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
                 self.__dragging_index = legend_data["index"]
                 self.__mouse_pressed_for_dragging = True
                 self.__generate_effective_entries()
+                self._invalidate_composer()
                 self.update()
             else:
                 # if we aren't the source, setup foreign_legend_* and update the display
                 assert display_item
                 self.__foreign_legend_entry = LegendEntry(label=legend_data["label"], fill_color=legend_data["fill_color"], stroke_color=legend_data["stroke_color"])
                 self.__foreign_legend_uuid_and_index = (display_item, typing.cast(int, legend_data["index"]))
+                self._invalidate_composer()
                 self.update()
             return "move"
         return "ignore"
@@ -1418,6 +1645,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
         self._drag_start_position = None
         self.__mouse_pressed_for_dragging = False
         self.__mouse_dragging = False
+        self._invalidate_composer()
 
         if mime_data.has_format(MimeTypes.LAYER_MIME_TYPE):
             legend_data, source_display_item = MimeTypes.mime_data_get_layer(mime_data, self.__delegate.get_document_model())
@@ -1451,60 +1679,7 @@ class LineGraphLegendCanvasItem(CanvasItem.AbstractCanvasItem):
     def effective_entries(self) -> typing.Sequence[LegendEntry]:
         return self.__effective_entries
 
-    def _repaint(self, drawing_context: DrawingContext.DrawingContext) -> None:
-        # don't display the canvas item if there are less than two items
-        if self.__legend_entries is None or len(self.__legend_entries) < 2:
-            return
-
-        font = "{0:d}px".format(self.font_size)
-
-        legend_width = 0
-        for index, legend_entry in enumerate(self.__effective_entries):
-            legend_width = max(legend_width, self.__ui_settings.get_font_metrics(font, legend_entry.label).width)
-
-        line_height = self.font_size + 4
-        border = 4
-        font = "{0:d}px".format(self.font_size)
-
-        effective_entries_and_foreign = list(self.__effective_entries)
-        if self.__foreign_legend_entry is not None and self.__entry_to_insert is not None:
-            effective_entries_and_foreign.insert(self.__entry_to_insert, self.__foreign_legend_entry)
-
-        legend_height = len(effective_entries_and_foreign) * line_height
-
-        with drawing_context.saver():
-            drawing_context.begin_path()
-            drawing_context.rect(0,
-                                 0,
-                                 legend_width + border * 2 + line_height,
-                                 legend_height + border * 2)
-            drawing_context.fill_style = "rgba(192, 192, 192, 0.5)"
-            drawing_context.fill()
-
-        if self.__mouse_pressed_for_dragging or self.__foreign_legend_entry is not None:
-            with drawing_context.saver():
-                drawing_context.begin_path()
-                entry_to_insert = self.__entry_to_insert or 0  # for type checking
-                drawing_context.rect(0,
-                                     entry_to_insert * line_height + border,
-                                     legend_width + border * 2 + line_height,
-                                     line_height)
-                drawing_context.fill_style = "rgba(192, 192, 192, 0.5)"
-                drawing_context.fill()
-
-        for index, legend_entry in enumerate(effective_entries_and_foreign):
-            with drawing_context.saver():
-                drawing_context.font = font
-                drawing_context.text_align = "right"
-                drawing_context.text_baseline = "bottom"
-                drawing_context.fill_style = "#000"
-                drawing_context.fill_text(legend_entry.label, legend_width + border, line_height * (index + 1) - 4 + border)
-
-                drawing_context.begin_path()
-                drawing_context.rect(legend_width + border + 3, line_height * index + 3 + border, line_height - 6, line_height - 6)
-                if legend_entry.fill_color:
-                    drawing_context.fill_style = legend_entry.fill_color
-                    drawing_context.fill()
-                if legend_entry.stroke_color:
-                    drawing_context.stroke_style = legend_entry.stroke_color
-                    drawing_context.stroke()
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
+        return LineGraphLegendCanvasItemComposer(self, self.layout_sizing, composer_cache,
+                                                 self.__legend_entries, self.__effective_entries, self.__foreign_legend_entry,
+                                                 self.__mouse_pressed_for_dragging, self.__entry_to_insert, self.__font_size, self.__ui_settings)

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -921,6 +921,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def toggle_frame_rate(self) -> None:
         self.__frame_rate_canvas_item.toggle_display(str(id(self)))
+        self.__line_graph_layers_canvas_item.display_frame_rate_id = self.__frame_rate_canvas_item.display_frame_rate_id
 
     def key_released(self, key: UserInterface.Key) -> bool:
         if super().key_released(key):

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -1014,8 +1014,9 @@ class DataItem(Persistence.PersistentObject):
         self.set_xdata(DataAndMetadata.new_data_and_metadata(data, timestamp=data_modified, timezone=timezone, timezone_offset=timezone_offset))
 
     def set_xdata(self, xdata: typing.Optional[DataAndMetadata.DataAndMetadata], data_modified: typing.Optional[datetime.datetime] = None) -> None:
-        with self.data_source_changes():
-            self.set_data_and_metadata(xdata, data_modified)
+        if not self._closed:
+            with self.data_source_changes():
+                self.set_data_and_metadata(xdata, data_modified)
 
     class DataAccessor:
         def __init__(self, data_item: DataItem, get_data: typing.Callable[[], typing.Optional[_ImageDataType]], set_data: typing.Callable[[typing.Optional[_ImageDataType]], None]) -> None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2828,7 +2828,7 @@ class DisplayItem(Persistence.PersistentObject):
         self.notify_property_changed("description")
         self.notify_property_changed("session_id")
 
-    def source_display_items_changed(self, source_display_items: typing.Sequence[DisplayItem], is_loading: bool) -> None:
+    def finish_project_read(self) -> None:
         # the line below is a hack to resend the display data delta. this is required because of an architectural
         # problem: the display layer may not initially have a correct display_data_channel until the whole project is
         # read. the display_data_channel will only return the correct value once the data items are read; and that

--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -1031,14 +1031,11 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
                 source_display_items = self.get_source_display_items(display_item) if display_item else list()
                 dependent_display_items = self.get_dependent_display_items(display_item) if display_item else list()
                 self.related_items_changed.fire(display_item, source_display_items, dependent_display_items)
-                display_item.source_display_items_changed(source_display_items, self.__is_loading)
 
         self.__display_item_item_inserted_listeners[display_item] = display_item.item_inserted_event.listen(functools.partial(item_changed, display_item))
         self.__display_item_item_removed_listeners[display_item] = display_item.item_removed_event.listen(functools.partial(item_changed, display_item))
         # send notifications
         self.notify_insert_item("display_items", display_item, before_index)
-        # update source items
-        display_item.source_display_items_changed(self.get_source_display_items(display_item), self.__is_loading)
 
     def __handle_display_item_removed(self, display_item: DisplayItem.DisplayItem) -> None:
         # remove it from the persistent_storage
@@ -1057,7 +1054,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         for data_item in self.__data_items:
             data_item.source_data_items_changed(self.get_source_data_items(data_item))
         for display_item in self.__display_items:
-            display_item.source_display_items_changed(self.get_source_display_items(display_item), self.__is_loading)
+            display_item.finish_project_read()
         self.project_loaded_event.fire()
         self.__is_loading = False
 
@@ -1343,9 +1340,6 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         # send the source changes to the target display item
         if isinstance(source_item, DataItem.DataItem) and isinstance(target_item, DataItem.DataItem):
             target_item.source_data_items_changed(self.get_source_data_items(target_item))
-            for display_item in self.get_display_items_for_data_item(target_item):
-                source_display_items = self.get_source_display_items(display_item) if display_item else list()
-                display_item.source_display_items_changed(source_display_items, self.__is_loading)
 
     def __add_dependency(self, source_item: Persistence.PersistentObject, target_item: Persistence.PersistentObject) -> None:
         # print(f"add dependency {source_item} {target_item}")
@@ -1366,9 +1360,6 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         # send the source changes to the target display item
         if isinstance(source_item, DataItem.DataItem) and isinstance(target_item, DataItem.DataItem):
             target_item.source_data_items_changed(self.get_source_data_items(target_item))
-            for display_item in self.get_display_items_for_data_item(target_item):
-                source_display_items = self.get_source_display_items(display_item) if display_item else list()
-                display_item.source_display_items_changed(source_display_items, self.__is_loading)
 
     def __computation_needs_update(self, computation: Symbolic.Computation) -> None:
         # When the computation for a data item is set or mutated, this function will be called.

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -828,6 +828,10 @@ class Graphic(Persistence.PersistentObject):
         return constraints
 
     def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+        if not self._closed:
+            self._draw(ctx, ui_settings, mapping, is_selected)
+
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         raise NotImplementedError()
 
     def test(self, mapping: CoordinateMappingLike, ui_settings: UISettings.UISettings, p: Geometry.FloatPoint, move_only: bool) -> typing.Tuple[typing.Optional[str], bool]:
@@ -898,7 +902,7 @@ class MissingGraphic(Graphic):
     def __init__(self, type: str) -> None:
         super().__init__(type)
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         pass
 
 
@@ -1089,7 +1093,7 @@ class RectangleTypeGraphic(Graphic):
         current = original + delta
         self.adjust_part(mapping, original, current, ("all", ) + self.begin_drag(), NullModifiers())
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         raise NotImplementedError()
 
 
@@ -1108,7 +1112,7 @@ class RectangleGraphic(RectangleTypeGraphic):
         if rotation != self.rotation:
             self.rotation = rotation
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         # origin is top left
         origin = mapping.map_point_image_norm_to_widget(self.bounds.origin)
         size = mapping.map_size_image_norm_to_widget(self.bounds.size)
@@ -1209,7 +1213,7 @@ class EllipseGraphic(RectangleTypeGraphic):
         if rotation != self.rotation:
             self.rotation = rotation
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         # origin is top left
         rotation = self.rotation
         stroke_style = self.used_stroke_style
@@ -1505,7 +1509,7 @@ class LineTypeGraphic(Graphic):
         current = original + delta
         self.adjust_part(mapping, original, current, ("all",) + self.begin_drag(), NullModifiers())
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         raise NotImplementedError()
 
 
@@ -1513,7 +1517,7 @@ class LineGraphic(LineTypeGraphic):
     def __init__(self) -> None:
         super().__init__("line-graphic", _("Line"))
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         p1 = mapping.map_point_image_norm_to_widget(self.start)
         p2 = mapping.map_point_image_norm_to_widget(self.end)
         with ctx.saver():
@@ -1570,7 +1574,7 @@ class LineProfileGraphic(LineTypeGraphic):
         super().read_from_mime_data(graphic_dict)
         self.width = graphic_dict.get("line_width", self.width)
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         p1 = mapping.map_point_image_norm_to_widget(self.start)
         p2 = mapping.map_point_image_norm_to_widget(self.end)
         w = mapping.map_size_image_to_widget(Geometry.FloatSize(width=self.width)).width
@@ -1709,7 +1713,7 @@ class PointTypeGraphic(Graphic):
         current = original + delta
         self.adjust_part(mapping, original, current, ("all",) + self.begin_drag(), NullModifiers())
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         raise NotImplementedError()
 
     @property
@@ -1726,7 +1730,7 @@ class PointGraphic(PointTypeGraphic):
         super().__init__("point-graphic", _("Point"))
         self.cross_hair_size = 12
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         p = mapping.map_point_image_norm_to_widget(self.position)
         with ctx.saver():
             ctx.begin_path()
@@ -2127,7 +2131,7 @@ class SpotGraphic(Graphic):
         current = original + delta
         self.adjust_part(mapping, original, current, ("all",) + self.begin_drag(), NullModifiers())
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         # origin is top left
         stroke_style = self.used_stroke_style
         fill_style = self.used_fill_style
@@ -2331,7 +2335,7 @@ class WedgeGraphic(Graphic):
                     numpy.where(-y * s_sign <= numpy.tan(-s) * -x * s_sign, 1, 0) &
                     numpy.where(-y * e_sign <= numpy.tan(-e) * -x * e_sign, 0, 1))
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         center = mapping.calibrated_origin_widget
         size = mapping.map_size_image_norm_to_widget(Geometry.FloatSize(1.0, 1.0))
         bounds = Geometry.FloatRect(Geometry.FloatPoint(), size) + mapping.map_point_image_norm_to_widget(Geometry.FloatPoint())
@@ -2527,7 +2531,7 @@ class RingGraphic(Graphic):
             mask = numpy.ones(data_shape)
         return mask
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         # origin is top left
         center = mapping.calibrated_origin_widget
         bounds0 = mapping.map_point_image_norm_to_widget(Geometry.FloatPoint(0.0, 0.0))
@@ -2866,7 +2870,7 @@ class LatticeGraphic(Graphic):
 
         return mask
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
+    def _draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool = False) -> None:
         start = mapping.calibrated_origin_image_norm
         u_pos = Geometry.FloatSize.make(self.u_pos)
         v_pos = Geometry.FloatSize.make(self.v_pos)

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -342,7 +342,7 @@ def fps_get(fps_id: str) -> str:
     m = v.last_window_frame_mean
     r = 1 / m if m != 0.0 else 0.0
     s = v.last_window_frame_std
-    return str(int(r * 10) / 10.0) + "fps / " + str(int(m * 1000)) + "ms / " + str(int(s * 1000)) + "ms"
+    return str(round(r * 10) / 10.0) + "fps / " + str(int(m * 1000)) + "ms / " + str(int(s * 1000)) + "ms"
 
 
 Trace = collections.namedtuple("Trace", ["start_time", "last_time_ref", "min_elapsed", "discard", "all"])

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1240,7 +1240,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
             header_height = self.display_panel.header_canvas_item.header_height
-            root_canvas_item.update_layout(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
+            root_canvas_item.update_layout_immediate(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
             # drag to make line
             display_panel.display_canvas_item.simulate_drag((100,125), (200,250))
             document_controller.periodic()
@@ -1270,7 +1270,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
             header_height = self.display_panel.header_canvas_item.header_height
-            root_canvas_item.update_layout(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
+            root_canvas_item.update_layout_immediate(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
             # drag for the line profile
             display_panel.display_canvas_item.simulate_drag((100,125), (200,250))
             self.document_controller.periodic()
@@ -1296,7 +1296,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
             header_height = self.display_panel.header_canvas_item.header_height
-            root_canvas_item.update_layout(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
+            root_canvas_item.update_layout_immediate(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=1000 + header_height))
             # drag and check transactions
             self.assertFalse(data_item.in_transaction_state)
             self.assertFalse(display_item.in_transaction_state)
@@ -1334,7 +1334,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             self.assertIsNotNone(display_panel.display_canvas_item)
-            root_canvas_item.update_layout(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=500 + header_height))
+            root_canvas_item.update_layout_immediate(Geometry.IntPoint(), Geometry.IntSize(width=1000, height=500 + header_height))
             document_controller.set_filter("none")
             document_controller.tool_mode = "line-profile"
             display_panel.display_canvas_item.simulate_drag((100,125), (200,250))

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -307,9 +307,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             axes = display_panel.display_canvas_item._axes
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
-            line_graph_layer.draw_fills(drawing_context)
-            line_graph_layer.draw_strokes(drawing_context)
+            canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
+            composer_cache = CanvasItem.ComposerCache()
+            line_graph_layer.draw_fills(drawing_context, canvas_bounds, composer_cache)
+            line_graph_layer.draw_strokes(drawing_context, canvas_bounds, composer_cache)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 
@@ -330,9 +331,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             self.assertEqual(axes.data_style, "log")
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
-            line_graph_layer.draw_fills(drawing_context)
-            line_graph_layer.draw_strokes(drawing_context)
+            canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
+            composer_cache = CanvasItem.ComposerCache()
+            line_graph_layer.draw_fills(drawing_context, canvas_bounds, composer_cache)
+            line_graph_layer.draw_strokes(drawing_context, canvas_bounds, composer_cache)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 
@@ -409,9 +411,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             axes = display_panel.display_canvas_item._axes
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
-            line_graph_layer.calculate(Geometry.IntRect.from_tlbr(0, 0, 480, 640))
-            line_graph_layer.draw_fills(drawing_context)
-            line_graph_layer.draw_strokes(drawing_context)
+            canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
+            composer_cache = CanvasItem.ComposerCache()
+            line_graph_layer.draw_fills(drawing_context, canvas_bounds, composer_cache)
+            line_graph_layer.draw_strokes(drawing_context, canvas_bounds, composer_cache)
             # ensure that the drawing commands are sufficiently populated to have drawn the graph
             self.assertGreater(len(drawing_context.commands), 100)
 


### PR DESCRIPTION
- **Change the line plot canvas items to use compositor-style repainting.**
- **Separate each layer of line plot into its own canvas item.**
- **Convert remaining repaint canvas items to use composers.**
- **Convert image area layout to composer architecture.**
- **Ensure data item is not closed before running set_xdata.**
- **Eliminate unnecessary display update when removing display item.**
- **Improve handling of line graph layer composition.**
- **Update canvas items using batch update to avoid repainting partial states.**
- **Remove unnecessary invalidate calls.**
- **Change graphics to only draw if not closed.**
- **Fix typo in image zoom.**
- **Improve frame rate display to show actual rate of repainting.**
