### PR TITLE
Change title of duplicated items to 'Duplicate', was 'Copy'.

### DIFF
--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -930,7 +930,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         data_item_copy.category = data_item.category
         display_item = self.get_display_item_for_data_item(data_item_copy)
         assert display_item
-        data_item_copy.title = display_item.displayed_title + " (" + _("Copy") + ")"
+        data_item_copy.title = display_item.displayed_title + " (" + _("Duplicate") + ")"
         return data_item_copy
 
     def __handle_data_item_inserted(self, data_item: DataItem.DataItem) -> None:

--- a/nion/swift/test/DocumentModel_test.py
+++ b/nion/swift/test/DocumentModel_test.py
@@ -2500,8 +2500,8 @@ class TestDocumentModelClass(unittest.TestCase):
                 self.assertEqual("test (Snapshot)", display_item_snapshot.displayed_title)
                 self.assertEqual("test (Display Snapshot)", display_snapshot.data_item.title)
                 self.assertEqual("test (Display Snapshot)", display_snapshot.displayed_title)
-                self.assertEqual("test (Copy)", display_copy.data_item.title)
-                self.assertEqual("test (Copy)", display_copy.displayed_title)
+                self.assertEqual("test (Duplicate)", display_copy.data_item.title)
+                self.assertEqual("test (Duplicate)", display_copy.displayed_title)
 
     def test_mapped_sum_connector_on_invalid_data(self):
         with TestContext.create_memory_context() as test_context:


### PR DESCRIPTION
Fixes #1522
