### PR TITLE
Fix the return of apply_layouts 

### DIFF
--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -1017,7 +1017,10 @@ class Workspace:
         return old_display_panel, old_splits, region_id
 
     def apply_layouts(self, primary_display_panel: DisplayPanel.DisplayPanel, display_panels: typing.Sequence[DisplayPanel.DisplayPanel], w: int, h: int) -> typing.List[DisplayPanel.DisplayPanel]:
-        """Apply a w x h display panels to the current workspace."""
+        """Apply a w x h display panels to the current workspace.
+
+        Returns the newly created display panels in the order they appear in the workspace display panels.
+        """
 
         assert self.__workspace
         change_workspace_contents_command = ChangeWorkspaceContentsCommand(self, _("Change Workspace Contents"))
@@ -1037,13 +1040,11 @@ class Workspace:
                 row_splitter_canvas_item.on_splits_will_change = functools.partial(self._splits_will_change, row_splitter_canvas_item)
                 row_splitter_canvas_item.on_splits_changed = functools.partial(self._splits_did_change, row_splitter_canvas_item)
                 display_panel_container.wrap_canvas_item(display_panel, row_splitter_canvas_item)
-                new_display_panels.append(display_panel)
                 row_display_panels.append(display_panel)
                 last_display_panel = display_panel
                 for row in range(1, h):
                     row_display_panel = DisplayPanel.DisplayPanel(self.document_controller, dict())
                     self.__insert_display_panel(self.__display_panels.index(last_display_panel) + 1, row_display_panel)
-                    new_display_panels.append(row_display_panel)
                     row_display_panels.append(row_display_panel)
                     last_display_panel = row_display_panel
                     row_splitter_canvas_item.insert_canvas_item(row + 1, row_display_panel)
@@ -1069,6 +1070,9 @@ class Workspace:
                         last_display_panel = column_display_panel
                         column_splitter_canvas_item.insert_canvas_item(column + 1, column_display_panel)
                     column_splitter_canvas_item.splits = [1//w] * w
+            else:
+                # When no column splits are made, the returned panels needs to include the row panels.
+                new_display_panels.extend(row_display_panels)
 
         # the layout has changed, write it to persistent storage
         self.__sync_layout()

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1799,6 +1799,23 @@ class TestWorkspaceClass(unittest.TestCase):
     #     # cannot implement until common code for display controllers is moved into document model
     #     pass
 
+    def test_apply_layouts_return_value(self):
+        """Test the apply_layouts method returns the new panels in the correct order."""
+        test_cases = [(w, h) for w in range(1, 5) for h in range(1, 4)]
+        with TestContext.create_memory_context() as test_context:
+            for test_case in test_cases:
+                with self.subTest(test_case):
+                    document_controller = test_context.create_document_controller()
+                    workspace_controller = document_controller.workspace_controller
+                    selected_display_panel = workspace_controller.display_panels[0]
+                    context = typing.cast(DocumentController.DocumentController.ActionContext, document_controller._get_action_context())
+                    test_w, test_h = test_case
+                    total_new_panels = test_w * test_h
+                    returned_display_panels = workspace_controller.apply_layouts(selected_display_panel, context.display_panels, test_w, test_h)
+                    self.assertEqual(len(returned_display_panels), total_new_panels)
+                    for returned_panel, layout_panel in zip(returned_display_panels, workspace_controller.display_panels):
+                        self.assertEqual(returned_panel, layout_panel)
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes a bug in the workspace controller's apply_layouts where the returned display panels would have duplicate entries. This also adds a test for that function.