### PR TITLE
Pass only read-only parameters to computation execute

### DIFF
--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1784,6 +1784,25 @@ class BoundDataStructure(BoundItemBase):
         super().close()
 
     @property
+    def computation_value(self) -> typing.Any:
+        if self.__property_name:
+            return getattr(self.__object, self.__property_name)
+
+        class DataStructureComputationValue:
+            def __init__(self, d: typing.Mapping[str, typing.Any]) -> None:
+                self.structure_type = d.get("structure_type", None)
+                for k, v in d["properties"].items():
+                    setattr(self, k, v)
+
+            def get_property(self, property: str) -> typing.Any:
+                return getattr(self, property, None)
+
+            def set_property(self, property: str, value: typing.Any) -> None:
+                setattr(self, property, value)
+
+        return DataStructureComputationValue(self.__object.write_to_dict()) if self.__object else None
+
+    @property
     def value(self) -> typing.Any:
         if self.__object and self.__property_name:
             return self.__object.get_property_value(self.__property_name)

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1932,6 +1932,10 @@ class BoundList(BoundItemBase):
         super().close()
 
     @property
+    def computation_value(self) -> typing.List[typing.Any]:
+        return [bound_item.computation_value if bound_item else None for bound_item in self.__bound_items]
+
+    @property
     def value(self) -> typing.List[typing.Any]:
         return [bound_item.value if bound_item else None for bound_item in self.__bound_items]
 

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1830,6 +1830,13 @@ class BoundGraphic(BoundItemBase):
         super().close()
 
     @property
+    def computation_value(self) -> typing.Any:
+        region = self.__object.get_region() if self.__object else None
+        if self.__property_name:
+            return getattr(region, self.__property_name)
+        return region
+
+    @property
     def value(self) -> typing.Any:
         if self.__property_name:
             return getattr(self.__object, self.__property_name)

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1233,7 +1233,14 @@ class BoundItemBase(Observable.Observable):
         BoundItemBase.count -= 1
 
     @property
+    def computation_value(self) -> typing.Any:
+        # this is the value passed to a computation using this bound item
+        return self.value
+
+    @property
     def value(self) -> typing.Any:
+        # this is the value or input object for the bound item.
+        # this may be different from computation_value while transitioning to the threaded computation system.
         return None
 
     @property
@@ -2368,7 +2375,7 @@ class Computation(Persistence.PersistentObject):
         for variable in self.variables:
             bound_object = variable.bound_item
             if bound_object is not None:
-                resolved_object = bound_object.value if bound_object else None
+                resolved_object = bound_object.computation_value if bound_object else None
                 # in the ideal world, we could clone the object/data and computations would not be
                 # able to modify the input objects; reality, though, dictates that performance is
                 # more important than this protection. so use the resolved object directly.

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1083,7 +1083,7 @@ class DataSource:
         self.__display_values = display_data_channel.get_latest_display_values() if display_data_channel else None
 
     def close(self) -> None:
-        pass
+        self.__display_values = None
 
     @property
     def data(self) -> typing.Optional[DataAndMetadata._ImageDataType]:
@@ -1257,7 +1257,6 @@ class BoundData(BoundItemBase):
 
     def __init__(self, container: Persistence.PersistentObject, specifier: DataSpecifier) -> None:
         super().__init__(specifier)
-
         self.__item_reference = container.create_item_reference(item_specifier=Persistence.read_persistent_specifier(specifier.reference_uuid))
         self.__data_changed_event_listener: typing.Optional[Event.EventListener] = None
 

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -1551,6 +1551,18 @@ class BoundDataItem(BoundItemBase):
         super().close()
 
     @property
+    def computation_value(self) -> typing.Any:
+        class DataItemComputationValue:
+            def __init__(self, xdata: DataAndMetadata.DataAndMetadata) -> None:
+                self.xdata = xdata
+
+            @property
+            def data(self) -> typing.Optional[DataAndMetadata._ImageDataType]:
+                return self.xdata.data if self.xdata else None
+
+        return DataItemComputationValue(self._data_item.xdata) if self._data_item and self._data_item.xdata else None
+
+    @property
     def value(self) -> typing.Optional[DataItem.DataItem]:
         return self._data_item
 

--- a/nion/swift/test/DataItem_test.py
+++ b/nion/swift/test/DataItem_test.py
@@ -1462,7 +1462,7 @@ class TestDataItemClass(unittest.TestCase):
             data_item2 = DataItem.DataItem(numpy.zeros((8, 8)))
             document_model.append_data_item(data_item)
             document_model.append_data_item(data_item2)
