### PR TITLE
make renaming a workspace update the title bar

### DIFF
--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -133,9 +133,11 @@ class RenameWorkspaceCommand(Undo.UndoableCommand):
 
     def _perform(self) -> None:
         self.__workspace_controller._workspace.name = self.__new_name
+        self.__workspace_controller.document_controller._workspace_changed(self.__workspace_controller._workspace)
 
     def _undo(self) -> None:
         self.__workspace_controller._workspace.name = self.__old_name
+        self.__workspace_controller.document_controller._workspace_changed(self.__workspace_controller._workspace)
 
     def _redo(self) -> None:
         self.perform()


### PR DESCRIPTION
Fixes #627. The _preform and _undo functions in the RenameWorkspaceCommand now call the document controller _workspace_changed. The other commands in Workspace.py were calling this method in the command so I did the same rather than placing it in the WorkspaceRenameAction in DocumentController.