### PR TITLE
Add switch project action and associated required machinery

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -880,7 +880,7 @@ class NewProjectAction(UIWindow.Action):
 
 
 class OpenProjectAction(UIWindow.Action):
-    action_id = "project.open_project"
+    action_id = "project.open_project_dialog"
     action_name = _("Open Project...")
 
     def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -686,7 +686,7 @@ class CollectionIndexAdapter(IndexValueAdapter):
     def get_index_value(self, display_data_channel: DisplayItem.DisplayDataChannel) -> float:
         index = self.__collection_index + (1 if display_data_channel.is_sequence else 0)
         dim_length = display_data_channel.dimensional_shape[index] if display_data_channel.dimensional_shape is not None else 0
-        return display_data_channel.collection_index[self.__collection_index] / (dim_length - 1)
+        return display_data_channel.collection_index[self.__collection_index] / (dim_length - 1) if dim_length > 1 else 0.0
 
     def get_index_str(self, display_data_channel: DisplayItem.DisplayDataChannel) -> str:
         return str(display_data_channel.collection_index[self.__collection_index])

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -385,6 +385,11 @@ class DocumentController(Window.Window):
     def consoles(self) -> typing.Sequence[ConsoleDialog.ConsoleDialog]:
         return self.__consoles
 
+    @property
+    def _project_reference(self) -> typing.Optional[Profile.ProjectReference]:
+        # TEST ONLY
+        return self.__project_reference
+
     def _create_menus(self) -> None:
         # don't use default implementation
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1785,7 +1785,7 @@ class DisplayDataShapeCalculator:
             else:
                 self.shape = tuple(dimensional_shape[next_dimension:])
                 self.calibrations = dimensional_calibrations[next_dimension:]
-                self.indexes = tuple(range(next_dimension, next_dimension + len(dimensional_shape)))
+                self.indexes = tuple(range(len(dimensional_shape)))[next_dimension:]
 
 
 class CalibrationDescriptionLike:

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -628,6 +628,18 @@ class Profile(Persistence.PersistentObject):
                 return project_reference
         return None
 
+    def get_project_reference_by_project_uuid(self, project_uuid: uuid.UUID) -> typing.Optional[ProjectReference]:
+        for project_reference in self.project_references:
+            if project_reference.project_uuid == project_uuid:
+                return project_reference
+        return None
+
+    def get_project_reference_by_path(self, path: pathlib.Path) -> typing.Optional[ProjectReference]:
+        for project_reference in self.project_references:
+            if project_reference.path == path:
+                return project_reference
+        return None
+
     def append_project_reference(self, project_reference: ProjectReference) -> None:
         assert not self.get_item_by_uuid("project_references", project_reference.uuid)
         assert project_reference.project_uuid not in {project_reference.project_uuid for project_reference in self.project_references}

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -14,7 +14,6 @@ from nion.swift.model import Cache
 from nion.swift.model import Changes
 from nion.swift.model import Connection
 from nion.swift.model import DataGroup
-from nion.swift.model import Symbolic
 from nion.swift.model import DataItem
 from nion.swift.model import DataStructure
 from nion.swift.model import DisplayItem

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -10,7 +10,7 @@
             },
             {
                 "type": "item",
-                "action_id": "project.open_project"
+                "action_id": "project.open_project_dialog"
             },
             {
                 "type": "item",

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1592,6 +1592,17 @@ class TestDisplayPanelClass(unittest.TestCase):
             document_controller.periodic()
             self.assertIsInstance(display_panel.display_canvas_item, ImageCanvasItem.ImageCanvasItem)
 
+    def test_display_2d_collection_with_dimension_1(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            display_panel = document_controller.selected_display_panel
+            data_item = DataItem.DataItem()
+            data_item.set_xdata(DataAndMetadata.new_data_and_metadata(numpy.ones((1, 1, 8, 8)), data_descriptor=DataAndMetadata.DataDescriptor(False, 2, 2)))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_panel.set_display_panel_display_item(display_item)
+
     def test_image_display_canvas_item_only_updates_if_display_data_changes(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()


### PR DESCRIPTION
- **Rename action_id for open project dialog.**
- **Remove duplicate import.**
- **Add a method to execute a list of application level commands.**
- **Add a switch project action, useful for testing.**

Console script, useful for testing. Switches repeatedly between last four projects.
```
app = api.application._application
project_uuids = [project_reference.project_uuid for project_reference in app._get_recent_project_references()[:4]]
commands = [("project.switch_project", {"project_uuid": project_uuid}) for project_uuid in project_uuids]
app.execute_command_list(commands, command_delay=2, repeat=10)
```