### PR TITLE
Ensure data panel selection is visible after revealing display items. Also notify if display item is filtered.

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -504,3 +504,7 @@ class DataPanel(Panel.Panel):
 
     def _request_focus_for_test(self) -> None:
         self.__list_canvas_item.request_focus()
+
+    def make_selection_visible(self) -> None:
+        self.__list_canvas_item.make_selection_visible()
+        self.__grid_canvas_item.make_selection_visible()

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -25,6 +25,7 @@ import weakref
 from nion.data import DataAndMetadata
 from nion.swift import ComputationPanel
 from nion.swift import ConsoleDialog
+from nion.swift import DataPanel
 from nion.swift import DisplayEditorPanel
 from nion.swift import DisplayPanel
 from nion.swift import EntityBrowser
@@ -779,6 +780,14 @@ class DocumentController(Window.Window):
             display_item = display_items[0]
             if display_item in filtered_display_items:
                 self.selection.anchor_index = filtered_display_items.index(display_item)
+        if not indexes:
+            Notification.notify(
+                Notification.Notification("nion.data_panel.no-targets", "\N{WARNING SIGN} Data Panel",
+                                          "No display/data item visible",
+                                          "The selected display/data item is not visible in the data panel.",))
+        else:
+            data_panel = typing.cast(DataPanel.DataPanel, self.find_dock_panel("data-panel"))
+            data_panel.make_selection_visible()
 
     def select_data_items_in_data_panel(self, data_items: typing.Sequence[DataItem.DataItem]) -> None:
         document_model = self.document_model


### PR DESCRIPTION
This PR is a fix for #1370. Suggested testing procedure in that issue.

Please review the code. I will merge sometime after #1369. This PR (and any other PR today) will not pass tests without #1369, which includes an updated workspace split-enabled check after a change in nionui. If you want to try it out, checkout this on top of #1369.