### PR TITLE
Interval text background

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -963,7 +963,7 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                 """Gets the rectangle that surrounds a text string
 
                 The positions returned are offset by x, y.
-                The text_baseline is the vertical alignment of the text, 'top', 'bottom' otherwise center
+                The text_baseline is the vertical alignment of the text, 'top', 'bottom' otherwise middle
                 Margin is added to the x-axis
                 """
                 metrics = self.__ui_settings.get_font_metrics(self.font, text)
@@ -973,14 +973,14 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                 height = ascent + descent
 
                 if baseline == "top":
-                    rect_top = y
+                    y_pos = y + ascent
                 elif baseline == "bottom":
-                    rect_top = y - ascent  # There is a bug in nionui-tool that means 'bottom' baseline is actually alphabetic
+                    y_pos = y  # There is a bug in nionui-tool that means 'bottom' baseline is actually alphabetic. Should be - descent
                 elif baseline == "middle":
-                    rect_top = y - height / 2
+                    y_pos = y + descent
                 else:  # alphabetic or ideographic
-                    rect_top = y - ascent
-
+                    y_pos = y
+                rect_top = y_pos - ascent
                 if align == "right":
                     rect_left = x - width + margin
                 elif align == "left":
@@ -1057,14 +1057,10 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                         if middle_text and region.style != "tag":
                             _draw_label_with_background(middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom")
                         drawing_context.fill_style = region_color
-                        if left_text and region.style != "tag":
-                            drawing_context.text_align = "right"
-                            drawing_context.text_baseline = "middle"
-                            drawing_context.fill_text(left_text, left - 5, level)
+                        if left_text:
+                            _draw_label_with_background(left_text, left - 5, level, "right", "middle")
                         if right_text:
-                            drawing_context.text_align = "left"
-                            drawing_context.text_baseline = "middle"
-                            drawing_context.fill_text(right_text, right + 5, level)
+                            _draw_label_with_background(right_text, right + 5, level, "left", "middle")
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -50,7 +50,6 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
-    show_width: bool
 
 
 _ = gettext.gettext
@@ -925,8 +924,6 @@ class LineGraphLayersCanvasItem(CanvasItem.CanvasItemComposition):
 
 
 class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
-    DIGIT_MAPPING = str.maketrans("0123456789", "0000000000")
-
     def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], regions: typing.Sequence[RegionInfo], is_focused: bool, ui_settings: UISettings.UISettings) -> None:
         super().__init__(canvas_item, layout_sizing, cache)
         self.__cache_values = list[typing.Tuple[CanvasItem.CacheValue, ...]]()
@@ -934,16 +931,17 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
         self.__regions = regions
         self.__is_focused = is_focused
         self.__ui_settings = ui_settings
-        self.font_size_metric = self.__ui_settings.get_font_metrics("12px", "My")  # If in the future the font_size changes then this should be changed to observe it and update accordingly
+        self.font = "12px"
+        self.font_size_metric = self.__ui_settings.get_font_metrics(self.font, "My")  # If in the future the font_size changes then this should be changed to observe it and update accordingly
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
         canvas_size = canvas_bounds.size
 
         regions = self.__regions
-        font_size = 12
-        text_background_color = "#99ffffff"
         box_text_color = "black"
+        text_background_color = "#99ffffff"
+
         axes = self.__axes
         if axes:
             # extract the data we need for drawing y-axis
@@ -956,7 +954,6 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
             plot_height = canvas_size.height - 1
             plot_origin_y = 0
-            drawing_context.font = "{0:d}px".format(font_size)
 
             def convert_coordinate_to_pixel(canvas_size: Geometry.IntSize, c: float, data_scale: float, data_left: float, data_right: float) -> float:
                 px = c * data_scale
