### PR TITLE
Use canvas item layout to layout and render the display panel headers.

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -36,6 +36,7 @@ from nion.swift.model import Graphics
 from nion.swift.model import Persistence
 from nion.swift.model import UISettings
 from nion.swift.model import Utility
+from nion.swift.model.UISettings import TruncateModeType
 from nion.ui import CanvasItem
 from nion.ui import DrawingContext
 from nion.ui import GridCanvasItem
@@ -1708,6 +1709,9 @@ class DisplayPanelUISettings(UISettings.UISettings):
     def get_font_metrics(self, font: str, text: str) -> UISettings.FontMetrics:
         return typing.cast(UISettings.FontMetrics, self.__ui.get_font_metrics(font, text))
 
+    def truncate_string_to_width(self, font_str: str, text: str, pixel_width: int, mode: UISettings.TruncateModeType) -> str:
+        return self.__ui.truncate_string_to_width(font_str, text, pixel_width, typing.cast(UserInterface.TruncateModeType, mode))
+
     @property
     def cursor_tolerance(self) -> float:
         return self.__ui.get_tolerance(UserInterface.ToleranceType.CURSOR)
@@ -1719,6 +1723,9 @@ class FixedUISettings(UISettings.UISettings):
 
     def get_font_metrics(self, font: str, text: str) -> UISettings.FontMetrics:
         return UISettings.FontMetrics(width=round(6.5 * len(text)), height=15, ascent=12, descent=3, leading=0)
+
+    def truncate_string_to_width(self, font_str: str, text: str, pixel_width: int, mode: UISettings.TruncateModeType) -> str:
+        raise NotImplementedError()
 
     @property
     def cursor_tolerance(self) -> float:

--- a/nion/swift/FilterPanel.py
+++ b/nion/swift/FilterPanel.py
@@ -18,6 +18,7 @@ import weakref
 from nion.swift import Panel
 from nion.swift.model import DisplayItem
 from nion.swift.model import UISettings
+from nion.ui import UserInterface
 from nion.utils import ListModel
 
 if typing.TYPE_CHECKING:
@@ -31,6 +32,21 @@ _KeyListType = typing.List[_KeyType]
 _ValueType = DisplayItem.DisplayItem
 
 _ = gettext.gettext
+
+
+class FilterPanelUISettings(UISettings.UISettings):
+    def __init__(self, ui: UserInterface.UserInterface) -> None:
+        self.__ui = ui
+
+    def get_font_metrics(self, font: str, text: str) -> UISettings.FontMetrics:
+        return typing.cast(UISettings.FontMetrics, self.__ui.get_font_metrics(font, text))
+
+    def truncate_string_to_width(self, font_str: str, text: str, pixel_width: int, mode: UISettings.TruncateModeType) -> str:
+        return self.__ui.truncate_string_to_width(font_str, text, pixel_width, typing.cast(UserInterface.TruncateModeType, mode))
+
+    @property
+    def cursor_tolerance(self) -> float:
+        return self.__ui.get_tolerance(UserInterface.ToleranceType.CURSOR)
 
 
 # TODO: Add button to convert between (filter <-> smart group) -> regular group
@@ -271,8 +287,7 @@ class FilterPanel:
         date_browser.add(date_browser_tree_widget)
         date_browser.add_stretch()
 
-        # TODO: clean up UISettings FontMetrics definition
-        header_canvas_item = Panel.HeaderCanvasItem(typing.cast(UISettings.UISettings, document_controller), _("Filter"))
+        header_canvas_item = Panel.HeaderCanvasItem(FilterPanelUISettings(document_controller.ui), _("Filter"))
 
         header_widget = ui.create_canvas_widget(properties={"height": header_canvas_item.header_height})
         header_widget.canvas_item.add_canvas_item(header_canvas_item)

--- a/nion/swift/model/UISettings.py
+++ b/nion/swift/model/UISettings.py
@@ -1,4 +1,5 @@
 import dataclasses
+import enum
 import typing
 
 
@@ -11,9 +12,19 @@ class FontMetrics:
     leading: int
 
 
+class TruncateModeType(enum.IntEnum):
+    LEFT = 0
+    RIGHT = 1
+    MIDDLE = 2
+    NONE = 3
+
+
 class UISettings(typing.Protocol):
 
     def get_font_metrics(self, font: str, text: str) -> FontMetrics:
+        ...
+
+    def truncate_string_to_width(self, font_str: str, text: str, pixel_width: int, mode: TruncateModeType) -> str:
         ...
 
     @property

--- a/nion/swift/resources/changes.json
+++ b/nion/swift/resources/changes.json
@@ -4,6 +4,12 @@
     "notes": [
       {
         "issues": [
+          "https://github.com/nion-software/nionswift/issues/1028", "https://github.com/nion-software/nionswift/issues/1280"
+        ],
+        "summary": "Improve display panel header to truncate string when not enough room. Add mouse over highlighting."
+      },
+      {
+        "issues": [
           "https://github.com/nion-software/nionswift/issues/1238"
         ],
         "summary": "Add a line profile computation automatically when copying and pasting a line profile from one image to another."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = nionswift
 version = 16.13.0
+# nionutils 4.14 (Platform)
 author = Nion Software
 author_email = swift@nion.com
 description = Nion Swift: Scientific Image Processing.


### PR DESCRIPTION
Adds highlighting when mouse over the title; and title middle truncation when
title is too long.
