### PR TITLE
Fix #1448. Update collection panel counts when display item properties (such as live-ness) change.

### DIFF
--- a/nion/swift/ProjectPanel.py
+++ b/nion/swift/ProjectPanel.py
@@ -495,6 +495,7 @@ class CollectionsWidget(Widgets.CompositeWidgetBase):
 
         # for testing
         self._collection_selection = collection_selection
+        self._collection_info_list_stream = collection_info_list_stream
 
     def close(self) -> None:
         self.__filter_changed_event_listener.close()
@@ -524,6 +525,10 @@ class CollectionsPanel(Panel.Panel):
     @property
     def _collection_selection(self) -> Selection.IndexedSelection:
         return self._collections_section._collection_selection
+
+    @property
+    def _collection_info_list_stream(self) -> Stream.PropertyChangedEventStream[typing.Sequence["DocumentController.CollectionInfo"]]:
+        return self._collections_section._collection_info_list_stream
 
 
 class ProjectDialog(Dialog.ActionDialog):

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -15,6 +15,7 @@ from nion.swift import DisplayPanel
 from nion.swift import Facade
 from nion.swift import HistogramPanel
 from nion.swift import MimeTypes
+from nion.swift import ProjectPanel
 from nion.swift.model import DataGroup
 from nion.swift.model import DataItem
 from nion.swift.test import TestContext
@@ -926,6 +927,24 @@ class TestDataPanelClass(unittest.TestCase):
             self.assertEqual(document_controller.selected_display_items, [display_item2])
             self.assertEqual(document_controller.selected_display_item, display_item2)
             self.assertEqual(display_item_stream.value, display_item2)
+
+    def test_collections_panel_updates_counts_when_property_changes(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item1 = DataItem.DataItem(numpy.zeros((4, 4)))
+            data_item1.category = "temporary"
+            data_item2 = DataItem.DataItem(numpy.zeros((4, 4)))
+            document_model.append_data_item(data_item1)
+            document_model.append_data_item(data_item2)
+            project_panel = typing.cast(ProjectPanel.CollectionsPanel, document_controller.find_dock_panel("collections-panel"))
+            # index, parent_row, parent_id
+            project_panel._collection_selection.set(2)
+            self.assertTrue(project_panel._collection_info_list_stream.value[2].title.endswith("(1)"))
+            data_item2.category = "temporary"
+            self.assertTrue(project_panel._collection_info_list_stream.value[2].title.endswith("(2)"))
+            data_item1.category = None
+            self.assertTrue(project_panel._collection_info_list_stream.value[2].title.endswith("(1)"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The counts for the collection panel are maintained by watching for items inserted and removed from a list and then matching those items against a predicate to determine if they should be counted or not. The problem was that internal property changes which could affect the predicate were not observed. This modifies the general case to observe property changes and reapply the predicate.

Please review for correctness or for learning about the code. I'd like to merge this within a few working days.

Future work may be to combine the lists that appear in the data panel and the counts. They are currently separate and use different underlying mechanisms, with the counts being higher performance.