### PR TITLE
Add verify of Project File Name on text_changed in New Project window

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -45,6 +45,7 @@ from nion.swift.model import FileStorageSystem
 from nion.swift.model import PlugInManager
 from nion.swift.model import Profile
 from nion.swift.model import Symbolic
+from nion.swift.model import Utility
 from nion.ui import Application as UIApplication
 from nion.ui import CanvasItem
 from nion.ui import Declarative
@@ -899,6 +900,19 @@ class NewProjectAction(UIWindow.Action):
                     safe_request_close()
                     return True
 
+                def verify_project_name(text: str) -> None:
+                    valid = text == Utility.simplify_filename(text)
+                    if valid:
+                        create_project_button.enabled = True
+                        create_project_button.tool_tip = None
+                        create_project_button.background_color = None
+                        project_name_field.background_color = None
+                    else:
+                        create_project_button.enabled = False
+                        create_project_button.background_color = "orange"
+                        create_project_button.tool_tip = "Invalid Characters in Project Name"
+                        project_name_field.background_color = "orange"
+
                 column = self.ui.create_column_widget()
 
                 directory_header_row = self.ui.create_row_widget()
@@ -933,6 +947,7 @@ class NewProjectAction(UIWindow.Action):
                 project_name_field.text = self.project_name
                 project_name_field.on_return_pressed = handle_new_and_close
                 project_name_field.on_escape_pressed = safe_request_close
+                project_name_field.on_text_edited = verify_project_name
                 project_name_row.add(project_name_field)
                 project_name_row.add_stretch()
                 project_name_row.add_spacing(13)
@@ -960,7 +975,7 @@ class NewProjectAction(UIWindow.Action):
                 choose_directory_button.on_clicked = choose
 
                 self.add_button(_("Cancel"), lambda: True)
-                self.add_button(_("Create Project"), handle_new_and_close)
+                create_project_button = self.add_button(_("Create Project"), handle_new_and_close)
 
                 self.content.add(column)
 


### PR DESCRIPTION
Added explicit sanity check of Project Name when text changed on the field.  Verifies compatibility using Utility.simplify_filename which detects any non-compatible filenames and returns a sanitised version so if they are different it means it was not compatible. Currently the identification for the user is some orange background flair and a tooltip on the Create button.