### PR TITLE
fix 1353 drag and drop files

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -312,6 +312,15 @@ class DataPanel(Panel.Panel):
                     return True
                 return False
 
+            def can_drop_mime_data(self, mime_data: UserInterface.MimeData, action: str, drop_index: int | None) -> bool:
+                return mime_data.has_file_paths
+
+            def drop_mime_data(self, mime_data: UserInterface.MimeData, action: str, drop_index: int | None) -> str:
+                display_items = document_controller.receive_files(mime_data.file_paths)
+                if set(display_items).intersection(set(document_controller.filtered_display_items_model.display_items)):
+                    document_controller.select_display_items_in_data_panel(display_items)
+                return "accept"
+
             def _get_mime_data_and_thumbnail_data(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> typing.Tuple[typing.Optional[UserInterface.MimeData], typing.Optional[_NDArray]]:
                 mime_data = None
                 thumbnail_data = None
@@ -345,6 +354,7 @@ class DataPanel(Panel.Panel):
         # note is_shared_selection is True for both list and grid canvas items. prevents the selection from being updated when items are inserted.
         # instead, the selection in the model itself is used.
         list_canvas_item = ListCanvasItem.ListCanvasItem2(Panel.ThreadSafeListModel(display_items_model, document_controller.event_loop), self.__selection, list_item_factory, item_delegate, item_height=80, key="display_items", is_shared_selection=True)
+        list_canvas_item.wants_drag_events = True
         list_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(list_canvas_item)
         list_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(list_scroll_area_canvas_item, CanvasItem.Orientation.Vertical)
         list_scroll_group_canvas_item = CanvasItem.CanvasItemComposition()
@@ -359,6 +369,7 @@ class DataPanel(Panel.Panel):
         # instead, the selection in the model itself is used.
         line_height = document_controller.get_font_metrics("11px sans-serif", "M").height
         grid_canvas_item = GridCanvasItem.GridCanvasItem2(Panel.ThreadSafeListModel(display_items_model, document_controller.event_loop), self.__selection, grid_item_factory, item_delegate, item_size=Geometry.IntSize(80 + line_height, 80), key="display_items", is_shared_selection=True)
+        grid_canvas_item.wants_drag_events = True
         grid_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(grid_canvas_item)
         grid_scroll_area_canvas_item.auto_resize_contents = True
         grid_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(grid_scroll_area_canvas_item, CanvasItem.Orientation.Vertical)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2662,7 +2662,7 @@ class DocumentController(Window.Window):
     # position in the document model (the end) and at the group at the position
     # specified by the index. if the data group is not specified, the item is added
     # at the index within the document model.
-    def receive_files(self, files: typing.Sequence[str], data_group: typing.Optional[DataGroup.DataGroup] = None, index: int = -1) -> None:
+    def receive_files(self, files: typing.Sequence[str], data_group: typing.Optional[DataGroup.DataGroup] = None, index: int = -1) -> typing.Sequence[DisplayItem.DisplayItem]:
         display_items = list[DisplayItem.DisplayItem]()
         file_paths = [pathlib.Path(file_path) for file_path in files]
         for file_index, file_path in enumerate(file_paths):
@@ -2724,6 +2724,7 @@ class DocumentController(Window.Window):
                 traceback.print_exc()
                 traceback.print_stack()
         self.select_display_items_in_data_panel(display_items)
+        return display_items
 
     def create_context_menu_for_display(self, display_items: typing.List[DisplayItem.DisplayItem]) -> UserInterface.Menu:
         # only used in tests

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -878,7 +878,15 @@ class Workspace:
             return "copy"
         if mime_data.has_format("text/uri-list"):
             index = len(document_model.data_items)
-            self.document_controller.receive_files(mime_data.file_paths, None, index)
+            display_items = self.document_controller.receive_files(mime_data.file_paths, None, index)
+            display_item = display_items[0] if len(display_items) > 0 else None
+            if display_item:
+                if region == "right" or region == "left" or region == "top" or region == "bottom":
+                    command = self.insert_display_panel(display_panel, region, display_item)
+                    self.document_controller.push_undo_command(command)
+                else:
+                    command = self.__replace_displayed_display_item(display_panel, display_item)
+                    self.document_controller.push_undo_command(command)
             return "copy"
         return "ignore"
 

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -873,6 +873,19 @@ class TestDataPanelClass(unittest.TestCase):
             data_panel._selection.set(1)
             self.assertEqual(items[1], document_controller.focused_display_item)
 
+    def test_drop_external_file(self):
+        with TestContext.MemoryProfileContext() as profile_context:
+            document_controller = profile_context.create_document_controller()
+            data_panel = typing.cast(DataPanel.DataPanel, document_controller.find_dock_panel("data-panel"))
+            document_model = document_controller.document_model
+            image_path = pathlib.Path(__file__).parent.parent / "resources" / "1x1_icon.png"
+            mime_data = TestUI.MimeData({"text/uri-list": pathlib.Path(image_path)})  # this is the format used by TestUI
+            self.assertTrue(data_panel._list_canvas_item._delegate.can_drop_mime_data(mime_data, "copy", None))
+            data_panel._list_canvas_item._delegate.drop_mime_data(mime_data, "copy", None)
+            self.assertEqual(1, len(document_model.data_items))
+            data_panel._grid_canvas_item._delegate.drop_mime_data(mime_data, "copy", None)
+            self.assertEqual(2, len(document_model.data_items))
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
This PR fixes #1353 and #1354. Basic integration tests, too.

- **Ensure files dropped on display panels appear in display panel.**
- **Handle data panel file dropping to import.**

This is a minor change. Reviewers can review to learn about code and be aware of the change. Planning to merge after a review approval or two days have passed.

Testing:
- drop external data file on display panel and confirm it is imported and displayed in the dropped panel
- drop external data file into data panel and confirm it is imported and selected in data panel