### PR TITLE
Update masks to use centre of pixel

### DIFF
--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -559,7 +559,7 @@ def draw_ellipse_graphic(ctx: DrawingContextLike, center: Geometry.FloatPoint, s
 def make_rectangle_mask(data_shape: DataAndMetadata.ShapeType, center: Geometry.FloatPoint, size: Geometry.FloatSize, rotation: float) -> DataAndMetadata._ImageDataType:
     mask = numpy.zeros(data_shape)
     bounds = Geometry.FloatRect.from_center_and_size(center, size)
-    a, b = bounds.top + bounds.height * 0.5, bounds.left + bounds.width * 0.5
+    a, b = bounds.top + bounds.height * 0.5 - 0.5, bounds.left + bounds.width * 0.5 - 0.5
     y, x = numpy.ogrid[-a:data_shape[0] - a, -b:data_shape[1] - b]  # type: ignore
     if rotation == 0.0:
         mask_eq = (numpy.fabs(x) / (bounds.width / 2) <= 1) & (numpy.fabs(y) / (bounds.height / 2) <= 1)

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -3075,7 +3075,7 @@ class RingMaskItem(MaskItem):
         calibrated_origin = calibrated_origin or Geometry.FloatPoint(y=data_shape[0] * 0.5 + 0.5, x=data_shape[1] * 0.5 + 0.5)
         mask: numpy.typing.NDArray[numpy.float64] = numpy.zeros(data_shape, dtype=float)
         bounds_int = ((0, 0), (int(data_shape[0]), int(data_shape[1])))
-        a, b = calibrated_origin.y, calibrated_origin.x
+        a, b = calibrated_origin.y - 0.5, calibrated_origin.x - 0.5
         y, x = numpy.ogrid[-a:data_shape[0] - a, -b:data_shape[1] - b] # type: ignore
         y = y / bounds_int[1][0]
         x = x / bounds_int[1][1]

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -3034,7 +3034,7 @@ class WedgeMaskItem(MaskItem):
         # a and b will be the calibrated pixel origin, expressed as pixels from top left
         calibrated_origin = calibrated_origin or Geometry.FloatPoint(y=data_shape[0] * 0.5 + 0.5,
                                                                      x=data_shape[1] * 0.5 + 0.5)
-        a, b = calibrated_origin.y, calibrated_origin.x
+        a, b = calibrated_origin.y - 0.5, calibrated_origin.x - 0.5
 
         # x and y will be pixel ramps increasing from top left to bottom right and zero at the origin
         y, x = numpy.ogrid[-a:data_shape[0] - a, -b:data_shape[1] - b]  # type: ignore

--- a/nion/swift/test/Region_test.py
+++ b/nion/swift/test/Region_test.py
@@ -155,23 +155,34 @@ class TestRegionClass(unittest.TestCase):
         with contextlib.closing(spot_graphic):
             spot_graphic.bounds = (0.2, 0.2), (0.1, 0.1)
             mask = spot_graphic.get_mask((1000, 1000))
-            self.assertEqual(mask.data[200, 200], 0)  # top left
-            self.assertEqual(mask.data[200, 300], 0)  # bottom left
-            self.assertEqual(mask.data[300, 300], 0)  # bottom right
-            self.assertEqual(mask.data[300, 200], 0)  # bottom left
-            self.assertEqual(mask.data[250, 201], 1)  # center top
-            self.assertEqual(mask.data[300, 250], 1)  # center right
-            self.assertEqual(mask.data[250, 300], 1)  # center bottom
-            self.assertEqual(mask.data[201, 250], 1)  # center left
 
-            self.assertEqual(mask.data[800, 800], 0)  # top left
+            self.assertEqual(mask.data[200, 200], 0)  # top left
+            self.assertEqual(mask.data[200, 299], 0)  # bottom left
+            self.assertEqual(mask.data[299, 299], 0)  # bottom right
+            self.assertEqual(mask.data[299, 200], 0)  # bottom left
+
+            self.assertEqual(mask.data[250, 200], 1)  # center top
+            self.assertEqual(mask.data[250, 199], 0)  # center top
+            self.assertEqual(mask.data[299, 250], 1)  # center right
+            self.assertEqual(mask.data[300, 250], 0)  # center right
+            self.assertEqual(mask.data[250, 299], 1)  # center bottom
+            self.assertEqual(mask.data[250, 300], 0)  # center bottom
+            self.assertEqual(mask.data[200, 250], 1)  # center left
+            self.assertEqual(mask.data[199, 250], 0)  # center left
+
+            self.assertEqual(mask.data[800, 800], 0)  # bottom right
             self.assertEqual(mask.data[800, 700], 0)  # bottom left
-            self.assertEqual(mask.data[700, 700], 0)  # bottom right
-            self.assertEqual(mask.data[700, 800], 0)  # bottom left
-            self.assertEqual(mask.data[750, 800], 1)  # center top
-            self.assertEqual(mask.data[701, 750], 1)  # center right
-            self.assertEqual(mask.data[750, 701], 1)  # center bottom
-            self.assertEqual(mask.data[800, 750], 1)  # center left
+            self.assertEqual(mask.data[700, 700], 0)  # top left
+            self.assertEqual(mask.data[700, 800], 0)  # top right
+
+            self.assertEqual(mask.data[750, 800], 1)  # center bottom
+            self.assertEqual(mask.data[750, 801], 0)  # center bottom
+            self.assertEqual(mask.data[700, 750], 1)  # center left
+            self.assertEqual(mask.data[699, 750], 0)  # center left
+            self.assertEqual(mask.data[750, 700], 1)  # center top
+            self.assertEqual(mask.data[750, 699], 0)  # center top
+            self.assertEqual(mask.data[800, 750], 1)  # center right
+            self.assertEqual(mask.data[801, 750], 0)  # center right
 
     def test_region_mask_rect(self):
         rect_graphic = Graphics.RectangleGraphic()

--- a/nion/swift/test/Region_test.py
+++ b/nion/swift/test/Region_test.py
@@ -137,13 +137,18 @@ class TestRegionClass(unittest.TestCase):
             ellipse_graphic.bounds = (0.2, 0.2), (0.1, 0.1)
             mask = ellipse_graphic.get_mask((1000, 1000))
             self.assertEqual(mask.data[200, 200], 0)  # top left
-            self.assertEqual(mask.data[200, 300], 0)  # bottom left
-            self.assertEqual(mask.data[300, 300], 0)  # bottom right
-            self.assertEqual(mask.data[300, 200], 0)  # bottom left
-            self.assertEqual(mask.data[250, 200], 1)  # center top
-            self.assertEqual(mask.data[300, 250], 1)  # center right
-            self.assertEqual(mask.data[250, 300], 1)  # center bottom
-            self.assertEqual(mask.data[200, 250], 1)  # center left
+            self.assertEqual(mask.data[200, 299], 0)  # bottom left
+            self.assertEqual(mask.data[299, 299], 0)  # bottom right
+            self.assertEqual(mask.data[299, 200], 0)  # bottom left
+
+            self.assertEqual(mask.data[249, 200], 1)  # center top
+            self.assertEqual(mask.data[249, 199], 0)  # center top
+            self.assertEqual(mask.data[299, 249], 1)  # center right
+            self.assertEqual(mask.data[300, 249], 0)  # center right
+            self.assertEqual(mask.data[249, 299], 1)  # center bottom
+            self.assertEqual(mask.data[249, 300], 0)  # center bottom
+            self.assertEqual(mask.data[200, 249], 1)  # center left
+            self.assertEqual(mask.data[199, 249], 0)  # center left
 
     def test_region_mask_spot(self):
         spot_graphic = Graphics.SpotGraphic()

--- a/nion/swift/test/Region_test.py
+++ b/nion/swift/test/Region_test.py
@@ -174,13 +174,21 @@ class TestRegionClass(unittest.TestCase):
             rect_graphic.bounds = (0.2, 0.2), (0.1, 0.1)
             mask = rect_graphic.get_mask((1000, 1000))
             self.assertEqual(mask.data[200, 200], 1)  # top left
-            self.assertEqual(mask.data[200, 300], 1)  # bottom left
-            self.assertEqual(mask.data[300, 300], 1)  # bottom right
-            self.assertEqual(mask.data[300, 200], 1)  # bottom left
-            self.assertEqual(mask.data[250, 200], 1)  # center top
-            self.assertEqual(mask.data[300, 250], 1)  # center right
-            self.assertEqual(mask.data[250, 300], 1)  # center bottom
-            self.assertEqual(mask.data[200, 250], 1)  # center left
+            self.assertEqual(mask.data[199, 199], 0)  # top left
+            self.assertEqual(mask.data[200, 299], 1)  # bottom left
+            self.assertEqual(mask.data[199, 300], 0)  # bottom left
+            self.assertEqual(mask.data[299, 299], 1)  # bottom right
+            self.assertEqual(mask.data[300, 300], 0)  # bottom right
+            self.assertEqual(mask.data[299, 200], 1)  # bottom left
+            self.assertEqual(mask.data[300, 199], 0)  # bottom left
+            self.assertEqual(mask.data[249, 200], 1)  # center top
+            self.assertEqual(mask.data[249, 199], 0)  # center top
+            self.assertEqual(mask.data[299, 249], 1)  # center right
+            self.assertEqual(mask.data[300, 249], 0)  # center right
+            self.assertEqual(mask.data[249, 299], 1)  # center bottom
+            self.assertEqual(mask.data[249, 300], 0)  # center bottom
+            self.assertEqual(mask.data[200, 249], 1)  # center left
+            self.assertEqual(mask.data[199, 249], 0)  # center left
 
     def test_region_mask_wedge(self):
         wedge_graphic = Graphics.WedgeGraphic()


### PR DESCRIPTION
This is to address https://github.com/nion-software/nionswift/issues/1472. The ellipse tests rely on https://github.com/nion-software/niondata/pull/67

This PR offsets the centre of the graphic by 0.5 pixels towards the top left in order to use the centre of the pixel to determine if they are in or out of the mask.

The test have been updated accordingly and also test that 1 pixel outside the mask is 0.