-            computation = document_model.create_computation("target.xdata = src")
+            computation = document_model.create_computation("target.xdata = src.filter_xdata")
             display_item = document_model.get_display_item_for_data_item(data_item)
             computation.create_input_item("src", Symbolic.make_item(display_item.display_data_channel, type="filter_xdata"))
             document_model.set_data_item_computation(data_item2, computation)

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -88,6 +88,7 @@ class TestDataPanelClass(unittest.TestCase):
                 display_panel.set_display_panel_display_item(display_item1)
                 data_panel = document_controller.find_dock_panel("data-panel")
                 document_controller.select_data_item_in_data_panel(data_item=data_item1)
+                document_model.recompute_all()
                 document_controller.periodic()
                 document_controller.selected_display_panel = display_panel
                 # first delete a child of a data item

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -140,6 +140,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.assertEqual(self.data_item, self.document_model.data_items[0])
         self.assertEqual(self.display_item.data_item, self.data_item)
         self.document_controller.processing_invert()
+        self.document_model.recompute_all()
         self.document_controller.periodic()
         self.display_panel.set_display_panel_display_item(self.display_item)
         self.assertEqual(self.display_panel.data_item, self.data_item)
@@ -152,6 +153,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.assertEqual(self.display_panel.data_item, self.data_item)
         inverted_data_item = self.document_controller.processing_invert().data_item
         inverted_display_item = self.document_model.get_display_item_for_data_item(inverted_data_item)
+        self.document_model.recompute_all()
         self.document_controller.periodic()
         self.display_panel.set_display_panel_display_item(inverted_display_item)
         self.assertEqual(self.display_panel.data_item, inverted_data_item)
@@ -2616,9 +2618,11 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_displayed_data_item(data_item1)
             document_controller.processing_invert()
             display_panel.set_displayed_data_item(data_item1)
+            document_model.recompute_all()
             document_controller.periodic()
             document_controller.display_filter = ListModel.TextFilter("text_for_filter", "99")
             data_item.set_data(numpy.zeros(8, ))
+            document_model.recompute_all()
             document_controller.periodic()
 
     def test_filter_masks_can_be_created_on_a_variety_of_displays(self):

--- a/nion/swift/test/DocumentController_test.py
+++ b/nion/swift/test/DocumentController_test.py
@@ -144,7 +144,7 @@ class TestDocumentControllerClass(unittest.TestCase):
     def test_document_controller_releases_itself(self):
         i = 0
         try:
-            for i in range(100):
+            for i in range(4):
                 with TestContext.create_memory_context() as test_context:
                     document_controller = test_context.create_document_controller()
                     document_model = document_controller.document_model
@@ -241,6 +241,7 @@ class TestDocumentControllerClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             line_profile_data_item = document_controller.processing_line_profile().data_item
+            document_model.recompute_all()
             document_controller.periodic()  # TODO: remove need to let the inspector catch up
             display_panel.set_display_panel_display_item(display_item)
             display_item.graphic_selection.clear()

--- a/nion/swift/test/DocumentModel_test.py
+++ b/nion/swift/test/DocumentModel_test.py
@@ -375,13 +375,13 @@ class TestDocumentModelClass(unittest.TestCase):
             d = src.data
             max_pos = list(numpy.unravel_index(numpy.argmax(d), d.shape))
             max_pos = max_pos[0] / d.shape[0], max_pos[1] / d.shape[1]
-            self.__src = src
             self.__max_pos = max_pos
 
         def commit(self):
             graphic = self.computation.get_result("graphic", None)
+            src = self.computation.get_input("src")
             if not graphic:
-                graphic = self.__src.add_point_region(*self.__max_pos)
+                graphic = src.add_point_region(*self.__max_pos)
                 self.computation.set_result("graphic", graphic)
             graphic.position = self.__max_pos
             TestDocumentModelClass.find_max_eval_count += 1
@@ -583,16 +583,16 @@ class TestDocumentModelClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src, value):
-            self.__src = src
             self.__value = value
 
         def commit(self):
             graphic = self.computation.get_result("graphic", None)
+            src = self.computation.get_input("src")
             if not self.__value and graphic:
-                self.__src.remove_region(graphic)
+                src.remove_region(graphic)
                 self.computation.set_result("graphic", None)
             elif self.__value and not graphic:
