### PR TITLE
fix 1363 metadata panel issues

### DIFF
--- a/nion/swift/ActivityPanel.py
+++ b/nion/swift/ActivityPanel.py
@@ -142,7 +142,11 @@ class ActivityPanel(Panel.Panel):
     def __init__(self, document_controller: DocumentController.DocumentController, panel_id: str, properties: typing.Mapping[str, typing.Any]) -> None:
         super().__init__(document_controller, panel_id, _("Activity"))
         activity_controller = ActivityController(document_controller)
-        self.widget = Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, activity_controller)
+        column = self.ui.create_column_widget()
+        column.add_spacing(0)  # work around unexplained Qt layout issue where widget did not appear at top of column on macOS
+        column.add(Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, activity_controller))
+        column.add_spacing(0)
+        self.widget = column
 
 """
         async def later() -> None:

--- a/nion/swift/MetadataPanel.py
+++ b/nion/swift/MetadataPanel.py
@@ -324,7 +324,9 @@ class MetadataPanel(Panel.Panel):
         metadata_editor_widget.canvas_item.add_canvas_item(scroll_group_canvas_item)
 
         column = self.ui.create_column_widget(properties={"size-policy-horizontal": "expanding", "size-policy-vertical": "expanding"})
+        column.add_spacing(0)  # work around unexplained Qt layout issue where widget did not appear at top of column on macOS
         column.add(metadata_editor_widget)
+        column.add_spacing(0)
 
         def metadata_source_changed(metadata_source: MetadataSource) -> None:
             delegate.metadata_source = metadata_source

--- a/nion/swift/resources/changes.json
+++ b/nion/swift/resources/changes.json
@@ -4,6 +4,12 @@
     "notes": [
       {
         "issues": [
+          "https://github.com/nion-software/nionswift/issues/1363"
+        ],
+        "summary": "Fix issue with metadata panel not showing data. Also add note when target data item has no metadata."
+      },
+      {
+        "issues": [
           "https://github.com/nion-software/nionswift/issues/217"
         ],
         "summary": "Composite line plots use source data item names unless label explicitly set in line plot."


### PR DESCRIPTION
- **Work-around for Qt layout issue on macOS.**
- **Fix issue with metadata panel not showing data. Also add note when target data item has no metadata.**

Metadata panel redraws in a thread for performance. The thread breaks its encapsulation to determine if it is visible, again, for performance. But drawing was not handling case where it was initially invisible and became visible. Now it redraws when becoming visible. Also other minor changes. Overall, this isn't the greatest implementation of threaded drawing, which could now be handled automatically. But I decided to avoid rewriting it since it was easiest to just "hack" this solution onto the current "hack". The painting-on-a-thread solution predates (and contirbutes to the ideas for) the more modern threaded canvas items.

This is a minor change. Reviewers can review to learn about code and be aware of the change. Planning to merge after a review approval or two days have passed.