### PR TITLE
Introduce nhdf file format based on HDF5 for import/export any display/data item

### DIFF
--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -878,7 +878,7 @@ class Workspace:
             return "copy"
         if mime_data.has_format("text/uri-list"):
             index = len(document_model.data_items)
-            self.document_controller.receive_files(mime_data.file_paths, None, index, threaded=True, display_panel=display_panel)
+            self.document_controller.receive_files(mime_data.file_paths, None, index)
             return "copy"
         return "ignore"
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1123,7 +1123,7 @@ class MemoryStorageHandler(StorageHandler.StorageHandler):
         self.__data_properties_map[self.__uuid] = Utility.clean_dict(properties)
 
     def write_data(self, data: _NDArray, file_datetime: datetime.datetime) -> None:
-        self.__data_map[self.__uuid] = data.copy()
+        self.__data_map[self.__uuid] = numpy.copy(data)
 
     def reserve_data(self, data_shape: typing.Tuple[int, ...], data_dtype: numpy.typing.DTypeLike, file_datetime: datetime.datetime) -> None:
         self.__data_map[self.__uuid] = numpy.zeros(data_shape, data_dtype)

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -545,17 +545,11 @@ class ProjectStorageSystemMigrationStage:
     pass
 
 
-"""Data item metadata for organizing within storage system."""
-@dataclasses.dataclass
-class DataItemMetadata:
-    uuid: uuid.UUID
-    created_local: datetime.datetime
-    session_id: str | None
-    large_format: bool
-
-
-def make_data_item_metadata(data_item: DataItem.DataItem) -> DataItemMetadata:
-    return DataItemMetadata(data_item.uuid, data_item.created_local, data_item.session_id, data_item.large_format)
+def make_storage_handler_attributes(data_item: DataItem.DataItem) -> StorageHandler.StorageHandlerAttributes:
+    dimensional_shape = data_item.dimensional_shape
+    data_dtype = data_item.data_dtype
+    n_bytes = typing.cast(int, numpy.prod(dimensional_shape + (numpy.dtype(data_dtype).itemsize,), dtype=numpy.int64))
+    return StorageHandler.StorageHandlerAttributes(data_item.uuid, data_item.created_local, data_item.session_id, n_bytes, data_item.large_format)
 
 
 class ProjectStorageSystem(PersistentStorageSystem):
@@ -571,7 +565,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
         self.__storage_adapter_map.clear()
 
     @abc.abstractmethod
