### PR TITLE
Add metadata paths for scan and camera orientation to metadata.py

### DIFF
--- a/nion/swift/model/Metadata.py
+++ b/nion/swift/model/Metadata.py
@@ -50,7 +50,7 @@ key_map = {
     'stem.beam_current_a': {'paths': ['instrument.beam_current', 'hardware_source.beam_current_a'], 'type': 'real'},
     'stem.defocus': {'paths': ['instrument.defocus', 'hardware_source.defocus_m'], 'type': 'real'},
     'stem.defocus_m': {'paths': ['instrument.defocus', 'hardware_source.defocus_m'], 'type': 'real'},
-    'stem.axis_details': {'paths': ['instrument.axis_details'], 'type': 'map'},
+    'stem.axis_transformation_matrices': {'paths': ['instrument.axis_transformation_matrices'], 'type': 'map'},
 
     'stem.eels.spectrum_type': {'paths': ['hardware_source.eels_spectrum_type'], 'type': 'string'},
     'stem.eels.resolution_eV': {'paths': ['hardware_source.eels_resolution_eV'], 'type': 'string'},


### PR DESCRIPTION
This is part of https://github.com/nion-software/nion-instrumentation/issues/390

It is to add the additional metadata paths to metadata.py for ease of access. However it may change to accommodate changes in https://github.com/nion-software/nion-instrumentation/pull/482.