### PR TITLE
Fix the Interval marker center

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -984,7 +984,7 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                         drawing_context.line_dash = 2
                     drawing_context.stroke()
 
-                    mid_x = (left + right) // 2
+                    mid_x = (left + right) / 2
                     drawing_context.move_to(left, level)
                     drawing_context.line_to(mid_x - 3, level)
                     drawing_context.move_to(mid_x + 3, level)


### PR DESCRIPTION
Addresses #1779. 
Before:
<img width="346" height="201" alt="Screenshot 2026-02-20 143357" src="https://github.com/user-attachments/assets/79cd7d3e-8dd0-4fed-be4e-f5b7839795ae" />

The fix makes the marker centered on a half pixel when the width is odd:
<img width="343" height="205" alt="Screenshot 2026-02-20 143757" src="https://github.com/user-attachments/assets/dde148a3-d723-4955-9ebc-3c75949f4ebb" />
The gap on the right is an independent PR #1777 