### PR TITLE
improve master detail browser

### DIFF
--- a/nion/swift/EntityBrowser.py
+++ b/nion/swift/EntityBrowser.py
@@ -480,7 +480,7 @@ Registry.register_component(DynamicDeclarativeWidgetConstructor(), {"declarative
 class MasterDetailHandler(Declarative.Handler):
 
     def __init__(self, model: Observable.Observable, items_key: str, component_fn: DynamicWidgetConstructorFn,
-                 title_getter: typing.Callable[[typing.Any], str]) -> None:
+                 title_getter: typing.Callable[[typing.Any], str], list_props: dict[str, typing.Any]) -> None:
         super().__init__()
 
         self.__component_fn = component_fn
@@ -510,8 +510,7 @@ class MasterDetailHandler(Declarative.Handler):
 
         item_list = u.create_list_box(items_ref="@binding(titles_model.items)",
                                       current_index="@binding(index_model.value)",
-                                      width=160, min_height=480,
-                                      size_policy_vertical="expanding")
+                                      **list_props)
 
         item_stack = u.create_stack(items=f"items_model.{items_key}", item_component_id="detail", current_index="@binding(index_model.value)")
 
@@ -567,7 +566,8 @@ class EntityBrowserEntry:
 
 
 def make_master_detail(project_item_handler: EntityBrowserEntry) -> Declarative.HandlerLike:
-    return MasterDetailHandler(project_item_handler.model, project_item_handler.items_key, project_item_handler.component_fn, project_item_handler.title_getter)
+    list_props = {"width": 160, "min_height": 480, "size_policy_vertical": "expanding"}
+    return MasterDetailHandler(project_item_handler.model, project_item_handler.items_key, project_item_handler.component_fn, project_item_handler.title_getter, list_props)
 
 
 class TopLevelItemHandler(Declarative.Handler):
@@ -624,4 +624,5 @@ def make_entity_browser_component(items: typing.Sequence[EntityBrowserEntry]) ->
     """Make an entity browser component with the top level items."""
 
     list_model = ListModel.ListModel[EntityBrowserEntry](items=items)
-    return MasterDetailHandler(list_model, "items", typing.cast(DynamicWidgetConstructorFn, TopLevelItemHandler), operator.attrgetter("label"))
+    list_props = {"width": 160, "min_height": 480, "size_policy_vertical": "expanding"}
+    return MasterDetailHandler(list_model, "items", typing.cast(DynamicWidgetConstructorFn, TopLevelItemHandler), operator.attrgetter("label"), list_props)

--- a/nion/swift/ProjectItemsDialog.py
+++ b/nion/swift/ProjectItemsDialog.py
@@ -214,21 +214,21 @@ class ProjectItemsDialog(Declarative.WindowHandler):
 
         items = (
             EntityBrowser.EntityBrowserEntry(context, _("Data Items"), document_controller.document_model, "data_items",
-                                             DataModel.DataItem, _("Data Item"), lambda x: typing.cast(str, x.title) if x.title else _("Auto")),
+                                             DataModel.DataItem, _("Data Item"), "title", _("Auto")),
             EntityBrowser.EntityBrowserEntry(context, _("Display Items"), document_controller.document_model, "display_items",
-                                             DataModel.DisplayItem, _("Display Item"), operator.attrgetter("displayed_title")),
+                                             DataModel.DisplayItem, _("Display Item"), "displayed_title"),
             EntityBrowser.EntityBrowserEntry(context, _("Data Structures"), document_controller.document_model, "data_structures",
-                                             None, _("Data Structure"), operator.attrgetter("structure_type")),
+                                             None, _("Data Structure"), "structure_type"),
             EntityBrowser.EntityBrowserEntry(context, _("Computations"), document_controller.document_model, "computations",
-                                             DataModel.Computation, _("Computation"), operator.attrgetter("label")),
+                                             DataModel.Computation, _("Computation"), "label"),
             EntityBrowser.EntityBrowserEntry(context, _("Connections"), document_controller.document_model, "connections",
-                                             DataModel.Connection, _("Connection"), lambda x: str(x.uuid)),
+                                             DataModel.Connection, _("Connection"), "uuid"),
             EntityBrowser.EntityBrowserEntry(context, _("Data Groups"), document_controller.document_model, "data_groups",
-                                             DataModel.DataGroup, _("Data Group"), operator.attrgetter("title")),
+                                             DataModel.DataGroup, _("Data Group"), "title"),
             EntityBrowser.EntityBrowserEntry(context, _("Projects"), typing.cast(typing.Any, document_controller.app).profile, "projects",
-                                             ProjectExtra, _("Project"), lambda x: x.title or _("Project")),
+                                             ProjectExtra, _("Project"), "title", _("Project")),
             EntityBrowser.EntityBrowserEntry(context, _("Workspaces"), document_controller.project, "workspaces",
-                                             DataModel.Workspace, _("Workspace"), operator.attrgetter("name")),
+                                             DataModel.Workspace, _("Workspace"), "name"),
         )
 
         # close any previous list dialog associated with the window

