### PR TITLE
Properly initialize display data channel display values stream. Test.

### DIFF
--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -1010,9 +1010,6 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         if update_session:
             display_item.session_id = self.session_id
         self._project.append_display_item(display_item)
-        # force display update
-        with display_item.display_item_changes():
-            pass
 
     def insert_display_item(self, before_index: int, display_item: DisplayItem.DisplayItem, *, update_session: bool = True) -> None:
         uuid_order = save_item_order(typing.cast(typing.List[Persistence.PersistentObject], self.__display_items))  # cast required for mypy bug?

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -3276,6 +3276,17 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             DisplayPanel.preview(DisplayPanel.DisplayPanelUISettings(document_controller.ui), display_item, Geometry.IntSize(128, 128))
 
+    def test_preview_produces_expected_data_on_orphan_display_item(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((10, 10)))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            with contextlib.closing(display_item.snapshot()) as display_item_snapshot:
+                drawing_context = DisplayPanel.preview(DisplayPanel.DisplayPanelUISettings(document_controller.ui), display_item_snapshot, Geometry.IntSize(256, 256))
+                self.assertIsNotNone(display_item_snapshot.display_data_channels[0].get_display_values_stream().value)
+
     def test_adding_fourier_filter_is_undoable(self):
         with TestContext.create_memory_context() as test_context:
             # set up the layout


### PR DESCRIPTION
This fixes a mostly-internal bug that would occasionally appear in exports, regular and SVG. This PR changes how display values are initialized on display data channels from explicitly to automatic. Added a test case.

Overall the system of display values mostly works, but is not a clean architecture. This builds on top of the existing architecture and doesn't try to clean it up or document it further.