### PR TITLE
Improve file format handling when data item data size changes

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -491,6 +491,8 @@ class Application(UIApplication.BaseApplication):
             try:
                 document_controller = self.open_project_window(project_reference, update_last_project_reference)
             except Exception:
+                import traceback
+                traceback.print_exc()
                 self.show_ok_dialog(_("Error Opening Project"), _("Unable to open default project."), completion_fn=self.show_choose_project_dialog)
                 return True
 

--- a/nion/swift/GeneratorDialog.py
+++ b/nion/swift/GeneratorDialog.py
@@ -193,11 +193,9 @@ class GenerateDataDialog(Declarative.WindowHandler):
             calibrations.append(Calibration.Calibration(units="nm"))
             calibrations.append(Calibration.Calibration(units="eV"))
 
-        is_large = numpy.prod(numpy.array(data_shape), dtype=numpy.int64).item() > 16 * 1024 * 1024
-
         document_model = self.__document_controller.document_model
 
-        data_item = DataItem.DataItem(large_format=is_large)
+        data_item = DataItem.DataItem()
         title_value = self.title_model.value
         if title_value:
             data_item.title = title_value

--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -164,6 +164,10 @@ class HDF5Handler(StorageHandler.StorageHandler):
     def factory(self) -> StorageHandler.StorageHandlerFactoryLike:
         return HDF5HandlerFactory()
 
+    @property
+    def storage_handler_type(self) -> str:
+        return "hdf5"
+
     # called before the file is moved; close but don't count.
     def prepare_move(self) -> None:
         with self.__lock:
@@ -287,6 +291,9 @@ class HDF5Handler(StorageHandler.StorageHandler):
 
 
 class HDF5HandlerFactory(StorageHandler.StorageHandlerFactoryLike):
+
+    def get_storage_handler_type(self) -> str:
+        return "hdf5"
 
     def is_matching(self, file_path: str) -> bool:
         if file_path.endswith(".h5") and os.path.exists(file_path):

--- a/nion/swift/model/NDataHandler.py
+++ b/nion/swift/model/NDataHandler.py
@@ -396,6 +396,10 @@ class NDataHandler(StorageHandler.StorageHandler):
     def factory(self) -> StorageHandler.StorageHandlerFactoryLike:
         return NDataHandlerFactory()
 
+    @property
+    def storage_handler_type(self) -> str:
+        return "ndata"
+
     # called before the file is moved; close but don't count.
     def prepare_move(self) -> None:
         pass
@@ -501,6 +505,9 @@ class NDataHandler(StorageHandler.StorageHandler):
 
 
 class NDataHandlerFactory(StorageHandler.StorageHandlerFactoryLike):
+
+    def get_storage_handler_type(self) -> str:
+        return "ndata"
 
     def is_matching(self, file_path: str) -> bool:
         """Return whether the given absolute file path is a ndata file."""

--- a/nion/swift/model/StorageHandler.py
+++ b/nion/swift/model/StorageHandler.py
@@ -16,6 +16,8 @@ _NDArray = numpy.typing.NDArray[typing.Any]
 
 class StorageHandlerFactoryLike(typing.Protocol):
 
+    def get_storage_handler_type(self) -> str: ...
+
     def is_matching(self, file_path: str) -> bool: ...
 
     def make(self, file_path: pathlib.Path) -> StorageHandler: ...
@@ -31,6 +33,9 @@ class StorageHandler(typing.Protocol):
 
     @property
     def factory(self) -> StorageHandlerFactoryLike: raise NotImplementedError()
+
+    @property
+    def storage_handler_type(self) -> str: raise NotImplementedError()
 
     @property
     def reference(self) -> str: raise NotImplementedError()


### PR DESCRIPTION
- **Improve error reporting when project can't be opened.**
- **Consolidate large format handling. Change file format to match changing data size.**

This changes behavior in the file storage system to automatically change the internal file format depending on the size of the data. A small data item stored as `.ndata` may be changed to `.h5` if the data size goes over 16MB.

Please review. The file storage system is not the cleanest code, but this change should be pretty clear that it tries to check the file type when the data changes. I'd like to merge this with or without reviews after two working days.