### PR TITLE
Add storage space to data panel info; add storage space/file-type to data item tool tip info.

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -142,7 +142,9 @@ class DisplayItemAdapter:
 
     @property
     def format_str(self) -> str:
-        return self.__display_item.size_and_data_format_as_string if self.__display_item else str()
+        format_str = self.__display_item.size_and_data_format_as_string if self.__display_item else str()
+        storage_space_string = self.__display_item.storage_space_string if self.__display_item else str()
+        return " ".join([format_str, storage_space_string])
 
     @property
     def datetime_str(self) -> str:
@@ -157,8 +159,12 @@ class DisplayItemAdapter:
         return self.__display_item.project_str if self.__display_item else str()
 
     @property
-    def tool_tip(self) -> str:
-        return self.__display_item.tool_tip_str if self.__display_item else str()
+    def list_tool_tip(self) -> str:
+        return self.__display_item.list_tool_tip_str if self.__display_item else str()
+
+    @property
+    def grid_tool_tip(self) -> str:
+        return self.__display_item.grid_tool_tip_str if self.__display_item else str()
 
     def drag_started(self, ui: UserInterface.UserInterface, x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> typing.Tuple[typing.Optional[UserInterface.MimeData], typing.Optional[_NDArray]]:
         if self.__display_item:
@@ -457,12 +463,18 @@ class ListCanvasItemDelegate(ListCanvasItem.ListCanvasItemDelegate):
         return self.__data_list_controller.display_item_adapter_count
 
     @property
-    def items(self) -> typing.Sequence[typing.Any]:
+    def items(self) -> typing.Sequence[DisplayItemAdapter]:
         return self.__data_list_controller.display_item_adapters
 
     @items.setter
-    def items(self, value: typing.Sequence[typing.Any]) -> None:
+    def items(self, value: typing.Sequence[DisplayItemAdapter]) -> None:
         raise NotImplementedError()
+
+    def item_tool_tip(self, index: int) -> typing.Optional[str]:
+        items = self.items
+        if 0 <= index < len(items):
+            return items[index].list_tool_tip
+        return None
 
     def paint_item(self, drawing_context: DrawingContext.DrawingContext, display_item_adapter: DisplayItemAdapter, rect: Geometry.IntRect, is_selected: bool) -> None:
         display_item_adapter.draw_list_item(drawing_context, rect)
@@ -499,7 +511,7 @@ class GridCanvasItemDelegate(GridCanvasItem.GridCanvasItemDelegate):
     def item_tool_tip(self, index: int) -> typing.Optional[str]:
         items = self.items
         if 0 <= index < len(items):
-            return items[index].tool_tip
+            return items[index].grid_tool_tip
         return None
 
     def paint_item(self, drawing_context: DrawingContext.DrawingContext, display_item_adapter: DisplayItemAdapter, rect: Geometry.IntRect, is_selected: bool) -> None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3080,9 +3080,17 @@ class DisplayItem(Persistence.PersistentObject):
 
     @property
     def tool_tip_str(self) -> str:
-        lines = [self.displayed_title, self.size_and_data_format_as_string, self.date_for_sorting_local_as_string, self.status_str, self.project_str]
+        lines = [self.displayed_title, self.size_and_data_format_as_string, self.storage_string, self.date_for_sorting_local_as_string, self.status_str, self.project_str]
         lines = [line for line in lines if line]
         return "\n".join(lines)
+
+    @property
+    def list_tool_tip_str(self) -> str:
+        return self.tool_tip_str
+
+    @property
+    def grid_tool_tip_str(self) -> str:
+        return self.tool_tip_str
 
     def __insert_display_data_channel(self, name: str, before_index: int, display_data_channel: DisplayDataChannel) -> None:
         display_data_channel.increment_display_ref_count(self._display_ref_count)
@@ -3339,6 +3347,16 @@ class DisplayItem(Persistence.PersistentObject):
     def size_and_data_format_as_string(self) -> str:
         data_item = self.data_item
         return data_item.size_and_data_format_as_string if data_item else str()
+
+    @property
+    def storage_space_string(self) -> str:
+        data_item = self.data_item
+        return data_item.storage_space_string if data_item else str()
+
+    @property
+    def storage_string(self) -> str:
+        data_item = self.data_item
+        return data_item.storage_string if data_item else str()
 
     @property
     def date_for_sorting(self) -> datetime.datetime:

--- a/nion/swift/resources/changes.json
+++ b/nion/swift/resources/changes.json
@@ -3,11 +3,14 @@
     "version": "UNRELEASED",
     "notes": [
       {
+        "issues": ["https://github.com/nion-software/nionswift/issues/1125"],
+        "summary": "Change Export SVG dialog to remember units."
+      },
+      {
         "summary": "Use filename when title is empty or missing on import (was only when missing)."
       },
       {
-        "issues": ["https://github.com/nion-software/nionswift/issues/1125"],
-        "summary": "Change Export SVG dialog to remember units."
+        "summary": "Add storage space to size info in data panel. Additionally, add file type in display item tool tips."
       }
     ]
   },


### PR DESCRIPTION
How to test: these new stats show up in the data panel at the end of the shape line; and in the tool tips when hovering over items in the data panel.