### PR TITLE
Fix 217. Use data item names for line plot layer names by default.

### DIFF
--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -1108,7 +1108,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 timestamp_ns = metadata_d.get("hardware_source", dict()).get("system_time_ns", time.perf_counter_ns()) if self.__display_latency else 0
                 self.__timestamp_canvas_item.timestamp_ns = timestamp_ns
 
-    def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, display_properties: Persistence.PersistentDictType, display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
+    def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, display_properties: Persistence.PersistentDictType, display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo]) -> None:
         # thread-safe
         data_and_metadata = self.__display_values.data_and_metadata if self.__display_values else None
         data_metadata = data_and_metadata.data_metadata if data_and_metadata else None

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -1108,7 +1108,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 timestamp_ns = metadata_d.get("hardware_source", dict()).get("system_time_ns", time.perf_counter_ns()) if self.__display_latency else 0
                 self.__timestamp_canvas_item.timestamp_ns = timestamp_ns
 
-    def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, display_properties: Persistence.PersistentDictType, display_layers: typing.Sequence[Persistence.PersistentDictType]) -> None:
+    def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, display_properties: Persistence.PersistentDictType, display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
         # thread-safe
         data_and_metadata = self.__display_values.data_and_metadata if self.__display_values else None
         data_metadata = data_and_metadata.data_metadata if data_and_metadata else None

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -114,7 +114,7 @@ MAX_LAYER_COUNT = 16
 
 
 class LinePlotDisplayInfo:
-    def __init__(self, display_calibration_info: typing.Optional[DisplayItem.DisplayCalibrationInfo], display_properties: Persistence.PersistentDictType, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]], display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
+    def __init__(self, display_calibration_info: typing.Optional[DisplayItem.DisplayCalibrationInfo], display_properties: Persistence.PersistentDictType, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]], display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo]) -> None:
         self.__display_calibration_info = display_calibration_info
         self.__y_min = display_properties.get("y_min", None)
         self.__y_max = display_properties.get("y_max", None)
@@ -532,7 +532,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo,
                                                display_properties: Persistence.PersistentDictType,
-                                               display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
+                                               display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo]) -> None:
         """Update the display values. Called from display panel.
 
         This method saves the display values and data and triggers an update. It should be as fast as possible.

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 # standard libraries
 import copy
+import dataclasses
 import math
 import operator
 import threading
@@ -113,7 +114,7 @@ MAX_LAYER_COUNT = 16
 
 
 class LinePlotDisplayInfo:
-    def __init__(self, display_calibration_info: typing.Optional[DisplayItem.DisplayCalibrationInfo], display_properties: Persistence.PersistentDictType, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]], display_layers: typing.Sequence[Persistence.PersistentDictType]) -> None:
+    def __init__(self, display_calibration_info: typing.Optional[DisplayItem.DisplayCalibrationInfo], display_properties: Persistence.PersistentDictType, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]], display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
         self.__display_calibration_info = display_calibration_info
         self.__y_min = display_properties.get("y_min", None)
         self.__y_max = display_properties.get("y_max", None)
@@ -253,11 +254,11 @@ class LinePlotDisplayInfo:
             axes = self.axes
 
             for index, display_layer in enumerate(self.__display_layers[0:MAX_LAYER_COUNT]):
-                fill_color_str = display_layer.get("fill_color")
-                stroke_color_str = display_layer.get("stroke_color")
-                stroke_width = display_layer.get("stroke_width", 0.5)
-                data_index = display_layer.get("data_index", 0)
-                data_row = display_layer.get("data_row", 0)
+                fill_color_str = display_layer.fill_color
+                stroke_color_str = display_layer.stroke_color
+                stroke_width = display_layer.stroke_width
+                data_index = display_layer.data_index or 0
+                data_row = display_layer.data_row or 0
                 if 0 <= data_index < len(xdata_list):
                     fill_color = Color.Color(fill_color_str) if fill_color_str else None
                     stroke_color = Color.Color(stroke_color_str) if stroke_color_str else None
@@ -284,9 +285,9 @@ class LinePlotDisplayInfo:
         if self.__legend_entries is None:
             legend_entries = list()
             for index, display_layer in enumerate(self.__display_layers[0:MAX_LAYER_COUNT]):
-                data_index = display_layer.get("data_index", None)
-                data_row = display_layer.get("data_row", None)
-                label = display_layer.get("label", str())
+                data_index = display_layer.data_index
+                data_row = display_layer.data_row
+                label = display_layer.label
                 if not label:
                     if data_index is not None and data_row is not None:
                         label = "Data {}:{}".format(data_index, data_row)
@@ -294,8 +295,8 @@ class LinePlotDisplayInfo:
                         label = "Data {}".format(data_index)
                     else:
                         label = "Unknown"
-                fill_color = display_layer.get("fill_color")
-                stroke_color = display_layer.get("stroke_color")
+                fill_color = display_layer.fill_color
+                stroke_color = display_layer.stroke_color
                 legend_entries.append(LineGraphCanvasItem.LegendEntry(label, fill_color, stroke_color))
             self.__legend_entries = legend_entries
         return self.__legend_entries
@@ -531,7 +532,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo,
                                                display_properties: Persistence.PersistentDictType,
-                                               display_layers: typing.Sequence[Persistence.PersistentDictType]) -> None:
+                                               display_layers: typing.Sequence[DisplayItem.DisplayLayer]) -> None:
         """Update the display values. Called from display panel.
 
         This method saves the display values and data and triggers an update. It should be as fast as possible.

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2696,12 +2696,17 @@ class DisplayItem(Persistence.PersistentObject):
             # removal of a display layer can cascade remove a display data channel and leave the display data channel
             # of the display layer dangling during the cascade. hack it here.
             data_index = None