-                graphic = self.__src.add_point_region(0.5, 0.5)
+                graphic = src.add_point_region(0.5, 0.5)
                 self.computation.set_result("graphic", graphic)
 
     def test_new_computation_with_optional_result(self):
@@ -648,16 +648,16 @@ class TestDocumentModelClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src, value):
-            self.__src = src
             self.__value = value
 
         def commit(self):
             graphics = self.computation.get_result("graphics")
+            src = self.computation.get_input("src")
             while len(graphics) < self.__value:
-                graphic = self.__src.add_point_region(0.5, 0.5)
+                graphic = src.add_point_region(0.5, 0.5)
                 graphics.append(graphic)
             while len(graphics) > self.__value:
-                self.__src.remove_region(graphics.pop())
+                src.remove_region(graphics.pop())
             self.computation.set_result("graphics", graphics)
 
     def test_new_computation_with_list_result(self):

--- a/nion/swift/test/Facade_test.py
+++ b/nion/swift/test/Facade_test.py
@@ -328,12 +328,13 @@ class TestFacadeClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src):
-            self.__src = src
+            pass
 
         def commit(self):
             graphic = self.computation.get_result("graphic")
+            src = self.computation.get_input("src")
             if not graphic:
-                graphic = self.__src.add_point_region(0.5, 0.5)
+                graphic = src.add_point_region(0.5, 0.5)
                 self.computation.set_result("graphic", graphic)
 
     def test_register_library_computation_and_execute_it(self):
@@ -354,13 +355,13 @@ class TestFacadeClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src, value):
-            self.__src = src
             self.__value = value
 
         def commit(self):
             graphic = self.computation.get_result("graphic")
+            src = self.computation.get_input("src")
             if not graphic:
-                graphic = self.__src.add_point_region(0.5, 0.5)
+                graphic = src.add_point_region(0.5, 0.5)
                 self.computation.set_result("graphic", graphic)
             graphic.label = str(self.__value)
 
@@ -388,7 +389,6 @@ class TestFacadeClass(unittest.TestCase):
 
         def execute(self, src):
             self.__data = src.data
-            self.__src = src
 
         def commit(self):
             dst = self.computation.get_result("dst")
@@ -421,7 +421,6 @@ class TestFacadeClass(unittest.TestCase):
         def execute(self, src):
             assert isinstance(src, Facade.DataSource)
             self.__data = src.data
-            self.__src = src
 
         def commit(self):
             dst = self.computation.get_result("dst")

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -1069,6 +1069,7 @@ class TestInspectorClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             inspector_panel = document_controller.find_dock_panel("inspector-panel")
+            document_model.recompute_all()
             document_controller.periodic()
             expected_inspector_section_count = len(inspector_panel._get_inspector_sections())
             # add the point graphic, ensure that inspector is updated with just a section for point graphic
@@ -1076,12 +1077,14 @@ class TestInspectorClass(unittest.TestCase):
             document_model.get_pick_new(display_item, display_item.data_item)
             self.assertEqual(document_controller.selected_data_item, data_item)
             document_controller.selected_display_item.graphic_selection.add(0)
+            document_model.recompute_all()
             document_controller.periodic()
             graphic_inspector_section_count = len(inspector_panel._get_inspector_sections())
             self.assertNotEqual(expected_inspector_section_count, graphic_inspector_section_count)
             # now remove the point graphic and ensure that inspector inspecting data item again
             self.assertEqual(len(document_controller.selected_display_item.graphic_selection.indexes), 1)  # make sure graphic is selected
             document_controller.remove_selected_graphics()
+            document_model.recompute_all()
             document_controller.periodic()
             self.assertEqual(len(document_controller.selected_display_item.graphic_selection.indexes), 0)  # make sure graphic is not selected
             actual_inspector_section_count = len(inspector_panel._get_inspector_sections())
@@ -1544,6 +1547,7 @@ class TestInspectorClass(unittest.TestCase):
             computation.create_output_item("dst", Symbolic.make_item(data_item2))
             computation.create_output_item("dst2", Symbolic.make_item(data_item3))
             document_model.append_computation(computation)
+            document_model.recompute_all()
             interval2.source = interval
             display_item.append_display_data_channel_for_data_item(data_item2)
             display_item.append_display_data_channel_for_data_item(data_item3)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -3987,8 +3987,8 @@ class TestStorageClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src_list):
