### PR TITLE
Use one as lower y-axis value when display limit negative and log display.

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -216,8 +216,10 @@ def calculate_y_axis(xdata_list: typing.Sequence[DataAndMetadata.DataAndMetadata
     # Convert calibrated limits to display space
     mapped_calibrated_data_min = data_style.convert_calibrated_value_to_mapped_calibrated_value(calibrated_min)
     mapped_calibrated_data_max = data_style.convert_calibrated_value_to_mapped_calibrated_value(calibrated_max)
-    if (math.isnan(mapped_calibrated_data_min) or math.isnan(mapped_calibrated_data_max) or math.isinf(mapped_calibrated_data_min) or math.isinf(mapped_calibrated_data_max)):
-        mapped_calibrated_data_min, mapped_calibrated_data_max = 0.0, 0.0
+    if math.isnan(mapped_calibrated_data_min) or math.isinf(mapped_calibrated_data_min):
+        mapped_calibrated_data_min = 0.0
+    if math.isnan(mapped_calibrated_data_max) or math.isinf(mapped_calibrated_data_max):
+        mapped_calibrated_data_max = 0.0
     mapped_calibrated_data_min, mapped_calibrated_data_max = min(mapped_calibrated_data_min, mapped_calibrated_data_max), max(mapped_calibrated_data_min, mapped_calibrated_data_max)
     if mapped_calibrated_data_min == mapped_calibrated_data_max:
         mapped_calibrated_data_min -= 1.0

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -142,6 +142,17 @@ class TestLineGraphCanvasItem(unittest.TestCase):
                 self.assertAlmostEqual(numpy.nanmin(mapped_calibrated_data), math.log10(numpy.nanmin(data)))
                 self.assertAlmostEqual(numpy.nanmax(mapped_calibrated_data), math.log10(numpy.nanmax(data)))
 
+    def test_line_plot_with_negative_lower_display_limit_in_log_scale_displays_reasonable_limits(self):
+        # tests that entering a invalid lower display limit (negative) still results in a mapped calibrated data limits.
+        data = numpy.linspace(0, 10, 100, endpoint=False)
+        intensity_calibration = Calibration.Calibration()
+        xdata = DataAndMetadata.new_data_and_metadata(data, intensity_calibration=intensity_calibration)
+        mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], -2, 12, "log")
+        # the mapped calibrated data min should be 0.0 (a reasonable value for negative data)
+        # the unmapped mapped calibrated data max should match the upper display limit (12).
+        self.assertAlmostEqual(0.0, mapped_calibrated_data_min)
+        self.assertAlmostEqual(12.0, math.pow(10, mapped_calibrated_data_max))
+
     def test_line_plot_with_log_scale_displays_integers(self):
         data = numpy.array([1,2,3], dtype=int)
         data_style = "log"


### PR DESCRIPTION
Fixes #1790

The value of one is a compromise. This usually results from the user adjusting
the y-axis on non-log display upward to be able to see the lower valued data
and then enabling log display. The value of one will be values less than one
and negative values at the bottom of the display.

Example display limits

<img width="298" height="39" alt="image" src="https://github.com/user-attachments/assets/68464965-3357-48a3-b9d9-0e3f264c7a91" />

Example of original data

<img width="354" height="231" alt="image" src="https://github.com/user-attachments/assets/a50be5df-47a2-4233-98b3-7897314c74e9" />

Example of incorrect log display (displaying -1 to 1) (existing code)

<img width="353" height="231" alt="image" src="https://github.com/user-attachments/assets/cea155a5-ae7a-4dc0-bc8a-2ae6004aeda9" />

Example of "correct" log display (display 1 to non-log display limit 8e7) (new code, this PR)

<img width="354" height="233" alt="image" src="https://github.com/user-attachments/assets/c862a73b-fc6f-42ac-82ea-394715a8505d" />