--- a/nion/swift/model/Schema.py
+++ b/nion/swift/model/Schema.py
@@ -1119,9 +1119,6 @@ class Entity(Observable.Observable):
         else:
             raise AttributeError()
 
-    def _field_value_changed(self, name: str, value: typing.Any) -> None:
-        pass
-
     def _get_array_item(self, name: str, index: int) -> typing.Any:
         array_field = typing.cast(typing.Optional[ArrayField], self.__get_field(name))
         if array_field:
@@ -1142,6 +1139,8 @@ class Entity(Observable.Observable):
             entity = typing.cast(Entity, item)
             entity._set_entity_parent(EntityParent(self, relationship_name=name))
             array_field.insert_value(self, index, item)  # passing self for container
+            self._set_modified(DateTime.utcnow())
+            self._item_inserted(name, index, item)
             self.item_inserted_event.fire(name, item, index)
         else:
             raise AttributeError()
@@ -1156,9 +1155,22 @@ class Entity(Observable.Observable):
             array_field.remove_value_at_index(index)  # passing self for container
             entity = typing.cast(Entity, item)
             entity._set_entity_parent(None)
+            self._set_modified(DateTime.utcnow())
+            self._item_removed(name, index, item)
             self.item_removed_event.fire(name, item, index)
         else:
             raise AttributeError()
+
+    # these methods can be overridden to provide custom behavior for storage and notification
+
+    def _field_value_changed(self, name: str, value: typing.Any) -> None:
+        pass
+
+    def _item_inserted(self, name: str, index: int, item: ItemProxyEntity) -> None:
+        pass
+
+    def _item_removed(self, name: str, index: int, item: ItemProxyEntity) -> None:
+        pass
 
     # compatibility functions for persistent object
 


### PR DESCRIPTION
- **Change master detail handler to take sizing properties as parameter.**
- **Add support for add/remove buttons to master-detail browser.**
- **Refactor master detail browser to use simplified list based on property rather than mapping.**
- **Add tracking of parent entity in entities for compatibility with persistence framework.**
- **Expand entity custom class factory capability.**
- **Add ability to write entity to storage when inserted/removed.**

The master-detail browser is currently used in the project items dialog, which is a debugging dialog used to examine most objects in a project.

However, it is a generally useful UI element that can be used in future situations. Particularly, I'm working on a capability to add custom command buttons #926.

Additionally, the original main project items (data item, display item, computation, etc.) were implemented within a persistence framework which ensures that they get written to disk when changed. A newer cleaner entity system also exists which potentially could simplify the object and persistence framework. The entity system lacks some capabilities that the persistence system implements, such as writing out sub-items when inserted/removed from relationships. This PR also addresses those in conjunction with the master-detail handler.

All of the changes in this PR are required to implement the custom command buttons which will be submitted in an upcoming PR.

Also, these are all "internal" changes that won't have a visible effect on the existing project items dialog, although it should continue to work the same.