### PR TITLE
Prefer the project data folder with same stem as index file. Test.

### DIFF
--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -862,15 +862,16 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         super().load_properties()
         project_data_folder_paths = list()
         existing_project_data_folder_paths = list()
+        # always prefer the index file root with " Data" suffix first
+        project_data_folder_path = self.__project_path.with_name(self.__project_path.stem + " Data")
+        if not project_data_folder_path.is_absolute():
+            project_data_folder_path = self.__project_path.parent / project_data_folder_path
+        project_data_folder_paths.append(project_data_folder_path)
+        if project_data_folder_path.exists():
+            existing_project_data_folder_paths.append(project_data_folder_path)
+        # now check for any folders listed in the properties
         for project_data_folder in self.get_storage_properties().get("project_data_folders", list()):
             project_data_folder_path = pathlib.Path(project_data_folder)
-            if not project_data_folder_path.is_absolute():
-                project_data_folder_path = self.__project_path.parent / project_data_folder_path
-            project_data_folder_paths.append(project_data_folder_path)
-            if project_data_folder_path.exists():
-                existing_project_data_folder_paths.append(project_data_folder_path)
-        if not existing_project_data_folder_paths:
-            project_data_folder_path = self.__project_path.with_name(self.__project_path.stem + " Data")
             if not project_data_folder_path.is_absolute():
                 project_data_folder_path = self.__project_path.parent / project_data_folder_path
             project_data_folder_paths.append(project_data_folder_path)


### PR DESCRIPTION
Fixes #1755 

This change ensures that if the user copies an index and folder on
disk and renames them to match and reloads, the newly renamed data
folder will be loaded instead of the data folder referenced in the
index file, which would be the original, not the copied, data folder.