@@ -969,7 +966,7 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                 The text_baseline is the vertical alignment of the text, 'top', 'bottom' otherwise center
                 Margin is added to the x-axis
                 """
-                metrics = self.__ui_settings.get_font_metrics(f"{font_size:d}px", text)
+                metrics = self.__ui_settings.get_font_metrics(self.font, text)
                 width = float(metrics.width) + 2 * margin  # Margin around the text for legibility
                 ascent = float(metrics.ascent)
                 descent = float(metrics.descent)
@@ -979,17 +976,17 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     rect_top = y
                 elif baseline == "bottom":
                     rect_top = y - ascent  # There is a bug in nionui-tool that means 'bottom' baseline is actually alphabetic
-                elif baseline == "center":
-                    rect_top = y + descent - height
-                else: # alphabetic or ideographic
+                elif baseline == "middle":
+                    rect_top = y - height / 2
+                else:  # alphabetic or ideographic
                     rect_top = y - ascent
 
                 if align == "right":
                     rect_left = x - width + margin
                 elif align == "left":
                     rect_left = x - margin
-                else:
-                    rect_left = x - width / 2.0  # center
+                else:  # center
+                    rect_left = x - width / 2.0
 
                 return Geometry.FloatRect.from_tlhw(rect_top, rect_left, height, width)
 
@@ -1004,6 +1001,14 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.fill()
                     drawing_context.stroke()
 
+            def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str) -> None:
+                drawing_context.text_baseline = text_baseline
+                drawing_context.text_align = text_align
+                label_rect = _get_text_rectangle(label_text, label_x, label_y, text_baseline, text_align)
+                drawing_context.stroke_style = region_color
+                _draw_text_background(label_rect, text_background_color)
+                drawing_context.fill_style = box_text_color
+                drawing_context.fill_text(label_text, label_x, label_y)
 
             for region in regions:
                 left_channel, right_channel = region.channels
@@ -1042,54 +1047,32 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.move_to(mid_x + 3, level)
                     drawing_context.line_to(right, level)
                     drawing_context.stroke()
-                    drawing_context.close_path()
+                    drawing_context.close_path()  # A new path is needed for the label to have a transparency in the background
                     drawing_context.line_dash = 0
-                    left_text = region.left_text
-                    right_text = region.right_text
-                    middle_text = region.middle_text
                     drawing_context.begin_path()
-                    if region_selected or region.show_width:
-                        if middle_text and region.style != "tag":
-                            text_align = "center"
-                            text_baseline = "bottom"
-                            drawing_context.text_baseline = text_baseline
-                            drawing_context.text_align = text_align
-                            middle_text_bottom = level - self.font_size_metric.height
-                            drawing_context.stroke_style = region_color
-                            mid_text_rect = _get_text_rectangle(middle_text.translate(self.DIGIT_MAPPING), mid_x, middle_text_bottom, text_baseline, text_align)
-                            drawing_context.fill_text(middle_text, mid_x, middle_text_bottom)
-                            _draw_text_background(mid_text_rect, text_background_color)
-                            drawing_context.fill_style = box_text_color
-                            drawing_context.fill_text(middle_text, mid_x, middle_text_bottom)
-
                     if region_selected:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), fill=selection_color, stroke=selection_color)
-
+                        drawing_context.font = self.font
+                        left_text = region.left_text
+                        right_text = region.right_text
+                        middle_text = region.middle_text
+                        if middle_text and region.style != "tag":
+                            _draw_label_with_background(middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom")
+                        drawing_context.fill_style = region_color
                         if left_text and region.style != "tag":
                             drawing_context.text_align = "right"
-                            drawing_context.text_baseline = "center"
+                            drawing_context.text_baseline = "middle"
                             drawing_context.fill_text(left_text, left - 5, level)
                         if right_text:
                             drawing_context.text_align = "left"
-                            drawing_context.text_baseline = "center"
+                            drawing_context.text_baseline = "middle"
                             drawing_context.fill_text(right_text, right + 5, level)
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
 
                     label = region.label
                     if label:
-                        drawing_context.line_dash = 0
-                        drawing_context.font = "{0:d}px".format(font_size)
-                        text_align = "center"
-                        label_y = level + self.font_size_metric.height
-                        text_baseline = "top"
-                        drawing_context.text_baseline = text_baseline
-                        drawing_context.text_align = text_align
-                        label_rect = _get_text_rectangle(label, mid_x, label_y, text_baseline, text_align)
-                        drawing_context.stroke_style = region_color
-                        _draw_text_background(label_rect, text_background_color)
-                        drawing_context.fill_style = box_text_color
-                        drawing_context.fill_text(label, mid_x, label_y)
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top")
                     drawing_context.close_path()
 
 class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -50,6 +50,7 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
+    show_width: bool
 
 
 _ = gettext.gettext
@@ -924,12 +925,16 @@ class LineGraphLayersCanvasItem(CanvasItem.CanvasItemComposition):
 
 
 class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
-    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], regions: typing.Sequence[RegionInfo], is_focused: bool) -> None:
+    DIGIT_MAPPING = str.maketrans("0123456789", "0000000000")
+
+    def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache, axes: typing.Optional[LineGraphAxes], regions: typing.Sequence[RegionInfo], is_focused: bool, ui_settings: UISettings.UISettings) -> None:
         super().__init__(canvas_item, layout_sizing, cache)
         self.__cache_values = list[typing.Tuple[CanvasItem.CacheValue, ...]]()
         self.__axes = axes
         self.__regions = regions
         self.__is_focused = is_focused
+        self.__ui_settings = ui_settings
+        self.font_size_metric = self.__ui_settings.get_font_metrics("12px", "My")  # If in the future the font_size changes then this should be changed to observe it and update accordingly
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
@@ -937,7 +942,8 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
         regions = self.__regions
         font_size = 12
-
+        text_background_color = "#99ffffff"
+        box_text_color = "black"
         axes = self.__axes
         if axes:
             # extract the data we need for drawing y-axis
@@ -950,10 +956,54 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
             plot_height = canvas_size.height - 1
             plot_origin_y = 0
+            drawing_context.font = "{0:d}px".format(font_size)
 
             def convert_coordinate_to_pixel(canvas_size: Geometry.IntSize, c: float, data_scale: float, data_left: float, data_right: float) -> float:
                 px = c * data_scale
                 return canvas_size.width * (px - data_left) / (data_right - data_left)
+
+            def _get_text_rectangle(text: str, x: float, y: float, baseline: str = "center", align: str = "center", margin: int = 1) -> Geometry.FloatRect:
+                """Gets the rectangle that surrounds a text string
+
+                The positions returned are offset by x, y.
+                The text_baseline is the vertical alignment of the text, 'top', 'bottom' otherwise center
+                Margin is added to the x-axis
+                """
+                metrics = self.__ui_settings.get_font_metrics(f"{font_size:d}px", text)
+                width = float(metrics.width) + 2 * margin  # Margin around the text for legibility
+                ascent = float(metrics.ascent)
+                descent = float(metrics.descent)
+                height = ascent + descent
+
+                if baseline == "top":
+                    rect_top = y
+                elif baseline == "bottom":
+                    rect_top = y - ascent  # There is a bug in nionui-tool that means 'bottom' baseline is actually alphabetic
+                elif baseline == "center":
+                    rect_top = y + descent - height
+                else: # alphabetic or ideographic
+                    rect_top = y - ascent
+
+                if align == "right":
+                    rect_left = x - width + margin
+                elif align == "left":
+                    rect_left = x - margin
+                else:
+                    rect_left = x - width / 2.0  # center
+
+                return Geometry.FloatRect.from_tlhw(rect_top, rect_left, height, width)
+
+            def _draw_text_background(text_rect: Geometry.FloatRect, background_color: str) -> None:
+                with drawing_context.saver():
+                    drawing_context.fill_style = background_color
+                    drawing_context.move_to(text_rect.left, text_rect.top)
+                    drawing_context.line_to(text_rect.right, text_rect.top)
+                    drawing_context.line_to(text_rect.right, text_rect.bottom)
+                    drawing_context.line_to(text_rect.left, text_rect.bottom)
+                    drawing_context.line_to(text_rect.left, text_rect.top)
+                    drawing_context.fill()
+                    drawing_context.stroke()
+
 
             for region in regions:
                 left_channel, right_channel = region.channels
@@ -992,47 +1042,65 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.move_to(mid_x + 3, level)
                     drawing_context.line_to(right, level)
                     drawing_context.stroke()
+                    drawing_context.close_path()
                     drawing_context.line_dash = 0
+                    left_text = region.left_text
+                    right_text = region.right_text
+                    middle_text = region.middle_text
+                    drawing_context.begin_path()
+                    if region_selected or region.show_width:
+                        if middle_text and region.style != "tag":
+                            text_align = "center"
+                            text_baseline = "bottom"
+                            drawing_context.text_baseline = text_baseline
+                            drawing_context.text_align = text_align
+                            middle_text_bottom = level - self.font_size_metric.height
+                            drawing_context.stroke_style = region_color
+                            mid_text_rect = _get_text_rectangle(middle_text.translate(self.DIGIT_MAPPING), mid_x, middle_text_bottom, text_baseline, text_align)
+                            drawing_context.fill_text(middle_text, mid_x, middle_text_bottom)
+                            _draw_text_background(mid_text_rect, text_background_color)
+                            drawing_context.fill_style = box_text_color
+                            drawing_context.fill_text(middle_text, mid_x, middle_text_bottom)
+
                     if region_selected:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), fill=selection_color, stroke=selection_color)
-                        drawing_context.fill_style = region_color
-                        drawing_context.font = "{0:d}px".format(font_size)
-                        left_text = region.left_text
-                        right_text = region.right_text
-                        middle_text = region.middle_text
-                        if middle_text and region.style != "tag":
-                            drawing_context.text_align = "center"
-                            drawing_context.text_baseline = "bottom"
-                            drawing_context.fill_text(middle_text, mid_x, level - 6)
+
                         if left_text and region.style != "tag":
                             drawing_context.text_align = "right"
                             drawing_context.text_baseline = "center"
-                            drawing_context.fill_text(left_text, left - 4, level)
+                            drawing_context.fill_text(left_text, left - 5, level)
                         if right_text:
                             drawing_context.text_align = "left"
                             drawing_context.text_baseline = "center"
-                            drawing_context.fill_text(right_text, right + 4, level)
+                            drawing_context.fill_text(right_text, right + 5, level)
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
 
                     label = region.label
                     if label:
                         drawing_context.line_dash = 0
-                        drawing_context.fill_style = region_color
                         drawing_context.font = "{0:d}px".format(font_size)
-                        drawing_context.text_align = "center"
-                        drawing_context.text_baseline = "top"
-                        drawing_context.fill_text(label, mid_x, level + 6)
-
+                        text_align = "center"
+                        label_y = level + self.font_size_metric.height
+                        text_baseline = "top"
+                        drawing_context.text_baseline = text_baseline
+                        drawing_context.text_align = text_align
+                        label_rect = _get_text_rectangle(label, mid_x, label_y, text_baseline, text_align)
+                        drawing_context.stroke_style = region_color
+                        _draw_text_background(label_rect, text_background_color)
+                        drawing_context.fill_style = box_text_color
+                        drawing_context.fill_text(label, mid_x, label_y)
+                    drawing_context.close_path()
 
 class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
     """Canvas item to draw the line plot itself."""
 
-    def __init__(self) -> None:
+    def __init__(self, ui_settings: UISettings.UISettings) -> None:
         super().__init__()
         self.__regions: typing.List[RegionInfo] = list()
         self.__axes: typing.Optional[LineGraphAxes] = None
         self.__is_focused = False
+        self.__ui_settings = ui_settings
 
     @property
     def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
@@ -1055,7 +1123,7 @@ class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
             self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
-        return LineGraphRegionsCanvasItemComposer(self, self.layout_sizing, composer_cache, self._axes, self.__regions, self.__is_focused)
+        return LineGraphRegionsCanvasItemComposer(self, self.layout_sizing, composer_cache, self._axes, self.__regions, self.__is_focused, self.__ui_settings)
 
 
 class LineGraphFrameCanvasItemComposer(CanvasItem.BaseComposer):

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -933,14 +933,14 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
         self.__ui_settings = ui_settings
         self.font = "12px"
         self.font_size_metric = self.__ui_settings.get_font_metrics(self.font, "My")  # If in the future the font_size changes then this should be changed to observe it and update accordingly
+        self.label_text_color = "black"
+        self.text_background_color = "#99ffffff"
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         # draw the data, if any
         canvas_size = canvas_bounds.size
 
         regions = self.__regions
-        box_text_color = "black"
-        text_background_color = "#99ffffff"
 
         axes = self.__axes
         if axes:
@@ -990,25 +990,23 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
                 return Geometry.FloatRect.from_tlhw(rect_top, rect_left, height, width)
 
-            def _draw_text_background(text_rect: Geometry.FloatRect, background_color: str) -> None:
-                with drawing_context.saver():
-                    drawing_context.fill_style = background_color
-                    drawing_context.move_to(text_rect.left, text_rect.top)
-                    drawing_context.line_to(text_rect.right, text_rect.top)
-                    drawing_context.line_to(text_rect.right, text_rect.bottom)
-                    drawing_context.line_to(text_rect.left, text_rect.bottom)
-                    drawing_context.line_to(text_rect.left, text_rect.top)
-                    drawing_context.fill()
-                    drawing_context.stroke()
-
             def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str) -> None:
-                drawing_context.text_baseline = text_baseline
-                drawing_context.text_align = text_align
-                label_rect = _get_text_rectangle(label_text, label_x, label_y, text_baseline, text_align)
-                drawing_context.stroke_style = region_color
-                _draw_text_background(label_rect, text_background_color)
-                drawing_context.fill_style = box_text_color
-                drawing_context.fill_text(label_text, label_x, label_y)
+                with drawing_context.saver():
+                    drawing_context.text_baseline = text_baseline
+                    drawing_context.text_align = text_align
+                    drawing_context.fill_style = self.text_background_color
+                    label_rect = _get_text_rectangle(label_text, label_x, label_y, text_baseline, text_align)
+
+                    # Draw the text background
+                    drawing_context.move_to(label_rect.left, label_rect.top)
+                    drawing_context.line_to(label_rect.right, label_rect.top)
+                    drawing_context.line_to(label_rect.right, label_rect.bottom)
+                    drawing_context.line_to(label_rect.left, label_rect.bottom)
+                    drawing_context.line_to(label_rect.left, label_rect.top)
+                    drawing_context.fill()
+
+                    drawing_context.fill_style = self.label_text_color
+                    drawing_context.fill_text(label_text, label_x, label_y)
 
             for region in regions:
                 left_channel, right_channel = region.channels
@@ -1074,6 +1072,7 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     if label:
                         _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top")
                     drawing_context.close_path()
+
 
 class LineGraphRegionsCanvasItem(CanvasItem.AbstractCanvasItem):
     """Canvas item to draw the line plot itself."""

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -347,7 +347,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_area_stack = CanvasItem.CanvasItemComposition()
         self.__line_graph_background_canvas_item = LineGraphCanvasItem.LineGraphBackgroundCanvasItem()
         self.__line_graph_layers_canvas_item = LineGraphCanvasItem.LineGraphLayersCanvasItem()
-        self.__line_graph_regions_canvas_item = LineGraphCanvasItem.LineGraphRegionsCanvasItem()
+        self.__line_graph_regions_canvas_item = LineGraphCanvasItem.LineGraphRegionsCanvasItem(ui_settings)
         self.__line_graph_legend_row = CanvasItem.CanvasItemComposition()
         self.__line_graph_legend_row.layout = CanvasItem.CanvasItemRowLayout(margins=Geometry.Margins(4, 8, 4, 8))
         self.__line_graph_legend_canvas_item = LineGraphCanvasItem.LineGraphLegendCanvasItem(ui_settings, typing.cast(LineGraphCanvasItem.LineGraphLegendCanvasItemDelegate, delegate))
@@ -646,7 +646,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 left_text = convert_to_calibrated_value_str(left_channel)
                 right_text = convert_to_calibrated_value_str(right_channel)
                 middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, None, graphic.color)
+                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, None, graphic.color, graphic.show_width)
                 regions.append(region)
             elif isinstance(graphic, Graphics.ChannelGraphic):
                 graphic_start, graphic_end = graphic.position, graphic.position
@@ -656,7 +656,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 left_text = convert_to_calibrated_value_str(left_channel)
                 right_text = convert_to_calibrated_value_str(right_channel)
                 middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, "tag", graphic.color)
+                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, "tag", graphic.color, False)
                 regions.append(region)
 
         self.__line_graph_regions_canvas_item.set_regions(regions)

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -646,7 +646,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 left_text = convert_to_calibrated_value_str(left_channel)
                 right_text = convert_to_calibrated_value_str(right_channel)
                 middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, None, graphic.color, graphic.show_width)
+                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, None, graphic.color)
                 regions.append(region)
             elif isinstance(graphic, Graphics.ChannelGraphic):
                 graphic_start, graphic_end = graphic.position, graphic.position
@@ -656,7 +656,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 left_text = convert_to_calibrated_value_str(left_channel)
                 right_text = convert_to_calibrated_value_str(right_channel)
                 middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, "tag", graphic.color, False)
+                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, "tag", graphic.color)
                 regions.append(region)
 
         self.__line_graph_regions_canvas_item.set_regions(regions)

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -1920,6 +1920,7 @@ class IntervalGraphic(Graphic):
 
         # interval is stored in image normalized coordinates
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
+        self.define_property("show_width", False, changed=self._property_changed, hidden=True)
         self._default_drag_part = "end"
 
     @property
@@ -1929,6 +1930,14 @@ class IntervalGraphic(Graphic):
     @interval.setter
     def interval(self, value: typing.Tuple[float, float]) -> None:
         self._set_persistent_property_value("interval", value)
+
+    @property
+    def show_width(self) -> bool:
+        return typing.cast(bool, self._get_persistent_property_value("show_width"))
+
+    @show_width.setter
+    def show_width(self, value: bool) -> None:
+        self._set_persistent_property_value("show_width", value)
 
     def reset_position(self) -> None:
         offset = -(self.interval[0] + self.interval[1]) / 2 + 0.5

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -1920,7 +1920,6 @@ class IntervalGraphic(Graphic):
 
         # interval is stored in image normalized coordinates
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
-        self.define_property("show_width", False, changed=self._property_changed, hidden=True)
         self._default_drag_part = "end"
 
     @property
@@ -1930,14 +1929,6 @@ class IntervalGraphic(Graphic):
     @interval.setter
     def interval(self, value: typing.Tuple[float, float]) -> None:
         self._set_persistent_property_value("interval", value)
-
-    @property
-    def show_width(self) -> bool:
-        return typing.cast(bool, self._get_persistent_property_value("show_width"))
-
-    @show_width.setter
-    def show_width(self, value: bool) -> None:
-        self._set_persistent_property_value("show_width", value)
 
     def reset_position(self) -> None:
         offset = -(self.interval[0] + self.interval[1]) / 2 + 0.5


### PR DESCRIPTION
Fixes #1810

Change the interval graphic's width and label to use a background text box and have black text. ~~The show_width is in preparation for the zlp graphic to always show the width.~~
<img width="316" height="523" alt="Screenshot 2026-03-02 163944" src="https://github.com/user-attachments/assets/3a4bfd2b-2ea7-4a1c-b34d-5596a224f377" />
