### PR TITLE
Fix #1203. Eliminate use of data sampling to calculate complex display limits.

### DIFF
--- a/nion/swift/test/Display_test.py
+++ b/nion/swift/test/Display_test.py
@@ -488,7 +488,7 @@ class TestDisplayClass(unittest.TestCase):
             display_data_channel.reset_display_limits()
             # the display limit should never be less than the display data minimum
             display_range = display_data_channel.get_latest_computed_display_values().display_range
-            self.assertLess(numpy.amin(display_data_channel.get_latest_computed_display_values().display_data_and_metadata.data), display_range[0])
+            self.assertLessEqual(numpy.amin(display_data_channel.get_latest_computed_display_values().display_data_and_metadata.data), display_range[0])
             self.assertAlmostEqual(numpy.amax(
                 display_data_channel.get_latest_computed_display_values().display_data_and_metadata.data), display_range[1])
 


### PR DESCRIPTION
The sample size was 200 and in no way could be representative of an
arbitrary complex valued image displayed in log-absolute. This was probably
done for perceived performance; but modern processors make the performance
issue minimal. So do not sample; just use the full range until a good
general sampling solution is implemented.