-    def _make_storage_handler(self, data_item_metadata: DataItemMetadata, file_handler: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> StorageHandler.StorageHandler: ...
+    def _make_storage_handler(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes, file_handler: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> StorageHandler.StorageHandler: ...
 
     @abc.abstractmethod
     def _find_storage_handlers(self) -> typing.Sequence[StorageHandler.StorageHandler]: ...
@@ -713,7 +707,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
     def _insert_item(self, parent: Persistence.PersistentObject, name: str, before_index: int, item: Persistence.PersistentObject) -> None:
         if isinstance(item, DataItem.DataItem):
             item_uuid = item.uuid
-            storage_handler = self._make_storage_handler(make_data_item_metadata(item))
+            storage_handler = self._make_storage_handler(make_storage_handler_attributes(item))
             assert item_uuid not in self.__storage_adapter_map
             persistent_dict = self._get_persistent_dict(item)
             assert persistent_dict is not None
@@ -893,12 +887,13 @@ class FileProjectStorageSystem(ProjectStorageSystem):
     def get_identifier(self) -> str:
         return str(self.__project_path)
 
-    def _make_storage_handler(self, data_item_metadata: DataItemMetadata, file_handler_factory: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> StorageHandler.StorageHandler:
+    def _make_storage_handler(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes, file_handler_factory: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> StorageHandler.StorageHandler:
         # if there are two handlers, first is small, second is large
         # if there is only one handler, it is used in all cases
-        file_handler_factory = file_handler_factory if file_handler_factory else (self._file_handler_factories[-1] if data_item_metadata.large_format else self._file_handler_factories[0])
+        is_large_format = storage_handler_attributes.n_bytes > 16 * 1024 * 1024 or storage_handler_attributes._force_large_format
+        file_handler_factory = file_handler_factory if file_handler_factory else (self._file_handler_factories[-1] if is_large_format else self._file_handler_factories[0])
         assert self.__project_data_path is not None
-        return file_handler_factory.make(self.__project_data_path / self.__get_base_path(data_item_metadata))
+        return file_handler_factory.make(self.__project_data_path / self.__get_base_path(storage_handler_attributes))
 
     def _find_storage_handlers(self) -> typing.Sequence[StorageHandler.StorageHandler]:
         return self.__find_storage_handlers(self.__project_data_path)
@@ -936,11 +931,11 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                         data_item.read_from_dict(properties)
                         data_item.finish_reading()
                         old_file_path = storage_handler.reference
-                        new_file_path = storage_handler.factory.make_path(self.__project_data_path / self.__get_base_path(make_data_item_metadata(data_item)))
+                        new_file_path = storage_handler.factory.make_path(self.__project_data_path / self.__get_base_path(make_storage_handler_attributes(data_item)))
                         if not os.path.exists(new_file_path):
                             os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
                             shutil.move(old_file_path, new_file_path)
-                        self._make_storage_handler(make_data_item_metadata(data_item)).close()  # what's this line for?
+                        self._make_storage_handler(make_storage_handler_attributes(data_item)).close()  # what's this line for?
                         properties["__large_format"] = isinstance(storage_handler, HDF5Handler.HDF5Handler)
                         return properties
         finally:
@@ -978,7 +973,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
             file_handler_factory = self.__get_file_handler_factory_for_file(str(old_data_item_path))
             # ask the storage system to make a storage handler (an instance of a file handler) for the data item
             # this ensures that the storage handler (file format) is the same as before.
-            with contextlib.closing(self._make_storage_handler(make_data_item_metadata(old_data_item), file_handler_factory)) as target_storage_handler:
+            with contextlib.closing(self._make_storage_handler(make_storage_handler_attributes(old_data_item), file_handler_factory)) as target_storage_handler:
                 if target_storage_handler and storage_handler.reference != target_storage_handler.reference:
                     os.makedirs(os.path.dirname(target_storage_handler.reference), exist_ok=True)
                     target_storage_handler.prepare_move()
@@ -1036,10 +1031,10 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         migration_stage = typing.cast(FileProjectStorageSystemMigrationStage, migration_stage)
         return self.__find_storage_handlers(migration_stage.library_folder)
 
-    def __get_base_path(self, data_item_metadata: DataItemMetadata) -> pathlib.Path:
-        data_item_uuid = data_item_metadata.uuid
-        created_local = data_item_metadata.created_local
-        session_id = data_item_metadata.session_id
+    def __get_base_path(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes) -> pathlib.Path:
+        data_item_uuid = storage_handler_attributes.uuid
+        created_local = storage_handler_attributes.created_local
+        session_id = storage_handler_attributes.session_id
         # data_item_uuid.bytes.encode('base64').rstrip('=\n').replace('/', '_')
         # and back: data_item_uuid = uuid.UUID(bytes=(slug + '==').replace('_', '/').decode('base64'))
         # also:
@@ -1176,8 +1171,8 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
     def get_identifier(self) -> str:
         return "memory"
 
-    def _make_storage_handler(self, data_item_metadata: DataItemMetadata, file_handler: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> MemoryStorageHandler:
-        data_item_uuid_str = str(data_item_metadata.uuid)
+    def _make_storage_handler(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes, file_handler: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> MemoryStorageHandler:
+        data_item_uuid_str = str(storage_handler_attributes.uuid)
         return MemoryStorageHandler(data_item_uuid_str, self.__data_properties_map, self.__data_map, self._test_data_read_event)
 
     def _find_storage_handlers(self) -> typing.Sequence[StorageHandler.StorageHandler]:

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1256,11 +1256,11 @@ def make_memory_persistent_storage_system() -> Persistence.PersistentStorageInte
     return MemoryPersistentStorageSystem()
 
 
-def make_index_project_storage_system(project_path: pathlib.Path) -> Persistence.PersistentStorageInterface:
+def make_index_project_storage_system(project_path: pathlib.Path) -> ProjectStorageSystem:
     return FileProjectStorageSystem(project_path)
 
 
-def make_folder_project_storage_system(project_folder_path: pathlib.Path) -> typing.Optional[Persistence.PersistentStorageInterface]:
+def make_folder_project_storage_system(project_folder_path: pathlib.Path) -> typing.Optional[ProjectStorageSystem]:
     for project_file, project_dir in FileProjectStorageSystem._get_migration_paths(project_folder_path):
         if project_file.exists():
             return FileProjectStorageSystem(project_file, project_dir)

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -637,6 +637,12 @@ class ProjectStorageSystem(PersistentStorageSystem):
                 return typing.cast(PersistentDictType, item_d)
         assert False
 
+    def register_storage_handler(self, storage_handler: StorageHandler.StorageHandler, properties: PersistentDictType) -> None:
+        data_item_uuid = uuid.UUID(properties["uuid"])
+        assert data_item_uuid not in self.__storage_adapter_map
+        storage_adapter = DataItemStorageAdapter(storage_handler, properties)
+        self.__storage_adapter_map[data_item_uuid] = storage_adapter
+
     def read_project_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[Persistence.ReaderError]]:
         """Read data items from the data reference handler and return as a dict.
 

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 import gettext
 import math
+import uuid
 
 # third party libraries
 import numpy  # for arange
@@ -648,6 +649,11 @@ class Graphic(Persistence.PersistentObject):
         self.__source_reference = self.create_item_reference()
         self._default_stroke_color = "#F80"
         self._default_drag_part = "all"
+
+    def update_uuids(self, uuid_map: dict[uuid.UUID, uuid.UUID]) -> None:
+        assert not self.persistent_object_context
+        self.__source_reference.item = None
+        self.uuid = uuid_map.setdefault(self.uuid, uuid.uuid4())
 
     @property
     def source_specifier(self) -> typing.Optional[Persistence._SpecifierType]:

--- a/nion/swift/model/Persistence.py
+++ b/nion/swift/model/Persistence.py
@@ -1201,6 +1201,12 @@ class PersistentObject(Observable.Observable):
         relationship = self.__relationships[name]
         return relationship.index.get(uuid)
 
+    def change_relationship_item_uuid(self, name: str, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> None:
+        """Change the uuid of an item."""
+        relationship = self.__relationships[name]
+        item = relationship.index.pop(old_uuid)
+        relationship.index[new_uuid] = item
+
     def get_relationship_items(self, name: str) -> typing.List[PersistentObject]:
         """Return the relationship items without making a copy."""
         return self.__relationships[name].values

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -126,7 +126,7 @@ class ProjectReference(Persistence.PersistentObject):
     def project_reference_parts(self) -> typing.Sequence[str]:
         raise NotImplementedError()
 
-    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[Persistence.PersistentStorageInterface]:
+    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystem]:
         raise NotImplementedError()
 
     def read_project_info(self, profile_context: typing.Optional[ProfileContext]) -> None:
@@ -249,7 +249,7 @@ class IndexProjectReference(ProjectReference):
         project_path = self.project_path
         return project_path.parts if project_path else tuple()
 
-    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[Persistence.PersistentStorageInterface]:
+    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystem]:
         project_path = self.project_path
         if project_path:
             return FileStorageSystem.make_index_project_storage_system(project_path)
@@ -295,7 +295,7 @@ class FolderProjectReference(ProjectReference):
     def project_reference_parts(self) -> typing.Sequence[str]:
         return self.project_folder_path.parts if self.project_folder_path else tuple()
 
-    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[Persistence.PersistentStorageInterface]:
+    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystem]:
         if self.project_folder_path:
             return FileStorageSystem.make_folder_project_storage_system(self.project_folder_path)
         return None
@@ -348,7 +348,7 @@ class PlaceholderProjectReference(ProjectReference):
     def project_reference_parts(self) -> typing.Sequence[str]:
         return (self.type, str(self.project_uuid or uuid.UUID()))
 
-    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[Persistence.PersistentStorageInterface]:
+    def make_storage(self, profile_context: typing.Optional[ProfileContext]) -> typing.Optional[FileStorageSystem.ProjectStorageSystem]:
         return None
 
 

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -41,7 +41,7 @@ class Project(Persistence.PersistentObject):
 
     PROJECT_VERSION = 3
 
-    def __init__(self, storage_system: Persistence.PersistentStorageInterface, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
+    def __init__(self, storage_system: FileStorageSystem.ProjectStorageSystem, cache_factory: typing.Optional[Cache.CacheFactory] = None) -> None:
         super().__init__()
 
         self.define_type("project")
@@ -242,7 +242,7 @@ class Project(Persistence.PersistentObject):
         return ListModel.PredicateFilter(functools.partial(is_display_item_active, weakref.ref(self)))
 
     @property
-    def project_storage_system(self) -> Persistence.PersistentStorageInterface:
+    def project_storage_system(self) -> FileStorageSystem.ProjectStorageSystem:
         return self.__storage_system
 
     def __data_item_inserted(self, name: str, before_index: int, data_item: DataItem.DataItem) -> None:

--- a/nion/swift/model/Schema.py
+++ b/nion/swift/model/Schema.py
@@ -662,6 +662,11 @@ class ReferenceField(Field):
     def reference_uuid(self) -> typing.Optional[uuid.UUID]:
         return self.__reference_uuid
 
+    def _update_reference_uuid(self, reference_uuid: typing.Optional[uuid.UUID]) -> None:
+        assert not self.__reference
+        assert not self.__shadow_item
+        self.__reference_uuid = reference_uuid
+
 
 class ComponentField(Field):
     """A component field, references another entity with cascading delete."""

--- a/nion/swift/model/StorageHandler.py
+++ b/nion/swift/model/StorageHandler.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import dataclasses
+import datetime
+import pathlib
 import typing
+import uuid
 
 import numpy
 import numpy.typing
-
-if typing.TYPE_CHECKING:
-    import datetime
-    import pathlib
 
 
 PersistentDictType = typing.Dict[str, typing.Any]
@@ -51,3 +51,38 @@ class StorageHandler(typing.Protocol):
     def prepare_move(self) -> None: ...
 
     def remove(self) -> None: ...
+
+
+@dataclasses.dataclass
+class StorageHandlerAttributes:
+    """Attributes for organizing within storage system."""
+    uuid: uuid.UUID
+    created_local: datetime.datetime
+    session_id: str | None
+    n_bytes: int
+    _force_large_format: bool = False
+
+
+class StorageHandlerProvider(typing.Protocol):
+    def make_storage_handler(self, attributes: StorageHandlerAttributes) -> StorageHandler: ...
+
+
+@dataclasses.dataclass
+class StorageHandlerImportData:
+    storage_handlers: typing.Sequence[StorageHandler]
+    uuid_map: typing.Mapping[uuid.UUID, uuid.UUID]
+    items: typing.Sequence[PersistentDictType]
+
+
+class StorageHandlerExportDataItem(typing.Protocol):
+    def write_to_dict(self) -> PersistentDictType: ...
+
+    @property
+    def data(self) -> _NDArray: raise NotImplementedError()
+
+
+class StorageHandlerExportItem(typing.Protocol):
+    def write_to_dict(self) -> PersistentDictType: ...
+
+    @property
+    def data_items(self) -> typing.Sequence[StorageHandlerExportDataItem]: raise NotImplementedError()

--- a/nion/swift/resources/changes.json
+++ b/nion/swift/resources/changes.json
@@ -3,6 +3,10 @@
     "version": "UNRELEASED",
     "notes": [
       {
+        "issues": ["https://github.com/nion-software/nionswift-io/issues/23"],
+        "summary": "Add support for exporting to HDF5-based 'nhdf' file format."
+      },
+      {
         "issues": ["https://github.com/nion-software/nionswift/issues/1125"],
         "summary": "Change Export SVG dialog to remember units."
       },

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -429,7 +429,7 @@ class TestDataPanelClass(unittest.TestCase):
             data_panel = document_controller.find_dock_panel("data-panel")
             data_panel.focused = True
             self.assertIsNone(document_controller.selected_display_item)
-            document_controller.receive_project_files([pathlib.Path(":/app/scroll_gem.png")], project=document_model._project, index=0, threaded=False)
+            document_controller.receive_files([pathlib.Path(":/app/scroll_gem.png")], index=0)
             document_controller.periodic()
             self.assertEqual(document_controller.selected_display_item, document_model.display_items[1])
 

--- a/nion/swift/test/DocumentController_test.py
+++ b/nion/swift/test/DocumentController_test.py
@@ -181,24 +181,10 @@ class TestDocumentControllerClass(unittest.TestCase):
             data_item3 = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
             data_item3.title = "data_item3"
             document_model.append_data_item(data_item3)
-            new_data_items = document_controller.receive_files([":/app/scroll_gem.png"], threaded=False)
+            count_before_import = len(document_model.data_items)
+            document_controller.receive_files([":/app/scroll_gem.png"])
+            new_data_items = document_model.data_items[count_before_import:]
             self.assertEqual(document_model.data_items.index(new_data_items[0]), 3)
-
-    def test_receive_files_should_put_files_into_document_model_at_index(self):
-        with TestContext.create_memory_context() as test_context:
-            document_controller = test_context.create_document_controller()
-            document_model = document_controller.document_model
-            data_item1 = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
-            data_item1.title = "data_item1"
-            document_model.append_data_item(data_item1)
-            data_item2 = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
-            data_item2.title = "data_item2"
-            document_model.append_data_item(data_item2)
-            data_item3 = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
-            data_item3.title = "data_item3"
-            document_model.append_data_item(data_item3)
-            new_data_items = document_controller.receive_files([":/app/scroll_gem.png"], index=2, threaded=False)
-            self.assertEqual(document_model.data_items.index(new_data_items[0]), 2)
 
     def test_receive_files_should_put_files_into_data_group_at_index(self):
         with TestContext.create_memory_context() as test_context:
@@ -218,7 +204,9 @@ class TestDocumentControllerClass(unittest.TestCase):
             data_item3.title = "data_item3"
             document_model.append_data_item(data_item3)
             data_group.append_display_item(document_model.get_display_item_for_data_item(data_item3))
-            new_data_items = document_controller.receive_files([":/app/scroll_gem.png"], data_group=data_group, index=2, threaded=False, project=document_model._project)
+            count_before_import = len(document_model.data_items)
+            document_controller.receive_files([":/app/scroll_gem.png"], data_group=data_group, index=2)
+            new_data_items = document_model.data_items[count_before_import:]
             self.assertEqual(document_model.data_items.index(new_data_items[0]), 3)
             self.assertEqual(data_group.display_items.index(document_model.get_display_item_for_data_item(new_data_items[0])), 2)
 

--- a/nion/swift/test/ImportExportManager_test.py
+++ b/nion/swift/test/ImportExportManager_test.py
@@ -199,15 +199,21 @@ class TestImportExportManagerClass(unittest.TestCase):
                 os.remove(file_path_bgr)
 
     def test_get_writers_for_empty_data_item_returns_valid_list(self):
-        data_item = DataItem.DataItem()
-        with contextlib.closing(data_item):
-            writers = ImportExportManager.ImportExportManager().get_writers_for_data_item(data_item)
+        with TestContext.create_memory_context() as test_context:
+            document_model = test_context.create_document_model()
+            data_item = DataItem.DataItem()
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            writers = ImportExportManager.ImportExportManager().get_writers_for_display_item(display_item)
             self.assertEqual(len(writers), 0)
 
     def test_get_writers_for_float_2d_data_item_returns_valid_list(self):
-        data_item = DataItem.DataItem(numpy.zeros((8, 8), float))
-        with contextlib.closing(data_item):
-            writers = ImportExportManager.ImportExportManager().get_writers_for_data_item(data_item)
+        with TestContext.create_memory_context() as test_context:
+            document_model = test_context.create_document_model()
+            data_item = DataItem.DataItem(numpy.zeros((8, 8), float))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            writers = ImportExportManager.ImportExportManager().get_writers_for_display_item(display_item)
             self.assertTrue(len(writers) > 0)
 
     def test_data_element_date_gets_set_as_data_item_created_date(self):

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -3376,7 +3376,8 @@ class TestStorageClass(unittest.TestCase):
                 profile.read_profile()
                 document_model = profile_context.create_document_model(auto_close=False)
                 with document_model.ref():
-                    with contextlib.closing(document_model._project.project_storage_system._make_storage_handler(data_item)) as handler:
+                    storage_handler_attributes = FileStorageSystem.make_storage_handler_attributes(data_item)
+                    with contextlib.closing(document_model._project.project_storage_system._make_storage_handler(storage_handler_attributes)) as handler:
                         handler.write_properties(data_item.write_to_dict(), DateTime.utcnow())
                         handler.write_data(numpy.zeros((8,8)), DateTime.utcnow())
             # read the document and migrate


### PR DESCRIPTION
This adds a new import/export file format which can handle any internal data type and also includes the associated display. It is based on HDF5 and I chose the file extension "nhdf". The commits up until the last one are preparatory and can be reviewed in order. The last commit (bottom of the list below) is the actual introduction of the file format. This PR is not optimized or tested for performance. The writer implementation currently only exports a single display/data item; but the format itself supports multiple data and display items. The reader implements multiples already.

Testing this PR involves exporting any display item to a file and re-importing it into the same or another project. During import, all internal objects are assigned new uuid's so there is no conflict.

- **Change io handler to determine writeability based on display item rather than data only.**
- **Restructure receive_files to be not-threaded and not-undoable.**
- **Change _make_storage_handler to take metadata rather than the data item itself.**
- **Narrow typing of storage_system passed to Project to ProjectStorageSystem.**
- **Refactor project loading into smaller methods. Add function to register storage handler.**
- **Use numpy.copy to be more compatible with h5py arrays.**
- **Add support for updating all display item uuid's before added to document.**
- **Refactor import to return a more generalized import data structure.**
- **Restructure importer to faciliate low level importer/exporter via registration.**
- **Add ndata HDF file format via low level import-export driver.**
