### PR TITLE
Improve naming of 'go to source/dependent' menu items, add 'reveal' component menu items

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2766,6 +2766,20 @@ class DocumentController(Window.Window):
                     reveal_text_pt2 = _("in Data Panel")
                     menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
                                        functools.partial(show_dependent_data_item, dependent_data_item))
+        display_item = action_context.display_item
+        if display_item:
+            if len(display_item.data_items) > 1:
+                menu.add_separator()
+                for data_item in display_item.data_items:
+                    def show_data_item(data_item: DataItem.DataItem) -> None:
+                        self.select_data_item_in_data_panel(data_item)
+
+                    truncated_title = self.ui.truncate_string_to_width(str(), data_item.title, 280,
+                                                                       UserInterface.TruncateModeType.MIDDLE)
+                    reveal_text = _("Reveal Component")
+                    reveal_text_pt2 = _("in Data Panel")
+                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
+                                        functools.partial(show_data_item, data_item))
 
     class ActionContext(Window.ActionContext):
         """Action contact.

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -793,7 +793,7 @@ class DocumentController(Window.Window):
         document_model = self.document_model
         associated_display_items = list()
         for data_item in data_items:
-            display_item = document_model.get_display_item_for_data_item(data_item)
+            display_item = document_model.get_best_display_item_for_data_item(data_item)
             if display_item:
                 associated_display_items.append(display_item)
         self.select_display_items_in_data_panel(associated_display_items)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2738,48 +2738,40 @@ class DocumentController(Window.Window):
         self.add_action_to_menu_if_enabled(menu, "display.reveal", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export_batch", action_context)
+
+        def reveal_data_item(data_item: DataItem.DataItem) -> None:
+            # same as selecting menu item for 'reveal'
+            action_context_ = self._get_action_context()
+            action_context_.display_panel = action_context.display_panel
+            action_context_.display_item = self.document_model.get_best_display_item_for_data_item(data_item)
+            self.perform_action_in_context("display.reveal", action_context_)
+
+        def make_reveal_data_item_callback(data_item: DataItem.DataItem) -> typing.Callable[[], None]:
+            return functools.partial(reveal_data_item, data_item)
+
+        def make_reveal_menu_item_title(data_item: DataItem.DataItem, text: str) -> str:
+            truncated_title = self.ui.truncate_string_to_width(str(), data_item.title, 280, UserInterface.TruncateModeType.MIDDLE)
+            reveal_text = _("Reveal")
+            return f"{reveal_text} {text} \"{truncated_title}\""
+
         data_item = action_context.data_item
         if data_item:
             source_data_items = self.document_model.get_source_data_items(data_item)
             if len(source_data_items) > 0:
                 menu.add_separator()
-                for source_data_item in source_data_items:
-                    def show_source_data_item(data_item: DataItem.DataItem) -> None:
-                        self.select_data_item_in_data_panel(data_item)
-
-                    truncated_title = self.ui.truncate_string_to_width(str(), source_data_item.title, 280,
-                                                                       UserInterface.TruncateModeType.MIDDLE)
-                    reveal_text = _("Reveal Source")
-                    reveal_text_pt2 = _("in Data Panel")
-                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
-                                       functools.partial(show_source_data_item, source_data_item))
+                for data_item in source_data_items:
+                    menu.add_menu_item(make_reveal_menu_item_title(data_item, _("Source")), make_reveal_data_item_callback(data_item))
             dependent_data_items = self.document_model.get_dependent_data_items(data_item)
             if len(dependent_data_items) > 0:
                 menu.add_separator()
-                for dependent_data_item in dependent_data_items:
-                    def show_dependent_data_item(data_item: DataItem.DataItem) -> None:
-                        self.select_data_item_in_data_panel(data_item)
-
-                    truncated_title = self.ui.truncate_string_to_width(str(), dependent_data_item.title, 280,
-                                                                       UserInterface.TruncateModeType.MIDDLE)
-                    reveal_text = _("Reveal Dependent")
-                    reveal_text_pt2 = _("in Data Panel")
-                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
-                                       functools.partial(show_dependent_data_item, dependent_data_item))
+                for data_item in dependent_data_items:
+                    menu.add_menu_item(make_reveal_menu_item_title(data_item, _("Dependent")), make_reveal_data_item_callback(data_item))
         display_item = action_context.display_item
         if display_item:
             if len(display_item.data_items) > 1:
                 menu.add_separator()
                 for data_item in display_item.data_items:
-                    def show_data_item(data_item: DataItem.DataItem) -> None:
-                        self.select_data_item_in_data_panel(data_item)
-
-                    truncated_title = self.ui.truncate_string_to_width(str(), data_item.title, 280,
-                                                                       UserInterface.TruncateModeType.MIDDLE)
-                    reveal_text = _("Reveal Component")
-                    reveal_text_pt2 = _("in Data Panel")
-                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
-                                        functools.partial(show_data_item, data_item))
+                    menu.add_menu_item(make_reveal_menu_item_title(data_item, _("Component")), make_reveal_data_item_callback(data_item))
 
     class ActionContext(Window.ActionContext):
         """Action contact.

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2749,7 +2749,9 @@ class DocumentController(Window.Window):
 
                     truncated_title = self.ui.truncate_string_to_width(str(), source_data_item.title, 280,
                                                                        UserInterface.TruncateModeType.MIDDLE)
-                    menu.add_menu_item("{0} \"{1}\"".format(_("Go to Source "), truncated_title),
+                    reveal_text = _("Reveal Source")
+                    reveal_text_pt2 = _("in Data Panel")
+                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
                                        functools.partial(show_source_data_item, source_data_item))
             dependent_data_items = self.document_model.get_dependent_data_items(data_item)
             if len(dependent_data_items) > 0:
@@ -2760,7 +2762,9 @@ class DocumentController(Window.Window):
 
                     truncated_title = self.ui.truncate_string_to_width(str(), dependent_data_item.title, 280,
                                                                        UserInterface.TruncateModeType.MIDDLE)
-                    menu.add_menu_item("{0} \"{1}\"".format(_("Go to Dependent "), truncated_title),
+                    reveal_text = _("Reveal Dependent")
+                    reveal_text_pt2 = _("in Data Panel")
+                    menu.add_menu_item(f"{reveal_text} \"{truncated_title}\" {reveal_text_pt2}",
                                        functools.partial(show_dependent_data_item, dependent_data_item))
 
     class ActionContext(Window.ActionContext):


### PR DESCRIPTION
This is a quick fix for:
- #1372
- #1373

Commits:

- [Improve naming of 'go to source/dependent' menu items.](https://github.com/nion-software/nionswift/pull/1374/commits/c5fa7ddc3e7834c4cb44fcdea6c5cacc4fa90c11)
- [Add items for composite display components to context menu.](https://github.com/nion-software/nionswift/pull/1374/commits/778ac3f00b6c354c752591c1b3b83f27694c31fe)
- [Use 'best' display item rather than assuming there is just one during reveals.](https://github.com/nion-software/nionswift/pull/1374/commits/1a99232f507f570d7a873abc3d259c89bff29dca)
- [Consolidate code, use action for reveals so they get logged.](https://github.com/nion-software/nionswift/pull/1374/commits/8bf55f6d804aff5c50865da38ad67385c25bb2e4)

Questions:
- Is the wording ok?

Review:
No urgency but I will merge after two working days.
