### PR TITLE
Ensure that error is raised when data item is deleted

### DIFF
--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -921,6 +921,7 @@ class DataItem(Persistence.PersistentObject):
 
     def queue_partial_update(self, partial_xdata: DataAndMetadata.DataAndMetadata, *, src_slice: typing.Sequence[slice],
                              dst_slice: typing.Sequence[slice], metadata: DataAndMetadata.DataMetadata) -> None:
+        assert not self._closed, _("Cannot update deleted data item")
         with self.__pending_xdata_lock:
             self.__pending_queue.append((partial_xdata, src_slice, dst_slice, metadata))
 

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -921,7 +921,8 @@ class DataItem(Persistence.PersistentObject):
 
     def queue_partial_update(self, partial_xdata: DataAndMetadata.DataAndMetadata, *, src_slice: typing.Sequence[slice],
                              dst_slice: typing.Sequence[slice], metadata: DataAndMetadata.DataMetadata) -> None:
-        assert not self._closed, _("Cannot update deleted data item")
+        if self._closed:
+            raise Exception(_("Cannot update deleted data item"))
         with self.__pending_xdata_lock:
             self.__pending_queue.append((partial_xdata, src_slice, dst_slice, metadata))
 


### PR DESCRIPTION
This is for https://github.com/nion-software/nionswift-instrumentation-kit/issues/249

The acquire function already has a cancel on error, but nothing was throwing an error to let it know that the dataitem no longer existed. 

This was the closest place I could find that knows about the item having being closed/deleted.

I couldn't think of a reason we would want to continue updating a dataitem that has been closed. When we raise this error, the error handling in the acquire function kicks in and cancels the acquisition.