### PR TITLE
Disable pan action on mouse wheel scroll

### DIFF
--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -1596,14 +1596,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         return True
 
     def wheel_changed(self, x: int, y: int, dx: int, dy: int, is_horizontal: bool) -> bool:
-        delegate = self.delegate
-        if delegate and self.__mouse_in:
-            dx = dx if is_horizontal else 0
-            dy = dy if not is_horizontal else 0
-            command = delegate.create_change_display_command(command_id="image_position", is_mergeable=True)
-            self._update_image_canvas_position(Geometry.FloatSize(-dy, -dx))
-            delegate.push_undo_command(command)
-            return True
+        # For now do nothing on the scroll wheel changing
         return False
 
     def pan_gesture(self, dx: int, dy: int) -> bool:


### PR DESCRIPTION
#1625

Removes the pan call in the wheel_changed handler function. For now does not replace it with anything else