-            if display_layer.display_data_channel and display_layer.display_data_channel in self.display_data_channels:
-                data_index = self.display_data_channels.index(display_layer.display_data_channel)
+            display_data_channel = display_layer.display_data_channel
+            if display_data_channel and display_data_channel in self.display_data_channels:
+                data_index = self.display_data_channels.index(display_data_channel)
+            label = display_layer.label
+            if not label:
+                data_item = display_data_channel.data_item if display_data_channel else None
+                label = data_item.title if data_item else None
             display_layer_info = DisplayLayerInfo(
                 data_index=data_index,
                 data_row=display_layer.data_row,
-                label=display_layer.label,
+                label=label,
                 stroke_color=display_layer.stroke_color,
                 fill_color=display_layer.fill_color,
                 stroke_width=display_layer.stroke_width

--- a/nion/swift/resources/changes.json
+++ b/nion/swift/resources/changes.json
@@ -4,6 +4,12 @@
     "notes": [
       {
         "issues": [
+          "https://github.com/nion-software/nionswift/issues/217"
+        ],
+        "summary": "Composite line plots use source data item names unless label explicitly set in line plot."
+      },
+      {
+        "issues": [
           "https://github.com/nion-software/nionswift/issues/1337"
         ],
         "summary": "Add titles in browser view."

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -2711,6 +2711,8 @@ class TestDisplayPanelClass(unittest.TestCase):
             self.assertEqual(2, len(new_display_item.display_data_channels))
             self.assertEqual(data_item1, new_display_item.data_items[0])
             self.assertEqual(data_item2, new_display_item.data_items[1])
+            self.assertFalse(new_display_item.display_layers[0].label)
+            self.assertFalse(new_display_item.display_layers[1].label)
             # undo and check original assumptions
             document_controller.last_undo_command.undo()
             self.assertEqual(3, len(document_model.data_items))


### PR DESCRIPTION
- **Refactor displays to take display layer as object rather than dict.**
- **Pass display layer info to display canvas items.**
- **Use display data channel label if layer has no label.**

The first two commits are refactoring precursor to the last commit which makes line plot layers default to the data item name.

There are many edge cases and I expect to have a few follow-up PR's with bug fixes that get revealed during testing and/or features that go along with this change.

However, I think it's worthwhile to get this PR merged first to see what else needs to be fixed after testing and use.
