### PR TITLE
Add ability to rename data group by hitting return or double clicking on list item.

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -125,9 +125,19 @@ class CollectionInfoController(Observable.Observable):
         oo.source(container).sequence_from_array("display_items", predicate=self.__filter_predicate.matches).len().action_fn(count_changed)
         self.__count_observer = typing.cast(Observer.AbstractItemSource, oo.make_observable())
 
+        def title_changed(key: str) -> None:
+            if key == "title":
+                if self.__data_group:
+                    self.__base_title = self.__data_group.title
+                    self.collection_info_stream.value = self.collection_info
+                    self.notify_property_changed("collection_info")
+
+        self.__title_changed_listener = self.__data_group.property_changed_event.listen(title_changed) if self.__data_group else None
+
     def close(self) -> None:
         self.__count_observer.close()
         self.__count_observer = typing.cast(typing.Any, None)
+        self.__title_changed_listener = None
         self.__data_group = None
 
     @property


### PR DESCRIPTION
This adds the missing ability to rename a data group. It requires the recent changes in `nionui`. The basic functionality is to click on a data group in the Collections panel, and either hit return or double click the item to change the name. The resulting pop-up dialog should be able to copy/paste/cut/select-all. The pop-up dialog should immediately respond to typing, i.e. not require any additional focus clicks; and should also respond to return to accept and escape to cancel.

Please review with the consideration that this is an acceptable but probably incomplete solution to #1463. I would suggest reviewing to ensure it is working as expected. I would also suggest testing this pop-up in varying situations including using return/escape, switching out of the application, exiting the application, having the pop-up appear on different sides of the screen, in various stages of scroll bar, etc. I tested as thoroughly as I could on macOS only.