-            if len(set(src.data_shape for src in src_list)) == 1:
-                self.__new_data = numpy.sum([src.data for src in src_list], axis=0)
+            if len(set(src.display_xdata.data_shape for src in src_list)) == 1:
+                self.__new_data = numpy.sum([src.display_xdata.data for src in src_list], axis=0)
             else:
                 self.__new_data = None
 

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -3788,7 +3788,7 @@ class TestStorageClass(unittest.TestCase):
                 data = numpy.ones((2, 2), numpy.double)
                 data_item = DataItem.DataItem(data)
                 document_model.append_data_item(data_item)
-                computation = document_model.create_computation(Symbolic.xdata_expression("xd.column(a.xdata)"))
+                computation = document_model.create_computation(Symbolic.xdata_expression("xd.column(a.xdata.data_shape)"))
                 computation.create_input_item("a", Symbolic.make_item(data_item))
                 computed_data_item = DataItem.DataItem(data.copy())
                 document_model.append_data_item(computed_data_item)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4027,16 +4027,16 @@ class TestStorageClass(unittest.TestCase):
             self.computation = computation
 
         def execute(self, src, value):
-            self.__src = src
             self.__value = value
 
         def commit(self):
             graphics = self.computation.get_result("graphics")
+            src = self.computation.get_input("src")
             while len(graphics) < self.__value:
-                graphic = self.__src.add_point_region(0.5, 0.5)
+                graphic = src.add_point_region(0.5, 0.5)
                 graphics.append(graphic)
             while len(graphics) > self.__value:
-                self.__src.remove_region(graphics.pop())
+                src.remove_region(graphics.pop())
             self.computation.set_result("graphics", graphics)
 
     def test_new_computation_with_list_result_reloads(self):

--- a/nion/swift/test/Symbolic_test.py
+++ b/nion/swift/test/Symbolic_test.py
@@ -1152,7 +1152,7 @@ class TestSymbolicClass(unittest.TestCase):
             document_model.set_data_item_computation(computed_data_item, computation)
             document_model.recompute_all()
             evaluation_count = computation._evaluation_count_for_test
-            computation.expression = Symbolic.xdata_expression("xd.gaussian_blur(a, 2)")
+            computation.expression = Symbolic.xdata_expression("xd.gaussian_blur(a.xdata, 2)")
             # computation should not be re-evaluated until requested
             self.assertEqual(computation._evaluation_count_for_test - evaluation_count, 0)
             document_model.recompute_all()
@@ -1348,7 +1348,7 @@ class TestSymbolicClass(unittest.TestCase):
             document_model.append_data_item(data_item)
             script_and_data = [
                 ("xd.histogram(a.xdata, 10)", None),
-                ("xd.line_profile(a.xdata, xd.vector(xd.norm_point(0.1, 0.1), xd.norma_point(0.8, 0.7)), 10)", None),
+                ("xd.line_profile(a.xdata, xd.vector(xd.norm_point(0.1, 0.1), xd.norm_point(0.8, 0.7)), 10)", None),
                 ("xd.transpose_flip(a.xdata, False, True, False)", None),
                 ("xd.crop(a.xdata, xd.rectangle_from_origin_size(xd.norm_point(0, 0), xd.norm_size(0.5, 0.625)))", src_data[0:5, 0:5]),
                 ("xd.sum(a.xdata, 0)", numpy.sum(src_data, 0)),


### PR DESCRIPTION
- **Introduce Region objects to represent Graphics for computations.**
- **Introduce computation_value to bound item and pass it to computation instead of value.**
- **Pass Regions instead of Graphics to computations.**
- **Pass DataItemComputationValue instead of DataItem to computations.**
- **Pass DataStructureComputationValue to computations instead of directly passing DataStructure.**
- **Add computation_value to BoundList.**
- **Always pass data source to computation executor instead of passing data directly.**
- **Ensure computations are run in tests. Also additional test cleanup.**

This changes parameter passing to computations to only pass read-only parameters. This also changes parameters that used to pass xdata directly to computations to now pass data sources. Graphics and data structures are no longer passed directly, but instead parameters with access to the model part of the graphic or data structure is passed. This change also improves tests to be more robust. All of these changes are preparation for threaded computations.

This change introduces Region objects to represent the Graphics when passed to computations. These may be changed in the future to be more computation specific; but they should be considered to be a stepping stone useful for the implementation of threaded computations (upcoming) for now.