### PR TITLE
Fix #1635. Do not auto close application while project switching error dialogs are open.

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -503,6 +503,22 @@ class Application(UIApplication.BaseApplication):
             # continue with opening the default project
             return self.__open_default_project(profile_dir, is_created)
 
+    def __show_project_error_dialog(self, title: str, message: str, *, completion_fn: typing.Optional[typing.Callable[[], None]] = None) -> None:
+        # during project management dialogs, we want to prevent the application from closing.
+        # so we enter a 'prevent close state', and then show the dialog. when the dialog completes,
+        # we exit the 'prevent close state'. if an exception occurs, we also exit the prevent close state
+        # and re-raise the exception.
+        def handle_complete() -> None:
+            self._exit_prevent_close_state()
+            if callable(completion_fn):
+                completion_fn()
+        self._enter_prevent_close_state()
+        try:
+            self.show_ok_dialog(title, message, completion_fn=handle_complete)
+        except Exception:
+            self._exit_prevent_close_state()
+            raise
+
     def __open_default_project(self, profile_dir: typing.Optional[pathlib.Path], is_created: bool) -> bool:
         # if the default project is known, open it.
         # if it fails, ask the user to select another project.
@@ -528,7 +544,7 @@ class Application(UIApplication.BaseApplication):
             except Exception:
                 import traceback
                 traceback.print_exc()
-                self.show_ok_dialog(_("Error Opening Project"), _("Unable to open default project."), completion_fn=self.show_choose_project_dialog)
+                self.__show_project_error_dialog(_("Error Opening Project"), _("Unable to open default project."), completion_fn=self.show_choose_project_dialog)
                 return True
 
             if profile_dir is None:
@@ -583,7 +599,7 @@ class Application(UIApplication.BaseApplication):
                 if project_reference:
                     self.open_project_reference(project_reference)
                 else:
-                    self.show_ok_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
+                    self.__show_project_error_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
 
     def show_choose_project_dialog(self) -> None:
         with self.prevent_close():
@@ -824,11 +840,11 @@ class Application(UIApplication.BaseApplication):
                             new_project_reference = profile.upgrade(project_reference)
                         except FileExistsError:
                             message = _("Upgraded project already exists.")
-                            self.show_ok_dialog(_("Error Upgrading Project"), f"{message}\n{project_reference.path}")
+                            self.__show_project_error_dialog(_("Error Upgrading Project"), f"{message}\n{project_reference.path}")
                             logging.getLogger("loader").info(f"Project already exists: {project_reference.path}")
                             new_project_reference = None
                         except Exception as e:
-                            self.show_ok_dialog(_("Error Upgrading Project"), _("Unable to upgrade project."))
+                            self.__show_project_error_dialog(_("Error Upgrading Project"), _("Unable to upgrade project."))
                             import traceback
                             traceback.print_exc()
                             new_project_reference = None
@@ -840,7 +856,7 @@ class Application(UIApplication.BaseApplication):
                                            ok_text=_("Upgrade"),
                                            completion_fn=handle_upgrade)
             else:
-                self.show_ok_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
+                self.__show_project_error_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
 
     def switch_project_reference(self, project_reference: Profile.ProjectReference) -> None:
         for window in self.windows:
@@ -849,7 +865,7 @@ class Application(UIApplication.BaseApplication):
         try:
             self.open_project_window(project_reference)
         except Exception:
-            self.show_ok_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
+            self.__show_project_error_dialog(_("Error Opening Project"), _("Unable to open project."), completion_fn=self.show_choose_project_dialog)
 
     @classmethod
     def get_nion_swift_version_info(cls) -> typing.List[typing.Tuple[str, str, str]]:


### PR DESCRIPTION
Note: Application can still be exited while dialogs are open by explicitly
quitting on platforms that support that.
