### PR TITLE
Add Workspace from selection

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -292,6 +292,8 @@ class DataPanel(Panel.Panel):
                 action_context = document_controller._get_action_context_for_display_items(display_items, None)
                 document_controller.populate_context_menu(menu, action_context)
                 menu.add_separator()
+                document_controller.add_action_to_menu_if_enabled(menu, "workspace.new_workspace_from_selection", action_context)
+                menu.add_separator()
                 document_controller.add_action_to_menu(menu, "item.delete", action_context)
                 menu.popup(context_menu_event.gp.x, context_menu_event.gp.y)
                 return True

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2882,7 +2882,6 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             self.__document_controller.add_action_to_menu(menu, "display_panel.select_siblings", action_context)
         if action_context.display_panel:
             menu.add_separator()
-            self.__document_controller.add_action_to_menu_if_enabled(menu, "workspace.split_from_selection", action_context)
             self.__document_controller.add_action_to_menu(menu, "workspace.split_vertical", action_context)
             self.__document_controller.add_action_to_menu(menu, "workspace.split_horizontal", action_context)
             menu.add_separator()

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2882,6 +2882,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             self.__document_controller.add_action_to_menu(menu, "display_panel.select_siblings", action_context)
         if action_context.display_panel:
             menu.add_separator()
+            self.__document_controller.add_action_to_menu_if_enabled(menu, "workspace.split_from_selection", action_context)
             self.__document_controller.add_action_to_menu(menu, "workspace.split_vertical", action_context)
             self.__document_controller.add_action_to_menu(menu, "workspace.split_horizontal", action_context)
             menu.add_separator()

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2894,6 +2894,8 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             self.__document_controller.add_action_to_menu(split_menu, "workspace.split_4x3", action_context)
             self.__document_controller.add_action_to_menu(split_menu, "workspace.split_4x4", action_context)
             self.__document_controller.add_action_to_menu(split_menu, "workspace.split_5x4", action_context)
+            menu.add_separator()
+            self.__document_controller.add_action_to_menu_if_enabled(menu, "workspace.new_workspace_from_selection", action_context)
         if self.__document_controller.is_action_enabled("display_panel.close", action_context):
             menu.add_separator()
             self.__document_controller.add_action_to_menu(menu, "display_panel.close", action_context)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2793,6 +2793,7 @@ class DocumentController(Window.Window):
         self.add_action_to_menu_if_enabled(menu, "display.reveal", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export_batch", action_context)
+        self.add_action_to_menu_if_enabled(menu, "workspace.new_workspace_from_selection", action_context)
 
         def reveal_data_item(data_item: DataItem.DataItem) -> None:
             # same as selecting menu item for 'reveal'
@@ -3822,6 +3823,180 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
         return super().execute(context)
 
 
+def _is_selected_in_workspace(selected: DisplayItem.DisplayItem, workspace: Workspace.Workspace) -> bool:
+    """Checks if the display item is in the display panels in the workspace"""
+    for display_panel in workspace.display_panels:
+        if display_panel._is_selected() and display_panel.display_item == selected:
+            return True
+    return False
+
+
+class SplitFromSelectionAction(WorkspaceSplitAction):
+    action_id = "workspace.split_from_selection"
+    action_name = _("Split Panel From Selection")
+    split_defaults = {1: (1, 1), 2: (2, 1), 3: (2, 2), 4: (2, 2), 5: (3, 2), 6: (3, 2), 7: (4, 2), 8: (4, 2), 9: (3, 3),
+                      12: (4, 3), 16: (4, 4), 20: (5, 4), 25: (5, 5), 30: (6, 5), 36: (6, 6), 42: (7, 6), 49: (7, 7),
+                      56: (8, 7), 64: (8, 8), 72: (9, 8), 81: (9, 9), 90: (10, 9), 100: (10, 10)}
+
+    @classmethod
+    def get_split(cls, selection_count: int) -> typing.Tuple[int, int]:
+        """Get a split for the layout that holds the selected items
+
+        If the number in the selection is n * n or (n + 1) * n and is below the 100 max then it uses a default split.
+        Otherwise it will return the smallest default split that can contain the number
+        """
+
+        if selection_count in cls.split_defaults:
+            return cls.split_defaults[selection_count]
+
+        for split_count in cls.split_defaults:
+            if split_count > selection_count:
+                return cls.split_defaults[split_count]
+
+        return 10, 10
+
+    def _get_selected(self, context: Window.ActionContext) -> list[DisplayItem.DisplayItem]:
+        """Gets the selection in the data panel used in a split"""
+        context = typing.cast(DocumentController.ActionContext, context)
+        selection = list(context.display_items)  # context.display_items can either be the data_panel display items or the workspace display items currently selected
+        window = typing.cast(DocumentController, context.window)
+        workspace_controller = window.workspace_controller
+        assert workspace_controller
+        selection_count = len(selection)
+        use_data_panel_selection = selection_count == 0  # either there is no selection in the data panel or there is no selection in the workspace panels
+        if not use_data_panel_selection and _is_selected_in_workspace(selection[0], workspace_controller):  # if there are items then check if the item is in the workspace
+            if selection_count == 1:
+                use_data_panel_selection = True  # Use the data panel selection only when one workspace display panel is selected
+            selection = []
+
+        if use_data_panel_selection:  # Try to use the data panel selection
+            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
+            display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
+            for index in data_panel._selection.ordered_indexes:
+                selection.append(display_items[index])
+
+        return selection
+
+    def execute(self, context: Window.ActionContext) -> Window.ActionResult:
+        context = typing.cast(DocumentController.ActionContext, context)
+        window = typing.cast(DocumentController, context.window)
+        assert window
+        workspace_controller = window.workspace_controller
+        assert workspace_controller
+        selected_display_panel = workspace_controller.document_controller.selected_display_panel
+        assert selected_display_panel
+        selection = self._get_selected(context)
+        selected_count = len(selection) + (0 if selected_display_panel.display_item is None else 1)  # if there is a display_item then the total splits needs to include it
+        horizontal, vertical = SplitFromSelectionAction.get_split(selected_count)
+
+        display_panels = context.display_panels if context.display_panels else [selected_display_panel]
+        if not (horizontal == 1 and vertical == 1):
+            display_panels = workspace_controller.apply_layouts(selected_display_panel, display_panels, horizontal, vertical)
+        new_workspace_result = Window.ActionResult(Window.ActionStatus.FINISHED)
+        new_workspace_result.results["display_panels"] = list(display_panels)
+
+        # Populate the newly created panel
+        # workspace_controller.document_controller.next_result_display_panel() would give the next display panel in the whole workspace
+        # instead iterate through the newly created panels
+        for display_item in selection:
+            for display_panel in display_panels:
+                if display_panel.is_result_panel and display_panel.display_panel_type == "empty":
+                    display_panel.set_display_item(display_item)  # Should this be set_displayed_data_item?
+                    break
+
+        return new_workspace_result
+
+    def is_enabled(self, context: Window.ActionContext) -> bool:
+        context = typing.cast(DocumentController.ActionContext, context)
+        selection = self._get_selected(context)
+        window = typing.cast(DocumentController, context.window)
+        workspace_controller = window.workspace_controller
+        assert workspace_controller
+        selected_display_panel = workspace_controller.document_controller.selected_display_panel
+        return bool(selection) and len(selection) < 101 and selected_display_panel is not None
+
+    def get_action_name(self, context: Window.ActionContext) -> str:
+        context = typing.cast(DocumentController.ActionContext, context)
+        selection = self._get_selected(context)
+
+        item_count = len(selection) + (0 if context.selected_display_panel is None or context.selected_display_panel.display_item is None else 1)
+        if item_count == 0:
+            return self.action_name
+
+        if item_count > 1:
+            h, w = SplitFromSelectionAction.get_split(len(selection))
+            return _("Split Panel From Selection") + f" {h}x{w} ({item_count} items)"
+
+        data_item = selection[0].data_item
+        display_item = selection[0]
+        if data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
+            displayed_title = display_item.displayed_title if display_item else data_item.title
+            return _("Insert ") + f" \"{displayed_title}\" " + _("Into Panel")
+        elif display_item:
+            return _("Insert ") + f" \"{display_item.displayed_title}\" " + _("Into Panel")
+        return self.action_name
+
+
+class NewFromSelectionAction(WorkspaceNewAction):
+    action_id = "workspace.new_workspace_from_selection"
+    action_name = _("New Workspace From Selection")
+
+    def execute(self, context: Window.ActionContext) -> Window.ActionResult:
+        context = typing.cast(DocumentController.ActionContext, context)
+        window = typing.cast(DocumentController, context.window)
+        selected_in_workspace = _is_selected_in_workspace(context.display_items[0], window.workspace_controller) if window.workspace_controller and len(context.display_items) > 0 else False
+
+        new_workspace_result = super().execute(context)
+        if new_workspace_result.status != Window.ActionStatus.FINISHED:
+            return new_workspace_result
+
+        workspace_controller = window.workspace_controller
+        assert workspace_controller
+        if selected_in_workspace:
+            context.display_panel = context.selected_display_panel
+            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
+            display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
+            workspace_items = list(context.display_items)
+            for index in data_panel._selection.ordered_indexes:
+                workspace_items.append(display_items[index])
+            context = window._get_action_context_for_display_items(workspace_items, context.display_panel)
+
+        # Since the only display panel will be the selected one, display_panels can just be a list with that inside
+        # apply_layouts mutates the workspace_controller.display_panels so using it will cause recursion
+        # The context.display_panels is no longer valid due to the creation of a new workspace
+        assert workspace_controller.document_controller.selected_display_panel
+        context.selected_display_panel = workspace_controller.document_controller.selected_display_panel
+        context.display_panels = [context.selected_display_panel]
+
+        window.perform_action_in_context("workspace.split_from_selection", context)
+        return new_workspace_result
+
+    def is_enabled(self, context: Window.ActionContext) -> bool:
+        context = typing.cast(DocumentController.ActionContext, context)
+        return bool(context.focus_widget) and bool(context.display_items) and len(context.display_items) < 101
+
+    def get_action_name(self, context: Window.ActionContext) -> str:
+        context = typing.cast(DocumentController.ActionContext, context)
+        window = typing.cast(DocumentController, context.window)
+        selected_in_workspace = _is_selected_in_workspace(context.display_items[0], window.workspace_controller) if window.workspace_controller and len(context.display_items) > 0 else False
+        data_item = context.data_item
+        display_item = context.display_item
+        item_count = len(context.display_items)
+        if selected_in_workspace:
+            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
+            item_count += len(data_panel._selection.ordered_indexes)
+
+        if item_count > 1:
+            h, w = SplitFromSelectionAction.get_split(item_count)
+            return _("New Workspace From Selection") + f" {h}x{w} ({item_count} items)"
+        elif data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
+            displayed_title = display_item.displayed_title if display_item else data_item.title
+            return _("New Workspace From") + f" \"{displayed_title}\""
+        elif display_item:
+            return _("New Workspace From") + f" \"{display_item.displayed_title}\""
+        return self.action_name
+
+
 Window.register_action(WorkspaceChangeSplits())
 Window.register_action(WorkspaceCloneAction())
 Window.register_action(WorkspaceNewAction())
@@ -3839,6 +4014,8 @@ Window.register_action(WorkspaceSplit3x3Action())
 Window.register_action(WorkspaceSplit4x3Action())
 Window.register_action(WorkspaceSplit4x4Action())
 Window.register_action(WorkspaceSplit5x4Action())
+Window.register_action(SplitFromSelectionAction())
+Window.register_action(NewFromSelectionAction())
 
 
 class AddGroupAction(Window.Action):

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3822,113 +3822,6 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
         return super().execute(context)
 
 
-class SplitFromSelectionAction(Window.Action):
-    action_id = "workspace.split_from_selection"
-    action_name = _("Split Panel From Selection")
-
-    @classmethod
-    def get_split(cls, selection_count: int) -> typing.Tuple[int, int]:
-        """Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
-
-        Depending on if the division of columns have ceil or floor applied first will affect the final split.
-        Both are calculated and the one that will have the least unused panels is returned.
-        """
-        ratio = 0.6
-        columns = math.sqrt(selection_count / ratio)
-
-        columns_ceil = math.ceil(columns)
-        rows_ceil = math.ceil(selection_count / columns_ceil)
-
-        columns_floor = math.floor(columns)
-        rows_floor = math.ceil(selection_count / columns_floor)
-
-        ceil_diff = columns_ceil * rows_ceil - selection_count
-        floor_diff = columns_floor * rows_floor - selection_count
-
-        if floor_diff < ceil_diff:
-            return columns_floor, rows_floor
-
-        return columns_ceil, rows_ceil
-
-    @staticmethod
-    def _get_selected(context: DocumentController.ActionContext) -> list[DisplayItem.DisplayItem]:
-        """Gets the selection in the data panel used in a split."""
-        selection = []
-        window = typing.cast(DocumentController, context.window)
-        workspace_controller = window.workspace_controller
-        assert workspace_controller
-        data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
-        display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
-        for index in data_panel._selection.ordered_indexes:
-            selection.append(display_items[index])
-
-        if len(selection) == 1 and context.display_panel and selection[0] == context.display_panel.display_item:
-            # Only one item in the selection and that item is the selected display panel's item.
-            return []  # The selection is only the selected display panel which can't split with itself so no selection is returned
-        return selection
-
-    def execute(self, context: Window.ActionContext) -> Window.ActionResult:
-        context = typing.cast(DocumentController.ActionContext, context)
-        window = typing.cast(DocumentController, context.window)
-        assert window
-        workspace_controller = window.workspace_controller
-        assert workspace_controller
-        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
-        assert selected_display_panel
-        selection = self._get_selected(context)
-        selected_count = len(selection) + (0 if selected_display_panel.display_item is None else 1)  # If there is a display_item then the total splits needs to include it
-        split_layout = SplitFromSelectionAction.get_split(selected_count)
-        display_panels = context.display_panels if context.display_panels else [selected_display_panel]
-        command = Workspace.SplitFromSelectionCommand(workspace_controller, selection, selected_display_panel, display_panels, split_layout)
-        command.perform()
-        window.push_undo_command(command)
-        return Window.ActionResult(Window.ActionStatus.FINISHED)
-
-    def is_enabled(self, context: Window.ActionContext) -> bool:
-        context = typing.cast(DocumentController.ActionContext, context)
-        window = typing.cast(DocumentController, context.window)
-        workspace_controller = window.workspace_controller
-        assert workspace_controller
-
-        selection = self._get_selected(context)
-        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
-        return bool(selection) and len(selection) < 101 and selected_display_panel is not None
-
-    def get_action_name(self, context: Window.ActionContext) -> str:
-        context = typing.cast(DocumentController.ActionContext, context)
-        window = typing.cast(DocumentController, context.window)
-        workspace_controller = window.workspace_controller
-        assert workspace_controller
-
-        selection = self._get_selected(context)
-        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
-
-        if not bool(selection) or len(selection) > 100 or selected_display_panel is None:
-            return self.action_name  # If the action is disabled return default name
-
-        if selected_display_panel:
-            display_item = selected_display_panel.display_item
-            if display_item is not None:
-                selection.insert(0, display_item)
-
-        item_count = len(selection)
-        if item_count == 0:
-            return self.action_name
-
-        if item_count > 1:
-            h, w = SplitFromSelectionAction.get_split(item_count)
-            return _("Split Panel From Selection") + f" {h}x{w} ({item_count} items)"
-
-        data_item = selection[0].data_item
-        display_item = selection[0]
-        if data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
-            displayed_title = display_item.displayed_title if display_item else data_item.title
-            return _("Insert Item") + f" \"{displayed_title}\" " + _("Into Panel")
-        elif display_item:
-            return _("Insert Item") + f" \"{display_item.displayed_title}\" " + _("Into Panel")
-        return self.action_name
-
-
 class NewFromSelectionAction(WorkspaceNewAction):
     action_id = "workspace.new_workspace_from_selection"
     action_name = _("New Workspace From Selection")
@@ -3956,7 +3849,7 @@ class NewFromSelectionAction(WorkspaceNewAction):
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
         selection = self._get_selected(context)
-        split = SplitFromSelectionAction.get_split(len(selection))
+        split = Workspace.SplitFromSelectionCommand.get_split(len(selection))
         command = Workspace.NewWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
         command.perform()
         window.push_undo_command(command)
@@ -3978,7 +3871,7 @@ class NewFromSelectionAction(WorkspaceNewAction):
         display_item = context.display_item
         item_count = len(selection)
         if item_count > 1:
-            h, w = SplitFromSelectionAction.get_split(item_count)
+            h, w = Workspace.SplitFromSelectionCommand.get_split(item_count)
             return _("New Workspace From Selection") + f" {h}x{w} ({item_count} items)"
         elif data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
             displayed_title = display_item.displayed_title if display_item else data_item.title
@@ -4005,7 +3898,6 @@ Window.register_action(WorkspaceSplit3x3Action())
 Window.register_action(WorkspaceSplit4x3Action())
 Window.register_action(WorkspaceSplit4x4Action())
 Window.register_action(WorkspaceSplit5x4Action())
-Window.register_action(SplitFromSelectionAction())
 Window.register_action(NewFromSelectionAction())
 
 

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3846,13 +3846,12 @@ class NewFromSelectionAction(WorkspaceNewAction):
         text = self.get_string_property(context, "name")
         if not text:
             return Window.ActionResult(Window.ActionStatus.CANCELLED)
-        context = typing.cast(DocumentController.ActionContext, context)
         window = typing.cast(DocumentController, context.window)
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
         selection = self._get_selected(context)
-        split = Workspace.SplitFromSelectionCommand.get_split(len(selection))
-        command = Workspace.NewWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
+        split = Workspace.Workspace.get_split_for_selection(len(selection))
+        command = Workspace.CreateWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
         command.perform()
         window.push_undo_command(command)
 
@@ -3865,6 +3864,10 @@ class NewFromSelectionAction(WorkspaceNewAction):
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
+        window = typing.cast(DocumentController, context.window)
+        workspace_controller = window.workspace_controller
+        assert workspace_controller is not None
+
         selection = self._get_selected(context)
         if not bool(context.focus_widget) or not bool(selection) or len(selection) > 100:
             return self.action_name  # If the action is disabled return the default name
@@ -3873,7 +3876,7 @@ class NewFromSelectionAction(WorkspaceNewAction):
         display_item = context.display_item
         item_count = len(selection)
         if item_count > 1:
-            h, w = Workspace.SplitFromSelectionCommand.get_split(item_count)
+            h, w = Workspace.Workspace.get_split_for_selection(item_count)
             return _("New Workspace From Selection") + f" {h}x{w} ({item_count} items)"
         elif data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
             displayed_title = display_item.displayed_title if display_item else data_item.title

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2793,7 +2793,6 @@ class DocumentController(Window.Window):
         self.add_action_to_menu_if_enabled(menu, "display.reveal", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export", action_context)
         self.add_action_to_menu_if_enabled(menu, "file.export_batch", action_context)
-        self.add_action_to_menu_if_enabled(menu, "workspace.new_workspace_from_selection", action_context)
 
         def reveal_data_item(data_item: DataItem.DataItem) -> None:
             # same as selecting menu item for 'reveal'
@@ -3823,58 +3822,49 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
         return super().execute(context)
 
 
-def _is_selected_in_workspace(selected: DisplayItem.DisplayItem, workspace: Workspace.Workspace) -> bool:
-    """Checks if the display item is in the display panels in the workspace"""
-    for display_panel in workspace.display_panels:
-        if display_panel._is_selected() and display_panel.display_item == selected:
-            return True
-    return False
-
-
-class SplitFromSelectionAction(WorkspaceSplitAction):
+class SplitFromSelectionAction(Window.Action):
     action_id = "workspace.split_from_selection"
     action_name = _("Split Panel From Selection")
-    split_defaults = {1: (1, 1), 2: (2, 1), 3: (2, 2), 4: (2, 2), 5: (3, 2), 6: (3, 2), 7: (4, 2), 8: (4, 2), 9: (3, 3),
-                      12: (4, 3), 16: (4, 4), 20: (5, 4), 25: (5, 5), 30: (6, 5), 36: (6, 6), 42: (7, 6), 49: (7, 7),
-                      56: (8, 7), 64: (8, 8), 72: (9, 8), 81: (9, 9), 90: (10, 9), 100: (10, 10)}
 
     @classmethod
     def get_split(cls, selection_count: int) -> typing.Tuple[int, int]:
-        """Get a split for the layout that holds the selected items
+        """Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
 
-        If the number in the selection is n * n or (n + 1) * n and is below the 100 max then it uses a default split.
-        Otherwise it will return the smallest default split that can contain the number
+        Depending on if the division of columns have ceil or floor applied first will affect the final split.
+        Both are calculated and the one that will have the least unused panels is returned.
         """
+        ratio = 0.6
+        columns = math.sqrt(selection_count / ratio)
 
-        if selection_count in cls.split_defaults:
-            return cls.split_defaults[selection_count]
+        columns_ceil = math.ceil(columns)
+        rows_ceil = math.ceil(selection_count / columns_ceil)
 
-        for split_count in cls.split_defaults:
-            if split_count > selection_count:
-                return cls.split_defaults[split_count]
+        columns_floor = math.floor(columns)
+        rows_floor = math.ceil(selection_count / columns_floor)
 
-        return 10, 10
+        ceil_diff = columns_ceil * rows_ceil - selection_count
+        floor_diff = columns_floor * rows_floor - selection_count
 
-    def _get_selected(self, context: Window.ActionContext) -> list[DisplayItem.DisplayItem]:
-        """Gets the selection in the data panel used in a split"""
-        context = typing.cast(DocumentController.ActionContext, context)
-        selection = list(context.display_items)  # context.display_items can either be the data_panel display items or the workspace display items currently selected
+        if floor_diff < ceil_diff:
+            return columns_floor, rows_floor
+
+        return columns_ceil, rows_ceil
+
+    @staticmethod
+    def _get_selected(context: DocumentController.ActionContext) -> list[DisplayItem.DisplayItem]:
+        """Gets the selection in the data panel used in a split."""
+        selection = []
         window = typing.cast(DocumentController, context.window)
         workspace_controller = window.workspace_controller
         assert workspace_controller
-        selection_count = len(selection)
-        use_data_panel_selection = selection_count == 0  # either there is no selection in the data panel or there is no selection in the workspace panels
-        if not use_data_panel_selection and _is_selected_in_workspace(selection[0], workspace_controller):  # if there are items then check if the item is in the workspace
-            if selection_count == 1:
-                use_data_panel_selection = True  # Use the data panel selection only when one workspace display panel is selected
-            selection = []
+        data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
+        display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
+        for index in data_panel._selection.ordered_indexes:
+            selection.append(display_items[index])
 
-        if use_data_panel_selection:  # Try to use the data panel selection
-            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
-            display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
-            for index in data_panel._selection.ordered_indexes:
-                selection.append(display_items[index])
-
+        if len(selection) == 1 and context.display_panel and selection[0] == context.display_panel.display_item:
+            # Only one item in the selection and that item is the selected display panel's item.
+            return []  # The selection is only the selected display panel which can't split with itself so no selection is returned
         return selection
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
@@ -3883,57 +3873,59 @@ class SplitFromSelectionAction(WorkspaceSplitAction):
         assert window
         workspace_controller = window.workspace_controller
         assert workspace_controller
-        selected_display_panel = workspace_controller.document_controller.selected_display_panel
+        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
         assert selected_display_panel
         selection = self._get_selected(context)
-        selected_count = len(selection) + (0 if selected_display_panel.display_item is None else 1)  # if there is a display_item then the total splits needs to include it
-        horizontal, vertical = SplitFromSelectionAction.get_split(selected_count)
-
+        selected_count = len(selection) + (0 if selected_display_panel.display_item is None else 1)  # If there is a display_item then the total splits needs to include it
+        split_layout = SplitFromSelectionAction.get_split(selected_count)
         display_panels = context.display_panels if context.display_panels else [selected_display_panel]
-        if not (horizontal == 1 and vertical == 1):
-            display_panels = workspace_controller.apply_layouts(selected_display_panel, display_panels, horizontal, vertical)
-        new_workspace_result = Window.ActionResult(Window.ActionStatus.FINISHED)
-        new_workspace_result.results["display_panels"] = list(display_panels)
-
-        # Populate the newly created panel
-        # workspace_controller.document_controller.next_result_display_panel() would give the next display panel in the whole workspace
-        # instead iterate through the newly created panels
-        for display_item in selection:
-            for display_panel in display_panels:
-                if display_panel.is_result_panel and display_panel.display_panel_type == "empty":
-                    display_panel.set_display_item(display_item)  # Should this be set_displayed_data_item?
-                    break
-
-        return new_workspace_result
+        command = Workspace.SplitFromSelectionCommand(workspace_controller, selection, selected_display_panel, display_panels, split_layout)
+        command.perform()
+        window.push_undo_command(command)
+        return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
         context = typing.cast(DocumentController.ActionContext, context)
-        selection = self._get_selected(context)
         window = typing.cast(DocumentController, context.window)
         workspace_controller = window.workspace_controller
         assert workspace_controller
-        selected_display_panel = workspace_controller.document_controller.selected_display_panel
+
+        selection = self._get_selected(context)
+        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
         return bool(selection) and len(selection) < 101 and selected_display_panel is not None
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
-        selection = self._get_selected(context)
+        window = typing.cast(DocumentController, context.window)
+        workspace_controller = window.workspace_controller
+        assert workspace_controller
 
-        item_count = len(selection) + (0 if context.selected_display_panel is None or context.selected_display_panel.display_item is None else 1)
+        selection = self._get_selected(context)
+        selected_display_panel = workspace_controller.document_controller.selected_display_panel or context.display_panel
+
+        if not bool(selection) or len(selection) > 100 or selected_display_panel is None:
+            return self.action_name  # If the action is disabled return default name
+
+        if selected_display_panel:
+            display_item = selected_display_panel.display_item
+            if display_item is not None:
+                selection.insert(0, display_item)
+
+        item_count = len(selection)
         if item_count == 0:
             return self.action_name
 
         if item_count > 1:
-            h, w = SplitFromSelectionAction.get_split(len(selection))
+            h, w = SplitFromSelectionAction.get_split(item_count)
             return _("Split Panel From Selection") + f" {h}x{w} ({item_count} items)"
 
         data_item = selection[0].data_item
         display_item = selection[0]
         if data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
             displayed_title = display_item.displayed_title if display_item else data_item.title
-            return _("Insert ") + f" \"{displayed_title}\" " + _("Into Panel")
+            return _("Insert Item") + f" \"{displayed_title}\" " + _("Into Panel")
         elif display_item:
-            return _("Insert ") + f" \"{display_item.displayed_title}\" " + _("Into Panel")
+            return _("Insert Item") + f" \"{display_item.displayed_title}\" " + _("Into Panel")
         return self.action_name
 
 
@@ -3941,59 +3933,58 @@ class NewFromSelectionAction(WorkspaceNewAction):
     action_id = "workspace.new_workspace_from_selection"
     action_name = _("New Workspace From Selection")
 
+    @staticmethod
+    def _get_selected(context: DocumentController.ActionContext) -> list[DisplayItem.DisplayItem]:
+        """Get the current selection. The order will be selected display panels with items then selected data panel items."""
+        window = typing.cast(DocumentController, context.window)
+        workspace_controller = window.workspace_controller
+        assert workspace_controller is not None
+        selection = [context.selected_display_panel.display_item] if context.selected_display_panel and context.selected_display_panel.display_item else []
+        selection.extend([display_panel.display_item for display_panel in workspace_controller.document_controller.secondary_display_panels if display_panel.display_item is not None])
+        data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
+        display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
+        for index in data_panel._selection.ordered_indexes:
+            selection.append(display_items[index])
+        return selection
+
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
+        text = self.get_string_property(context, "name")
+        if not text:
+            return Window.ActionResult(Window.ActionStatus.CANCELLED)
         context = typing.cast(DocumentController.ActionContext, context)
         window = typing.cast(DocumentController, context.window)
-        selected_in_workspace = _is_selected_in_workspace(context.display_items[0], window.workspace_controller) if window.workspace_controller and len(context.display_items) > 0 else False
-
-        new_workspace_result = super().execute(context)
-        if new_workspace_result.status != Window.ActionStatus.FINISHED:
-            return new_workspace_result
-
         workspace_controller = window.workspace_controller
-        assert workspace_controller
-        if selected_in_workspace:
-            context.display_panel = context.selected_display_panel
-            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
-            display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
-            workspace_items = list(context.display_items)
-            for index in data_panel._selection.ordered_indexes:
-                workspace_items.append(display_items[index])
-            context = window._get_action_context_for_display_items(workspace_items, context.display_panel)
+        assert workspace_controller is not None
+        selection = self._get_selected(context)
+        split = SplitFromSelectionAction.get_split(len(selection))
+        command = Workspace.NewWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
+        command.perform()
+        window.push_undo_command(command)
 
-        # Since the only display panel will be the selected one, display_panels can just be a list with that inside
-        # apply_layouts mutates the workspace_controller.display_panels so using it will cause recursion
-        # The context.display_panels is no longer valid due to the creation of a new workspace
-        assert workspace_controller.document_controller.selected_display_panel
-        context.selected_display_panel = workspace_controller.document_controller.selected_display_panel
-        context.display_panels = [context.selected_display_panel]
-
-        window.perform_action_in_context("workspace.split_from_selection", context)
-        return new_workspace_result
+        return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
         context = typing.cast(DocumentController.ActionContext, context)
-        return bool(context.focus_widget) and bool(context.display_items) and len(context.display_items) < 101
+        selection = self._get_selected(context)
+        return bool(context.focus_widget) and bool(selection) and len(selection) < 101
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
-        window = typing.cast(DocumentController, context.window)
-        selected_in_workspace = _is_selected_in_workspace(context.display_items[0], window.workspace_controller) if window.workspace_controller and len(context.display_items) > 0 else False
-        data_item = context.data_item
-        display_item = context.display_item
-        item_count = len(context.display_items)
-        if selected_in_workspace:
-            data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
-            item_count += len(data_panel._selection.ordered_indexes)
+        selection = self._get_selected(context)
+        if not bool(context.focus_widget) or not bool(selection) or len(selection) > 100:
+            return self.action_name  # If the action is disabled return the default name
 
+        data_item = selection[0].data_item if selection[0].data_item is not None else None
+        display_item = context.display_item
+        item_count = len(selection)
         if item_count > 1:
             h, w = SplitFromSelectionAction.get_split(item_count)
             return _("New Workspace From Selection") + f" {h}x{w} ({item_count} items)"
         elif data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
             displayed_title = display_item.displayed_title if display_item else data_item.title
-            return _("New Workspace From") + f" \"{displayed_title}\""
+            return _("New Workspace From Item ") + f" \"{displayed_title}\""
         elif display_item:
-            return _("New Workspace From") + f" \"{display_item.displayed_title}\""
+            return _("New Workspace From Item") + f" \"{display_item.displayed_title}\""
         return self.action_name
 
 

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3827,6 +3827,7 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
 class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
     action_id = "workspace.new_workspace_from_selection"
     action_name = _("New Workspace From Selection")
+    max_split = 60
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
         text = self.get_string_property(context, "name")
@@ -3847,7 +3848,8 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         context = typing.cast(DocumentController.ActionContext, context)
         window = typing.cast(DocumentController, context.window)
         selection = window.selected_display_items
-        return bool(context.focus_widget) and bool(selection) and len(selection) < 101
+        # Checking the focus widget ensures there is actually a selection, as selected_display_items can be non-empty even when there is no visible selection
+        return bool(context.focus_widget) and bool(selection) and len(selection) < self.max_split + 1
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
@@ -3856,7 +3858,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         assert workspace_controller is not None
 
         selection = window.selected_display_items
-        if not bool(context.focus_widget) or not bool(selection) or len(selection) > 100:
+        if not bool(context.focus_widget) or not bool(selection) or len(selection) > self.max_split:
             return self.action_name  # If the action is disabled return the default name
 
         data_item = selection[0].data_item if selection[0].data_item is not None else None

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3824,23 +3824,9 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
         return super().execute(context)
 
 
-class NewFromSelectionAction(WorkspaceNewAction):
+class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
     action_id = "workspace.new_workspace_from_selection"
     action_name = _("New Workspace From Selection")
-
-    @staticmethod
-    def _get_selected(context: DocumentController.ActionContext) -> list[DisplayItem.DisplayItem]:
-        """Get the current selection. The order will be selected display panels with items then selected data panel items."""
-        window = typing.cast(DocumentController, context.window)
-        workspace_controller = window.workspace_controller
-        assert workspace_controller is not None
-        selection = [context.selected_display_panel.display_item] if context.selected_display_panel and context.selected_display_panel.display_item else []
-        selection.extend([display_panel.display_item for display_panel in workspace_controller.document_controller.secondary_display_panels if display_panel.display_item is not None])
-        data_panel = typing.cast(DataPanel.DataPanel, window.find_dock_panel("data-panel"))
-        display_items = workspace_controller.document_controller.filtered_display_items_model.display_items
-        for index in data_panel._selection.ordered_indexes:
-            selection.append(display_items[index])
-        return selection
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
         text = self.get_string_property(context, "name")
@@ -3849,7 +3835,7 @@ class NewFromSelectionAction(WorkspaceNewAction):
         window = typing.cast(DocumentController, context.window)
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
-        selection = self._get_selected(context)
+        selection = list(window.selected_display_items)
         split = Workspace.Workspace.get_split_for_selection(len(selection))
         command = Workspace.CreateWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
         command.perform()
@@ -3859,7 +3845,8 @@ class NewFromSelectionAction(WorkspaceNewAction):
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
         context = typing.cast(DocumentController.ActionContext, context)
-        selection = self._get_selected(context)
+        window = typing.cast(DocumentController, context.window)
+        selection = window.selected_display_items
         return bool(context.focus_widget) and bool(selection) and len(selection) < 101
 
     def get_action_name(self, context: Window.ActionContext) -> str:
@@ -3868,7 +3855,7 @@ class NewFromSelectionAction(WorkspaceNewAction):
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
 
-        selection = self._get_selected(context)
+        selection = window.selected_display_items
         if not bool(context.focus_widget) or not bool(selection) or len(selection) > 100:
             return self.action_name  # If the action is disabled return the default name
 
@@ -3903,7 +3890,7 @@ Window.register_action(WorkspaceSplit3x3Action())
 Window.register_action(WorkspaceSplit4x3Action())
 Window.register_action(WorkspaceSplit4x4Action())
 Window.register_action(WorkspaceSplit5x4Action())
-Window.register_action(NewFromSelectionAction())
+Window.register_action(CreateWorkspaceFromSelectionAction())
 
 
 class AddGroupAction(Window.Action):

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3827,7 +3827,7 @@ class WorkspaceSplit5x4Action(WorkspaceSplitAction):
 class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
     action_id = "workspace.new_workspace_from_selection"
     action_name = _("New Workspace From Selection")
-    max_split = 60
+    MAX_PANELS: typing.Final[int] = 60
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
         text = self.get_string_property(context, "name")
@@ -3847,8 +3847,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         context = typing.cast(DocumentController.ActionContext, context)
         window = typing.cast(DocumentController, context.window)
         selection = window.selected_display_items
-        # Checking the focus widget ensures there is actually a selection, as selected_display_items can be non-empty even when there is no visible selection
-        return bool(context.focus_widget) and bool(selection) and len(selection) <= self.max_split
+        return bool(selection) and len(selection) <= self.MAX_PANELS
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
@@ -3856,10 +3855,10 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
 
-        selection = window.selected_display_items
-        if not bool(context.focus_widget) or not bool(selection) or len(selection) > self.max_split:
+        if not self.is_enabled(context):
             return self.action_name  # If the action is disabled return the default name
 
+        selection = window.selected_display_items
         data_item = selection[0].data_item
         display_item = context.display_item
         item_count = len(selection)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3711,7 +3711,9 @@ class WorkspaceSplitAction(Window.Action):
             v = self.get_int_property(context, "vertical_count")
             h = max(1, min(8, h))
             v = max(1, min(8, v))
+            change_workspace_contents_command = Workspace.ChangeWorkspaceContentsCommand(workspace_controller, _("Change Workspace Contents"))
             display_panels = workspace_controller.apply_layouts(selected_display_panel, display_panels, h, v)
+            window.push_undo_command(change_workspace_contents_command)
             action_result = Window.ActionResult(Window.ActionStatus.FINISHED)
             action_result.results["display_panels"] = list(display_panels)
             return action_result

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3841,7 +3841,6 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         command = Workspace.CreateWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
         command.perform()
         window.push_undo_command(command)
-
         return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
@@ -3849,7 +3848,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         window = typing.cast(DocumentController, context.window)
         selection = window.selected_display_items
         # Checking the focus widget ensures there is actually a selection, as selected_display_items can be non-empty even when there is no visible selection
-        return bool(context.focus_widget) and bool(selection) and len(selection) < self.max_split + 1
+        return bool(context.focus_widget) and bool(selection) and len(selection) <= self.max_split
 
     def get_action_name(self, context: Window.ActionContext) -> str:
         context = typing.cast(DocumentController.ActionContext, context)
@@ -3861,7 +3860,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         if not bool(context.focus_widget) or not bool(selection) or len(selection) > self.max_split:
             return self.action_name  # If the action is disabled return the default name
 
-        data_item = selection[0].data_item if selection[0].data_item is not None else None
+        data_item = selection[0].data_item
         display_item = context.display_item
         item_count = len(selection)
         if item_count > 1:
@@ -3869,7 +3868,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
             return _("New Workspace From Selection") + f" {h}x{w} ({item_count} items)"
         elif data_item and len(context.model.get_display_items_for_data_item(data_item)) == 1:
             displayed_title = display_item.displayed_title if display_item else data_item.title
-            return _("New Workspace From Item ") + f" \"{displayed_title}\""
+            return _("New Workspace From Item") + f" \"{displayed_title}\""
         elif display_item:
             return _("New Workspace From Item") + f" \"{display_item.displayed_title}\""
         return self.action_name

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -90,11 +90,12 @@ class CreateWorkspaceFromSelectionCommand(CreateWorkspaceCommand):
         self.__title = "New Workspace From Selection"
         self.__selection = selection
         self.__layout_shape = layout_shape
+        self.__workspace_controller = workspace_controller
 
     def _perform(self) -> None:
         super()._perform()
         horizontal, vertical = self.__layout_shape
-        # The newly created workspace will have one display panel that is the selected one
+        # The newly created workspace will have one display panel which is the selected one
         selected_display_panel = self.__workspace_controller.document_controller.selected_display_panel
         assert selected_display_panel
         # apply_layouts mutates the workspace_controller.display_panels so directly using it would cause recursion

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -101,7 +101,8 @@ class CreateWorkspaceFromSelectionCommand(CreateWorkspaceCommand):
         # apply_layouts mutates the workspace_controller.display_panels so directly using it would cause recursion
         display_panels = [selected_display_panel]
         display_panels = self.__workspace_controller.apply_layouts(selected_display_panel, display_panels, horizontal, vertical)
-        self.__workspace_controller.insert_items_into_panels(self.__selection, display_panels)
+        for display_item, display_panel in zip(self.__selection, display_panels):  # Populate the display panels with the items
+            display_panel.set_display_item(display_item)
 
 
 class RemoveWorkspaceCommand(Undo.UndoableCommand):
@@ -1059,24 +1060,6 @@ class Workspace:
             return columns_floor, rows_floor
 
         return columns_ceil, rows_ceil
-
-    @staticmethod
-    def insert_items_into_panels(display_items: typing.Sequence[DisplayItem.DisplayItem],
-                                 display_panels: typing.Sequence[DisplayPanel.DisplayPanel],
-                                 override_existing_display_item: bool = False) -> None:
-        """Insert the display items into the display panels if they are result panels otherwise skipping them.
-
-        DocumentControllers next_result_display_panel() would give the next display panel in the whole workspace.
-        If override_existing_display_item is False the panels are skipped if they are non-empty.
-        """
-        result_panels = [panel for panel in display_panels if panel.is_result_panel]
-        for display_item in display_items:
-            if not result_panels:
-                return
-            display_panel = result_panels.pop(0)
-            if not override_existing_display_item and display_panel.display_panel_type != "empty":
-                continue
-            display_panel.set_display_item(display_item)
 
 
 class WorkspaceManager(metaclass=Utility.Singleton):

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -72,9 +72,8 @@ class SplitFromSelectionCommand(Undo.UndoableCommand):
     def _perform(self) -> None:
         horizontal, vertical = self.__layout_shape
         if not (horizontal == 1 and vertical == 1):
+            self.__undo_command = ChangeWorkspaceContentsCommand(self.__workspace_controller, _("Change Workspace Contents"))
             display_panels = self.__workspace_controller.apply_layouts(self.__selected_panel, self.__display_panels, horizontal, vertical)
-            self.__undo_command = self.__workspace_controller.document_controller.last_undo_command
-            self.__workspace_controller.document_controller.pop_undo_command()
             # Populate the newly created panels
             # workspace_controller.document_controller.next_result_display_panel() would give the next display panel in the whole workspace
             # instead iterate through the newly created panels and set the display item
@@ -1045,13 +1044,13 @@ class Workspace:
         return old_display_panel, old_splits, region_id
 
     def apply_layouts(self, primary_display_panel: DisplayPanel.DisplayPanel, display_panels: typing.Sequence[DisplayPanel.DisplayPanel], w: int, h: int) -> list[DisplayPanel.DisplayPanel]:
-        """Change the workspace to have w x h display panels.
+        """Split each display panel in display_panels to have w by h display panels.
 
+        The primary_display_panel will have the focus set on completion.
         Returns the newly created display panels in the order they appear in the workspace display panels.
         """
 
         assert self.__workspace
-        change_workspace_contents_command = ChangeWorkspaceContentsCommand(self, _("Change Workspace Contents"))
 
         new_display_panels = list()
 
@@ -1106,8 +1105,6 @@ class Workspace:
         self.__sync_layout()
 
         primary_display_panel.request_focus()
-
-        self.document_controller.push_undo_command(change_workspace_contents_command)
 
         return new_display_panels
 

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import gettext
 import json
+import math
 import random
 import string
 import threading
@@ -93,6 +94,30 @@ class SplitFromSelectionCommand(Undo.UndoableCommand):
     def _redo(self) -> None:
         assert self.__new_layout is not None
         self.__workspace_controller.reconstruct(self.__new_layout)
+
+    @classmethod
+    def get_split(cls, selection_count: int) -> typing.Tuple[int, int]:
+        """Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
+
+        Depending on if the division of columns have ceil or floor applied first will affect the final split.
+        Both are calculated and the one that will have the least unused panels is returned.
+        """
+        ratio = 0.6
+        columns = math.sqrt(selection_count / ratio)
+
+        columns_ceil = math.ceil(columns)
+        rows_ceil = math.ceil(selection_count / columns_ceil)
+
+        columns_floor = math.floor(columns)
+        rows_floor = math.ceil(selection_count / columns_floor)
+
+        ceil_diff = columns_ceil * rows_ceil - selection_count
+        floor_diff = columns_floor * rows_floor - selection_count
+
+        if floor_diff < ceil_diff:
+            return columns_floor, rows_floor
+
+        return columns_ceil, rows_ceil
 
 
 class NewWorkspaceFromSelectionCommand(Undo.UndoableCommand):

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -49,6 +49,105 @@ def create_splitter_desc(orientation: str, splits: typing.Sequence[float], child
     return {"type": "splitter", "orientation": orientation, "splits": list(splits), "children": list(children)}
 
 
+class SplitFromSelectionCommand(Undo.UndoableCommand):
+    def __init__(self, workspace_controller: Workspace, selection: list[DisplayItem.DisplayItem], selected_panel: DisplayPanel.DisplayPanel,
+                 display_panels: list[DisplayPanel.DisplayPanel], layout_shape: tuple[int, int]) -> None:
+        super().__init__("Split From Selection")
+        self.__workspace_controller = workspace_controller
+        self.__selection = selection
+        self.__selected_panel = selected_panel
+        self.__display_panels = display_panels
+        self.__layout_shape = layout_shape
+        self.__undo_command: Undo.UndoableCommand | None = None
+        self.__new_layout: typing.Optional[Persistence.PersistentDictType] = None
+        self.initialize()
+
+    def _get_modified_state(self) -> typing.Any:
+        return self.__workspace_controller._project.modified_state
+
+    def _set_modified_state(self, modified_state: typing.Any) -> None:
+        self.__workspace_controller._project.modified_state = modified_state
+
+    def _perform(self) -> None:
+        horizontal, vertical = self.__layout_shape
+        if not (horizontal == 1 and vertical == 1):
+            display_panels = self.__workspace_controller.apply_layouts(self.__selected_panel, self.__display_panels, horizontal, vertical)
+            self.__undo_command = self.__workspace_controller.document_controller.last_undo_command
+            self.__workspace_controller.document_controller.pop_undo_command()
+            # Populate the newly created panels
+            # workspace_controller.document_controller.next_result_display_panel() would give the next display panel in the whole workspace
+            # instead iterate through the newly created panels and set the display item
+            for display_item in self.__selection:
+                for display_panel in display_panels:
+                    if display_panel.is_result_panel and display_panel.display_panel_type == "empty":
+                        display_panel.set_display_item(display_item)
+                        break
+        else:
+            self.__undo_command = self.__workspace_controller._replace_displayed_display_item(self.__selected_panel, self.__selection[0])
+        self.__new_layout = self.__workspace_controller.deconstruct()
+
+    def _undo(self) -> None:
+        assert self.__undo_command is not None
+        self.__undo_command.undo()
+
+    def _redo(self) -> None:
+        assert self.__new_layout is not None
+        self.__workspace_controller.reconstruct(self.__new_layout)
+
+
+class NewWorkspaceFromSelectionCommand(Undo.UndoableCommand):
+    def __init__(self, workspace_controller: Workspace, name: str,
+                 selection: list[DisplayItem.DisplayItem], layout_shape: tuple[int, int]) -> None:
+        super().__init__("New Workspace From Selection")
+        self.__workspace_controller = workspace_controller
+        self.__workspace_layout_uuid = workspace_controller._workspace.uuid
+        self.__new_name = name
+        self.__new_layout: typing.Optional[Persistence.PersistentDictType] = None
+        self.__new_workspace_id: typing.Optional[str] = None
+        self.__selection = selection
+        self.__layout_shape = layout_shape
+        self.__undo_command: Undo.UndoableCommand | None = None
+
+        self.initialize()
+
+    def _get_modified_state(self) -> typing.Any:
+        return self.__workspace_controller._project.modified_state
+
+    def _set_modified_state(self, modified_state: typing.Any) -> None:
+        self.__workspace_controller._project.modified_state = modified_state
+
+    def _perform(self) -> None:
+        new_workspace = self.__workspace_controller.new_workspace(name=self.__new_name, layout=self.__new_layout, workspace_id=self.__new_workspace_id)
+        self.__workspace_controller._change_workspace(new_workspace)
+
+        selected_display_panel = self.__workspace_controller.document_controller.selected_display_panel
+        # Since the only display panel will be the selected one, display_panels can just be a list with that inside
+        # apply_layouts mutates the workspace_controller.display_panels so using it will cause recursion
+        # The context.display_panels is no longer valid due to the creation of a new workspace
+        assert selected_display_panel
+        display_panels = [selected_display_panel]
+        split_command = SplitFromSelectionCommand(self.__workspace_controller, self.__selection, selected_display_panel, display_panels, self.__layout_shape)
+        split_command.perform()
+        self.__undo_command = split_command
+
+    def _undo(self) -> None:
+        assert self.__undo_command is not None
+        self.__undo_command.undo()
+        new_workspace = self.__workspace_controller._workspace
+        workspace_layout = self.__workspace_controller.get_workspace_layout_by_uuid(self.__workspace_layout_uuid)
+        assert workspace_layout
+        self.__new_layout = self.__workspace_controller._workspace.layout
+        self.__new_workspace_id = self.__workspace_controller._workspace.workspace_id
+        self.__workspace_controller._change_workspace(workspace_layout)
+        self.__workspace_controller._project.remove_item("workspaces", new_workspace)
+
+    def _redo(self) -> None:
+        new_workspace = self.__workspace_controller.new_workspace(name=self.__new_name, layout=self.__new_layout, workspace_id=self.__new_workspace_id)
+        self.__workspace_controller._change_workspace(new_workspace)
+        assert self.__undo_command is not None
+        self.__undo_command.redo()
+
+
 class CreateWorkspaceCommand(Undo.UndoableCommand):
     def __init__(self, workspace_controller: Workspace, name: str) -> None:
         super().__init__("Create Workspace")

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -84,10 +84,10 @@ class CreateWorkspaceCommand(Undo.UndoableCommand):
 
 
 class CreateWorkspaceFromSelectionCommand(CreateWorkspaceCommand):
+    """Create a workspace, then split the panels and insert the selected display items."""
     def __init__(self, workspace_controller: Workspace, name: str,
                  selection: list[DisplayItem.DisplayItem], layout_shape: tuple[int, int]) -> None:
         super().__init__(workspace_controller, name)
-        self.__title = "New Workspace From Selection"
         self.__selection = selection
         self.__layout_shape = layout_shape
         self.__workspace_controller = workspace_controller
@@ -1034,20 +1034,23 @@ class Workspace:
         self.__workspace.layout = self._deconstruct(self.__canvas_item.canvas_items[0])
 
     @staticmethod
-    def get_split_for_selection(selection_count: int) -> typing.Tuple[int, int]:
-        """ Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
+    def get_split_for_selection(selection_count: int) -> tuple[int, int]:
+        """Get a split for the layout that holds the selected items that is approximately a 5:3 ratio.
 
         Depending on if the division of columns have ceil and floor applied first will affect the final split.
         Both are calculated and the one that will have the least unused panels is returned.
         """
+        if selection_count == 0:
+            return 1, 1
+
         ratio = 0.6
         columns = math.sqrt(selection_count / ratio)
 
         columns_ceil = math.ceil(columns)
-        rows_ceil = math.ceil(selection_count / columns_ceil)
+        rows_ceil = math.ceil(selection_count / columns_ceil) if columns_ceil > 0 else 1
 
         columns_floor = math.floor(columns)
-        rows_floor = math.ceil(selection_count / columns_floor)
+        rows_floor = math.ceil(selection_count / columns_floor) if columns_floor > 0 else 1
 
         ceil_diff = columns_ceil * rows_ceil - selection_count
         floor_diff = columns_floor * rows_floor - selection_count
@@ -1058,19 +1061,20 @@ class Workspace:
         return columns_ceil, rows_ceil
 
     @staticmethod
-    def insert_items_into_panels(display_items: list[DisplayItem.DisplayItem],
-                                 display_panels: list[DisplayPanel.DisplayPanel],
-                                 override_existing: bool = False) -> None:
-        """Insert the display items into the display panels.
+    def insert_items_into_panels(display_items: typing.Sequence[DisplayItem.DisplayItem],
+                                 display_panels: typing.Sequence[DisplayPanel.DisplayPanel],
+                                 override_existing_display_item: bool = False) -> None:
+        """Insert the display items into the display panels if they are result panels otherwise skipping them.
 
         DocumentControllers next_result_display_panel() would give the next display panel in the whole workspace.
+        If override_existing_display_item is False the panels are skipped if they are non-empty.
         """
         result_panels = [panel for panel in display_panels if panel.is_result_panel]
         for display_item in display_items:
             if not result_panels:
                 return
             display_panel = result_panels.pop(0)
-            if not override_existing and display_panel.display_panel_type != "empty":
+            if not override_existing_display_item and display_panel.display_panel_type != "empty":
                 continue
             display_panel.set_display_item(display_item)
 

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -50,128 +50,6 @@ def create_splitter_desc(orientation: str, splits: typing.Sequence[float], child
     return {"type": "splitter", "orientation": orientation, "splits": list(splits), "children": list(children)}
 
 
-class SplitFromSelectionCommand(Undo.UndoableCommand):
-    def __init__(self, workspace_controller: Workspace, selection: list[DisplayItem.DisplayItem], selected_panel: DisplayPanel.DisplayPanel,
-                 display_panels: list[DisplayPanel.DisplayPanel], layout_shape: tuple[int, int]) -> None:
-        super().__init__("Split From Selection")
-        self.__workspace_controller = workspace_controller
-        self.__selection = selection
-        self.__selected_panel = selected_panel
-        self.__display_panels = display_panels
-        self.__layout_shape = layout_shape
-        self.__undo_command: Undo.UndoableCommand | None = None
-        self.__new_layout: typing.Optional[Persistence.PersistentDictType] = None
-        self.initialize()
-
-    def _get_modified_state(self) -> typing.Any:
-        return self.__workspace_controller._project.modified_state
-
-    def _set_modified_state(self, modified_state: typing.Any) -> None:
-        self.__workspace_controller._project.modified_state = modified_state
-
-    def _perform(self) -> None:
-        horizontal, vertical = self.__layout_shape
-        if not (horizontal == 1 and vertical == 1):
-            self.__undo_command = ChangeWorkspaceContentsCommand(self.__workspace_controller, _("Change Workspace Contents"))
-            display_panels = self.__workspace_controller.apply_layouts(self.__selected_panel, self.__display_panels, horizontal, vertical)
-            # Populate the newly created panels
-            # workspace_controller.document_controller.next_result_display_panel() would give the next display panel in the whole workspace
-            # instead iterate through the newly created panels and set the display item
-            for display_item in self.__selection:
-                for display_panel in display_panels:
-                    if display_panel.is_result_panel and display_panel.display_panel_type == "empty":
-                        display_panel.set_display_item(display_item)
-                        break
-        else:
-            self.__undo_command = self.__workspace_controller._replace_displayed_display_item(self.__selected_panel, self.__selection[0])
-        self.__new_layout = self.__workspace_controller.deconstruct()
-
-    def _undo(self) -> None:
-        assert self.__undo_command is not None
-        self.__undo_command.undo()
-
-    def _redo(self) -> None:
-        assert self.__new_layout is not None
-        self.__workspace_controller.reconstruct(self.__new_layout)
-
-    @classmethod
-    def get_split(cls, selection_count: int) -> typing.Tuple[int, int]:
-        """Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
-
-        Depending on if the division of columns have ceil or floor applied first will affect the final split.
-        Both are calculated and the one that will have the least unused panels is returned.
-        """
-        ratio = 0.6
-        columns = math.sqrt(selection_count / ratio)
-
-        columns_ceil = math.ceil(columns)
-        rows_ceil = math.ceil(selection_count / columns_ceil)
-
-        columns_floor = math.floor(columns)
-        rows_floor = math.ceil(selection_count / columns_floor)
-
-        ceil_diff = columns_ceil * rows_ceil - selection_count
-        floor_diff = columns_floor * rows_floor - selection_count
-
-        if floor_diff < ceil_diff:
-            return columns_floor, rows_floor
-
-        return columns_ceil, rows_ceil
-
-
-class NewWorkspaceFromSelectionCommand(Undo.UndoableCommand):
-    def __init__(self, workspace_controller: Workspace, name: str,
-                 selection: list[DisplayItem.DisplayItem], layout_shape: tuple[int, int]) -> None:
-        super().__init__("New Workspace From Selection")
-        self.__workspace_controller = workspace_controller
-        self.__workspace_layout_uuid = workspace_controller._workspace.uuid
-        self.__new_name = name
-        self.__new_layout: typing.Optional[Persistence.PersistentDictType] = None
-        self.__new_workspace_id: typing.Optional[str] = None
-        self.__selection = selection
-        self.__layout_shape = layout_shape
-        self.__undo_command: Undo.UndoableCommand | None = None
-
-        self.initialize()
-
-    def _get_modified_state(self) -> typing.Any:
-        return self.__workspace_controller._project.modified_state
-
-    def _set_modified_state(self, modified_state: typing.Any) -> None:
-        self.__workspace_controller._project.modified_state = modified_state
-
-    def _perform(self) -> None:
-        new_workspace = self.__workspace_controller.new_workspace(name=self.__new_name, layout=self.__new_layout, workspace_id=self.__new_workspace_id)
-        self.__workspace_controller._change_workspace(new_workspace)
-
-        selected_display_panel = self.__workspace_controller.document_controller.selected_display_panel
-        # Since the only display panel will be the selected one, display_panels can just be a list with that inside
-        # apply_layouts mutates the workspace_controller.display_panels so using it will cause recursion
-        # The context.display_panels is no longer valid due to the creation of a new workspace
-        assert selected_display_panel
-        display_panels = [selected_display_panel]
-        split_command = SplitFromSelectionCommand(self.__workspace_controller, self.__selection, selected_display_panel, display_panels, self.__layout_shape)
-        split_command.perform()
-        self.__undo_command = split_command
-
-    def _undo(self) -> None:
-        assert self.__undo_command is not None
-        self.__undo_command.undo()
-        new_workspace = self.__workspace_controller._workspace
-        workspace_layout = self.__workspace_controller.get_workspace_layout_by_uuid(self.__workspace_layout_uuid)
-        assert workspace_layout
-        self.__new_layout = self.__workspace_controller._workspace.layout
-        self.__new_workspace_id = self.__workspace_controller._workspace.workspace_id
-        self.__workspace_controller._change_workspace(workspace_layout)
-        self.__workspace_controller._project.remove_item("workspaces", new_workspace)
-
-    def _redo(self) -> None:
-        new_workspace = self.__workspace_controller.new_workspace(name=self.__new_name, layout=self.__new_layout, workspace_id=self.__new_workspace_id)
-        self.__workspace_controller._change_workspace(new_workspace)
-        assert self.__undo_command is not None
-        self.__undo_command.redo()
-
-
 class CreateWorkspaceCommand(Undo.UndoableCommand):
     def __init__(self, workspace_controller: Workspace, name: str) -> None:
         super().__init__("Create Workspace")
@@ -203,6 +81,26 @@ class CreateWorkspaceCommand(Undo.UndoableCommand):
 
     def _redo(self) -> None:
         self.perform()
+
+
+class CreateWorkspaceFromSelectionCommand(CreateWorkspaceCommand):
+    def __init__(self, workspace_controller: Workspace, name: str,
+                 selection: list[DisplayItem.DisplayItem], layout_shape: tuple[int, int]) -> None:
+        super().__init__(workspace_controller, name)
+        self.__title = "New Workspace From Selection"
+        self.__selection = selection
+        self.__layout_shape = layout_shape
+
+    def _perform(self) -> None:
+        super()._perform()
+        horizontal, vertical = self.__layout_shape
+        # The newly created workspace will have one display panel that is the selected one
+        selected_display_panel = self.__workspace_controller.document_controller.selected_display_panel
+        assert selected_display_panel
+        # apply_layouts mutates the workspace_controller.display_panels so directly using it would cause recursion
+        display_panels = [selected_display_panel]
+        display_panels = self.__workspace_controller.apply_layouts(selected_display_panel, display_panels, horizontal, vertical)
+        self.__workspace_controller.insert_items_into_panels(self.__selection, display_panels)
 
 
 class RemoveWorkspaceCommand(Undo.UndoableCommand):
@@ -1133,6 +1031,47 @@ class Workspace:
         # ensure that the layout is written to persistent storage
         assert self.__workspace
         self.__workspace.layout = self._deconstruct(self.__canvas_item.canvas_items[0])
+
+    @staticmethod
+    def get_split_for_selection(selection_count: int) -> typing.Tuple[int, int]:
+        """ Get a split for the layout that holds the selected items that is approximately a 5:3 ratio
+
+        Depending on if the division of columns have ceil and floor applied first will affect the final split.
+        Both are calculated and the one that will have the least unused panels is returned.
+        """
+        ratio = 0.6
+        columns = math.sqrt(selection_count / ratio)
+
+        columns_ceil = math.ceil(columns)
+        rows_ceil = math.ceil(selection_count / columns_ceil)
+
+        columns_floor = math.floor(columns)
+        rows_floor = math.ceil(selection_count / columns_floor)
+
+        ceil_diff = columns_ceil * rows_ceil - selection_count
+        floor_diff = columns_floor * rows_floor - selection_count
+
+        if floor_diff < ceil_diff:
+            return columns_floor, rows_floor
+
+        return columns_ceil, rows_ceil
+
+    @staticmethod
+    def insert_items_into_panels(display_items: list[DisplayItem.DisplayItem],
+                                 display_panels: list[DisplayPanel.DisplayPanel],
+                                 override_existing: bool = False) -> None:
+        """Insert the display items into the display panels.
+
+        DocumentControllers next_result_display_panel() would give the next display panel in the whole workspace.
+        """
+        result_panels = [panel for panel in display_panels if panel.is_result_panel]
+        for display_item in display_items:
+            if not result_panels:
+                return
+            display_panel = result_panels.pop(0)
+            if not override_existing and display_panel.display_panel_type != "empty":
+                continue
+            display_panel.set_display_item(display_item)
 
 
 class WorkspaceManager(metaclass=Utility.Singleton):

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -727,10 +727,6 @@
                 ]
             },
             {
-                "type": "item",
-                "action_id": "workspace.split_from_selection"
-            },
-            {
                 "type": "separator"
             },
             {

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -667,6 +667,10 @@
             },
             {
                 "type": "item",
+                "action_id": "workspace.new_workspace_from_selection"
+            },
+            {
+                "type": "item",
                 "action_id": "workspace.rename"
             },
             {
@@ -721,6 +725,10 @@
                         "action_id": "workspace.split_5x4"
                     }
                 ]
+            },
+            {
+                "type": "item",
+                "action_id": "workspace.split_from_selection"
             },
             {
                 "type": "separator"

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -1418,13 +1418,13 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.assertIsNone(self.document_controller.ui.popup)
         self.display_panel._context_menu_event_for_testing(500, 500)
         # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(21, len(self.document_controller.ui.popup.items))
+        self.assertEqual(23, len(self.document_controller.ui.popup.items))
 
     def test_image_display_panel_produces_context_menu_with_correct_item_count_outside_image_area(self):
         self.assertIsNone(self.document_controller.ui.popup)
         self.display_panel._context_menu_event_for_testing(10, 32)  # header + 10
         # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(21, len(self.document_controller.ui.popup.items))
+        self.assertEqual(23, len(self.document_controller.ui.popup.items))
 
     def test_image_display_panel_with_no_image_produces_context_menu_with_correct_item_count(self):
         self.display_panel.set_display_panel_display_item(None)
@@ -1432,7 +1432,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.refresh_layout_immediate()
         self.display_panel._context_menu_event_for_testing(500, 500)
         # reveal, export, sep, del, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(14, len(self.document_controller.ui.popup.items))
+        self.assertEqual(15, len(self.document_controller.ui.popup.items))
 
     def test_empty_display_panel_produces_context_menu_with_correct_item_count(self):
         d = {"type": "image", "display-panel-type": "empty-display-panel"}
@@ -1441,7 +1441,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.refresh_layout_immediate()
         self.display_panel._context_menu_event_for_testing(500, 500)
         # reveal, export, sep, del, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(14, len(self.document_controller.ui.popup.items))
+        self.assertEqual(15, len(self.document_controller.ui.popup.items))
 
     def test_browser_display_panel_produces_context_menu_with_correct_item_count_over_data_item(self):
         d = {"type": "image", "display-panel-type": "browser-display-panel"}
@@ -1451,7 +1451,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.refresh_layout_immediate()
         self.display_panel._context_menu_event_for_testing(40, 40)
         # show, sep, delete, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(21, len(self.document_controller.ui.popup.items))
+        self.assertEqual(22, len(self.document_controller.ui.popup.items))
 
     def test_browser_display_panel_produces_context_menu_with_correct_item_count_over_area_to_right_of_data_item(self):
         d = {"type": "image", "display-panel-type": "browser-display-panel"}
@@ -1461,7 +1461,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.refresh_layout_immediate()
         self.display_panel._context_menu_event_for_testing(300, 40)
         # reveal, export, sep, del, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(14, len(self.document_controller.ui.popup.items))
+        self.assertEqual(15, len(self.document_controller.ui.popup.items))
 
     def test_browser_display_panel_produces_context_menu_with_correct_item_count_below_last_data_item(self):
         d = {"type": "image", "display-panel-type": "browser-display-panel"}
@@ -1471,7 +1471,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.refresh_layout_immediate()
         self.display_panel._context_menu_event_for_testing(300, 300)
         # reveal, export, sep, del, sep, split h, split v, sep, none, sep, data, thumbnails, browser, sep
-        self.assertEqual(14, len(self.document_controller.ui.popup.items))
+        self.assertEqual(15, len(self.document_controller.ui.popup.items))
 
     def test_browser_context_menu_deletes_all_selected_items(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -7,20 +7,18 @@ import logging
 import pathlib
 import typing
 import unittest
-import urllib
-import uuid
 import weakref
 
 # third party libraries
 import numpy
 
 # local libraries
-from nion.swift import Application, DataPanel
+from nion.swift import DataPanel
 from nion.swift import DisplayPanel
 from nion.swift import DocumentController
 from nion.swift import MimeTypes
 from nion.swift import Workspace
-from nion.swift.model import DataItem, DisplayItem
+from nion.swift.model import DataItem
 from nion.swift.test import DocumentController_test, TestContext
 from nion.ui import CanvasItem
 from nion.ui import Window
@@ -108,12 +106,8 @@ class SplitCase:
                  initial_layout_id: str = "1x1", is_disabled: bool = False) -> None:
         """Contains setup and the expected outcome for a specific split case testing the new workspace from selection functions.
 
-        @param total_data_items: the total number of data items created for a test.
-        @param selected_data_items_indices: indices of selected data panel items, None means no data items are selected.
-        @param initial_layout_id: a string identifier used by get_layout when setting up the initial workspace for a test.
-        @param expected_split_shape: the expected split to be created, (horizontal, vertical), None is used when the test is disabled.
+        initial_layout_id: a string identifier used by get_layout when setting up the initial workspace for a test.
         """
-        self.expected_h, self.expected_w = expected_split_shape if expected_split_shape else (0, 0)
         self.expected_split_shape: tuple[int, int] = expected_split_shape or (0, 0)
         self.selected_data_items_indices: list[int] = selected_data_items_indices or []
         self.initial_layout_id = initial_layout_id
@@ -122,8 +116,10 @@ class SplitCase:
         original_shape = [int(value) for value in initial_shape_chars[:2]]
         assert len(original_shape) == 2
         self.initial_shape = tuple(original_shape)
-        self.total_expected_panels = self.expected_h * self.expected_w
+        expected_h, expected_w = self.expected_split_shape
+        self.total_expected_panels = expected_h * expected_w
         self.is_disabled = is_disabled
+
 
 class TestWorkspaceClass(unittest.TestCase):
 
@@ -1873,7 +1869,7 @@ class TestWorkspaceClass(unittest.TestCase):
         document_controller.workspace_controller.display_panels[0].request_focus()  # This ensures the focus_widget is valid
 
         # Set up the selection
-        selected_data_items = [data_item for data_item in data_items if data_items.index(data_item) in test_case.selected_data_items_indices]
+        selected_data_items = [data_items[i] for i in range(len(data_items)) if i in test_case.selected_data_items_indices]
         document_controller.select_data_items_in_data_panel(selected_data_items)
 
         data_panel = typing.cast(DataPanel.DataPanel, document_controller.find_dock_panel("data-panel"))
@@ -1886,7 +1882,8 @@ class TestWorkspaceClass(unittest.TestCase):
         assert workspace_controller is not None
         self.assertEqual(test_case.total_expected_panels, len(workspace_controller.display_panels))
         for new_display_panel, selected_item in zip(workspace_controller.display_panels, selected_data_items):
-            self.assertEqual(new_display_panel.data_item, selected_item, msg=f"Order mismatch for newly created items {new_display_panel.data_item.title}!={selected_item.title}")
+            title = new_display_panel.data_item.title if new_display_panel.data_item else "None"
+            self.assertEqual(new_display_panel.data_item, selected_item, msg=f"Order mismatch for newly created items {title}!={selected_item.title}")
 
     def run_split_test(self, test_case: SplitCase) -> None:
         """Test a split in test_case against the expected result."""
@@ -1907,11 +1904,11 @@ class TestWorkspaceClass(unittest.TestCase):
 
             self._verify_split_results(document_controller, selected_data_items, test_case)
 
-    def test_new_workspace_disabled_no_item(self):  # No selected data items, no change
+    def test_new_workspace_disabled_no_item(self):  # No selected data items, no expected change
         test_case = SplitCase(selected_data_items_indices=[], total_data_items=0, initial_layout_id="2x1", is_disabled=True)
         self.run_split_test(test_case)
 
-    def test_new_workspace_disabled_too_many_total(self):  # Total selected data items (6 display panel items, 95 data panel items) is too large, no change
+    def test_new_workspace_disabled_too_many_total(self):  # Total selected data items, 61, is too large, no expected change
         item_count = DocumentController.CreateWorkspaceFromSelectionAction.max_split + 1
         test_case = SplitCase(selected_data_items_indices=[x for x in range(0, item_count)], total_data_items=item_count, initial_layout_id="3x2", is_disabled=True)
         self.run_split_test(test_case)

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -8,6 +8,7 @@ import pathlib
 import typing
 import unittest
 import urllib
+import uuid
 import weakref
 
 # third party libraries
@@ -22,6 +23,7 @@ from nion.swift import Workspace
 from nion.swift.model import DataItem
 from nion.swift.test import DocumentController_test, TestContext
 from nion.ui import CanvasItem
+from nion.ui import Window
 from nion.ui import TestUI
 from nion.utils import DateTime
 from nion.utils import Geometry
@@ -1787,6 +1789,237 @@ class TestWorkspaceClass(unittest.TestCase):
             document_controller.handle_redo()
             document_controller.periodic()
             self.assertTrue(document_controller.title.endswith(new_name))
+
+    class SplitLayoutCase:
+        def __init__(self, selected_data_items: list[int], expected_layout_shape: tuple[int, int], selected_workspace_panels: list[int], initial_layout_id: str = "1x1", should_layout_change: bool = True,
+                     workspace_display_panels: list[tuple[int, int]] | None = None) -> None:
+            self.selected_data_items = selected_data_items  # List of indices into the data_items
+            self.initial_workspace_layout = initial_layout_id  # str ID of the initial layout from get_layout
+            self.selected_workspace_panels = selected_workspace_panels  # List indices of the workspace panels that should be selected
+            self.expected_layout_shape = expected_layout_shape
+            self.should_layout_change = should_layout_change
+            self.workspace_display_panels = workspace_display_panels or []  # map the index of display panel to the index of display item, for display panels that have an existing display item
+
+    def _setup_split_tests(self, document_controller: DocumentController.DocumentController, test_case: SplitLayoutCase,
+                           data_items: list[DataItem.DataItem], selected_data_items: list[DataItem.DataItem]) \
+            -> list[DataItem.DataItem]:
+        """Set up the current workspace before preforming the split tests"""
+        document_controller.select_data_items_in_data_panel(selected_data_items)
+        _, layout_d = get_layout(test_case.initial_workspace_layout)
+        new_layout = self._setup_layout_selection(layout_d, test_case.selected_workspace_panels)
+
+        workspace = document_controller.workspace_controller.new_workspace("layout", layout=new_layout)
+
+        workspace_controller = document_controller.workspace_controller
+        workspace_controller.change_workspace(workspace)
+
+        # Setup any display panels that already have a data item
+        for display_panel_index, data_item_index in test_case.workspace_display_panels:
+            data_item = data_items[data_item_index]
+            workspace_controller.display_panels[display_panel_index].set_displayed_data_item(data_item)
+            if display_panel_index in test_case.selected_workspace_panels:
+                selected_data_items.insert(0, data_item)
+
+        return selected_data_items
+
+    def _traverse_layout(self, recursive_dict: dict[str, typing.Any], current_index: int,
+                         image_callback: typing.Callable[[dict[str, typing.Any], int], tuple[dict[str, typing.Any], int]]) \
+            -> tuple[dict[str, typing.Any], int, int, int]:
+        """Post Order traversal of a layout's images, calling image_callback on any images"""
+        horizontal, vertical = 1, 1
+        if recursive_dict.get("children"):
+            children = []
+            for child in recursive_dict["children"]:
+                new_child, current_index, child_h, child_v = self._traverse_layout(child, current_index, image_callback)
+                horizontal = child_h if child_h > 1 else horizontal
+                vertical = child_v if child_v > 1 else vertical
+                children.append(new_child)
+            if len(recursive_dict.get("splits")) > 1:
+                if recursive_dict.get("orientation") == "horizontal":
+                    horizontal = len(recursive_dict.get("splits"))
+                elif recursive_dict.get("orientation") == "vertical":
+                    vertical = len(recursive_dict.get("splits"))
+            recursive_dict["children"] = children
+        elif recursive_dict.get("type") == 'image':
+            recursive_dict, current_index = image_callback(recursive_dict, current_index)
+        return recursive_dict, current_index, horizontal, vertical
+
+    def _setup_layout_selection(self, layout: dict[str, typing.Any], selected_workspace_panels: list[int]) -> dict[str, typing.Any]:
+        """Correctly set the 'selected' attribute for image indexes in the selected_workspace_panels list"""
+        def select_image_callback(image_dict: dict[str, typing.Any], current_index: int) -> tuple[dict[str, typing.Any], int]:
+            if current_index not in selected_workspace_panels:
+                if image_dict.get('selected'):
+                    del image_dict['selected']
+            else:
+                image_dict['selected'] = True
+            current_index += 1
+            return image_dict, current_index
+
+        new_layout, _, _, _ = self._traverse_layout(layout, 0, select_image_callback)
+        return new_layout
+
+    def _layout_to_display_panel_uuids(self, starting_display_panel: DisplayPanel.DisplayPanel | dict[str, typing.Any],
+                                       total_expected_panels: int, workspace_controller: Workspace.Workspace)\
+            -> tuple[list[uuid.UUID], int, int]:
+        """Get the display panel uuids from the layout dictionary in order"""
+        if isinstance(starting_display_panel, DisplayPanel.DisplayPanel):
+            # Get the container of the new display panels
+            starting_container = starting_display_panel.container if total_expected_panels > 1 else starting_display_panel
+            if 1 < total_expected_panels != len(starting_container.canvas_items):
+                starting_container = starting_container.container
+
+            end_layout = workspace_controller._deconstruct(starting_container)
+        else:
+            end_layout = starting_display_panel
+
+        uuids: list[uuid.UUID] = []
+
+        def append_image_uuid_callback(image_dict: dict[str, typing.Any], current_index: int) -> tuple[dict[str, typing.Any], int]:
+            if image_dict.get('display_item_specifier') and image_dict.get('uuid'):  # Empty panels have a UUID but only display items have the specifier
+                uuids.append(uuid.UUID(image_dict.get('uuid')))
+            return image_dict, current_index
+
+        _, _, horizontal, vertical = self._traverse_layout(end_layout, 0, append_image_uuid_callback)
+        return uuids, horizontal, vertical
+
+    def test_workspace_split_from_selection(self):
+        test_cases = [
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], expected_layout_shape=(1, 1), selected_workspace_panels=[0], should_layout_change=False),  # No selected data items, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(0, 102)], expected_layout_shape=(1, 1), selected_workspace_panels=[0], should_layout_change=False),  # Too many selected items, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), selected_workspace_panels=[], should_layout_change=False),  # No selected panels, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), initial_layout_id="2x1", selected_workspace_panels=[0, 1], should_layout_change=False),  # Too many selected workspace panels so no change
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), selected_workspace_panels=[0]),  # 1 panel, 1 data item, result is the selected panel gets a data item inserted
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1], expected_layout_shape=(2, 1), selected_workspace_panels=[0]),  # 1 panel, 2 data items, the result is the panel is split down the middle
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4, 5], expected_layout_shape=(3, 2), selected_workspace_panels=[0]),  # 1 panel, 6 data items split will result with 3x2
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], expected_layout_shape=(3, 2), selected_workspace_panels=[0]),  # 1 panel, 5 data items split will be 3x2 with one empty
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="2x1", selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels right selected, 5 data items split will be 3x2 with one empty
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="1x2", selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels bottom selected, 5 data items split will be 3x2 with one empty
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], workspace_display_panels=[(0, 0)], selected_workspace_panels=[0], expected_layout_shape=(3, 2)),  # 1 panel with an existing data item, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], initial_layout_id="2x1", workspace_display_panels=[(1, 0)], selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels, second with an existing data item and selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], initial_layout_id="2x1", workspace_display_panels=[(0, 5), (1, 7)], selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panel with an existing data item only second selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+        ]
+
+        data_items = []
+        for i in range(102):
+            data_item = DataItem.DataItem(numpy.zeros((1, 1)))
+            data_item.title = f"#{i}"  # Title is useful for debugging failures
+            data_items.append(data_item)
+
+        with (TestContext.create_memory_context() as test_context):
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            for data_item in reversed(data_items):  # Items are ordered by last added, reversing the list means #0 will be last
+                document_model.append_data_item(data_item)
+
+            for index, test_case in enumerate(test_cases):
+                with self.subTest(f"test case #{index}: {test_case}"):
+                    # select_data_items_in_data_panel needs the input list reversed, otherwise the selection become #0, #2, #1 instead of #2, #1, #0
+                    selected_data_items = [data_items[i] for i in reversed(test_case.selected_data_items)]
+                    expected_w, expected_h = test_case.expected_layout_shape
+                    total_expected_panels = expected_w * expected_h  # Only the total is checked
+
+                    selected_data_items = self._setup_split_tests(document_controller, test_case, data_items, selected_data_items)
+
+                    workspace_controller = document_controller.workspace_controller
+                    starting_display_panels = workspace_controller.display_panels
+
+                    document_controller.perform_action("workspace.split_from_selection")
+
+                    if not test_case.should_layout_change:  # Layout expected to be unchanged
+                        self.assertEqual(starting_display_panels, workspace_controller.display_panels)
+                        continue
+
+                    assert len(test_case.selected_workspace_panels) == 1
+                    # Find the start and end indices of the new panels
+                    selected_display_panel_index = test_case.selected_workspace_panels[0]
+                    starting_index = workspace_controller.display_panels.index(starting_display_panels[selected_display_panel_index])
+                    end_index = workspace_controller.display_panels.index(starting_display_panels[selected_display_panel_index + 1]) if len(starting_display_panels) < selected_display_panel_index + 1 else len(workspace_controller.display_panels)
+
+                    new_display_panels = list(workspace_controller.display_panels[starting_index:end_index])
+                    self.assertEqual(len(new_display_panels), total_expected_panels)
+
+                    # Get the display panel uuids from the layout of the new panels
+                    image_uuids, new_horizontal, new_vertical = self._layout_to_display_panel_uuids(starting_display_panels[selected_display_panel_index], total_expected_panels, workspace_controller)
+                    self.assertTrue(new_horizontal == expected_h and new_vertical == expected_w, msg=f"Incorrect Layout shape got h {new_horizontal} expected {expected_h}, got v {new_vertical} expected {expected_w}")
+                    self.assertEqual(len(image_uuids), len(selected_data_items))
+                    # The order of the data panel items should be the same as the selection order
+                    for image_uuid in image_uuids:
+                        image_display_panel = workspace_controller.get_display_panel_by_uuid(image_uuid)
+                        self.assertIsNotNone(image_display_panel, msg=f"Display Panel {image_uuid} was not in the workspace display panels")
+                        current_data_item = selected_data_items.pop(0)
+                        self.assertEqual(image_display_panel.data_item, current_data_item, msg=f"not equal {image_display_panel.data_item.title}!={current_data_item.title}")
+
+    def test_new_workspace_from_selection(self):
+        test_cases = [
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[], should_layout_change=False),  # No selected data items, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[0, 1], should_layout_change=False),  # No data items in selected panels, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(0, 102)], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[], should_layout_change=False),  # Too many selected items, no change
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(6, 102)], initial_layout_id="3x2", expected_layout_shape=(3, 2), selected_workspace_panels=[i for i in range(0, 6)], workspace_display_panels=[(i, i) for i in range(0, 6)], should_layout_change=False),  # Total selected data items (6 display panel items, 95 data panel items) is too large, no change
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], initial_layout_id="2x1", expected_layout_shape=(1, 1), selected_workspace_panels=[]),  # 1 data item selected becomes a workspace with that item
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="2x1", expected_layout_shape=(3, 2), selected_workspace_panels=[]),  # 5 data items selected becomes a workspace split 3x2
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(1, 1), selected_workspace_panels=[0], workspace_display_panels=[(0, 0)]),  # 1 data panel item selected becomes a workspace with that item
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="3x2", expected_layout_shape=(3, 2), selected_workspace_panels=[0, 1, 2, 3, 4], workspace_display_panels=[(i, i) for i in range(0, 5)]),  # 5 data panel items selected becomes a workspace split 3x2
+
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], initial_layout_id="3x2", expected_layout_shape=(2, 1), selected_workspace_panels=[0], workspace_display_panels=[(0, 1)]),  # 1 data panel item and 1 display panel item selected becomes a workspace split 2x1
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1], initial_layout_id="3x1", expected_layout_shape=(3, 2), selected_workspace_panels=[i for i in range(0, 3)], workspace_display_panels=[(i - 2, i) for i in range(2, 5)]),  # 2 data panel items and 3 display panel items selected becomes a workspace split 3x2
+            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[4, 5, 6, 7], initial_layout_id="3x2", expected_layout_shape=(4, 2), selected_workspace_panels=[0, 1, 2, 3, 4, 5], workspace_display_panels=[(i, i) for i in range(0, 4)]),  # 4 data panel items and 4 display panel items selected becomes a workspace split 4x2, the empty display panels that are selected are not used
+        ]
+
+        data_items = []
+        for i in range(102):
+            data_item = DataItem.DataItem(numpy.zeros((1, 1)))
+            data_item.title = f"#{i}"  # Title is useful for debugging failures
+            data_items.append(data_item)
+
+        with (TestContext.create_memory_context() as test_context):
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            for data_item in reversed(data_items):  # Items are ordered by last added, reversing the list means #0 will be last
+                document_model.append_data_item(data_item)
+
+            for index, test_case in enumerate(test_cases):
+                with self.subTest(f"test case #{index}: {test_case}"):
+                    # select_data_items_in_data_panel needs the input list reversed, otherwise the selection become #0, #2, #1 instead of #2, #1, #0
+                    selected_data_items = [data_items[i] for i in reversed(test_case.selected_data_items)]
+                    expected_w, expected_h = test_case.expected_layout_shape
+                    total_expected_panels = expected_w * expected_h  # Only the total is checked
+
+                    selected_data_items = self._setup_split_tests(document_controller, test_case, data_items, selected_data_items)
+
+                    starting_display_panels = document_controller.workspace_controller.display_panels
+                    document_controller.workspace_controller.select_sibling_display_panels([starting_display_panels[i] for i in reversed(test_case.selected_workspace_panels) if starting_display_panels[i] != document_controller.selected_display_panel])
+
+                    # Execute the action from the test since invoke would bring up a text input dialog for the name
+                    new_workspace_action = Window.actions["workspace.new_workspace_from_selection"]
+                    action_context = document_controller._get_action_context()
+                    new_workspace_action.set_string_property(action_context, "name", "New Workspace")
+                    if new_workspace_action.is_enabled(action_context):
+                        _ = new_workspace_action.execute(action_context)
+
+                    workspace_controller = document_controller.workspace_controller
+
+                    if not test_case.should_layout_change:  # Layout expected to be unchanged
+                        self.assertEqual(starting_display_panels, workspace_controller.display_panels)
+                        continue
+
+                    self.assertEqual(len(workspace_controller.display_panels), total_expected_panels)
+
+                    # Get the display panel uuids from the layout of the new workspace panels
+                    layout_d = workspace_controller.deconstruct()
+                    image_uuids, new_horizontal, new_vertical = self._layout_to_display_panel_uuids(layout_d, total_expected_panels, workspace_controller)
+                    self.assertTrue(new_horizontal == expected_h and new_vertical == expected_w, msg=f"Incorrect Layout shape got h {new_horizontal} expected {expected_h}, got v {new_vertical} expected {expected_w}")
+                    self.assertEqual(len(image_uuids), len(selected_data_items))
+                    # The order of the data panel items should be the same as the selection order
+                    for image_uuid in image_uuids:
+                        image_display_panel = workspace_controller.get_display_panel_by_uuid(image_uuid)
+                        self.assertIsNotNone(image_display_panel, msg=f"Display Panel {image_uuid} was not in the workspace display panels")
+                        current_data_item = selected_data_items.pop(0)
+                        self.assertEqual(image_display_panel.data_item, current_data_item, msg=f"not equal {image_display_panel.data_item.title}!={current_data_item.title}")
 
     # def test_display_panel_controller_initially_displays_existing_data(self):
     #     # cannot implement until common code for display controllers is moved into document model

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1873,7 +1873,7 @@ class TestWorkspaceClass(unittest.TestCase):
         document_controller.select_data_items_in_data_panel(selected_data_items)
 
         data_panel = typing.cast(DataPanel.DataPanel, document_controller.find_dock_panel("data-panel"))
-        data_panel._request_focus_for_test()  # This ensures the focus widget is set for the data panel, which is required for the action to run
+        data_panel._request_focus_for_test()  # This ensures the focus widget is set for the data panel
         return document_controller, selected_data_items
 
     def _verify_split_results(self, document_controller: DocumentController.DocumentController, selected_data_items: list[DataItem.DataItem], test_case: SplitCase) -> None:
@@ -1909,7 +1909,7 @@ class TestWorkspaceClass(unittest.TestCase):
         self.run_split_test(test_case)
 
     def test_new_workspace_disabled_too_many_total(self):  # Total selected data items, 61, is too large, no expected change
-        item_count = DocumentController.CreateWorkspaceFromSelectionAction.max_split + 1
+        item_count = DocumentController.CreateWorkspaceFromSelectionAction.MAX_PANELS + 1
         test_case = SplitCase(selected_data_items_indices=[x for x in range(0, item_count)], total_data_items=item_count, initial_layout_id="3x2", is_disabled=True)
         self.run_split_test(test_case)
 

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1941,18 +1941,6 @@ class TestWorkspaceClass(unittest.TestCase):
     def copy_display_panel_uuids(self, display_panels: typing.Sequence[DisplayPanel.DisplayPanel]) -> list[tuple[uuid.UUID, uuid.UUID | None]]:
         return [(display_panel.uuid, display_panel.data_item.uuid if display_panel.data_item is not None else None) for display_panel in display_panels]
 
-    def run_disabled_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]):
-        """Test there is no change for invalid test cases.
-
-        Setup the selection using the test_case and then run perform_func with the document controller to call the action.
-        """
-        with TestContext.create_memory_context() as test_context:
-            document_controller, _ = self.__setup_split_test(test_context, test_case)
-            workspace_controller = document_controller.workspace_controller
-            starting_display_panels = workspace_controller.display_panels
-            perform_func(document_controller)
-            self.assertEqual(starting_display_panels, workspace_controller.display_panels)
-
     def _verify_split_results(self, document_controller: DocumentController.DocumentController, selected_data_items: list[DataItem.DataItem], test_case: SplitCase, initial_display_panels: list[tuple[uuid.UUID, uuid.UUID | None]]) -> None:
         """Verify the number, shape, and order of the created panels, as well as the undo and redo."""
 
@@ -2022,58 +2010,18 @@ class TestWorkspaceClass(unittest.TestCase):
             perform_func(document_controller)
             self._verify_split_results(document_controller, selected_data_items, test_case, initial_display_panels)
 
-    def perform_split_selection(self, document_controller: DocumentController.DocumentController):
-        """The perform_func to be passed into the run_split_test function for the workspace.split_from_selection tests"""
-        action_context = document_controller._get_action_context()
-        document_controller.perform_action_in_context("workspace.split_from_selection", action_context)
 
-    def test_split_disabled_when_no_data_panel_items_selected(self):
-        test_case = SplitCase(selected_data_items_indices=[], selected_workspace_panels_indices=[0], total_data_items=1)
-        self.run_disabled_split_test(test_case, self.perform_split_selection)
+    def run_disabled_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]):
+        """Test there is no change for invalid test cases.
 
-    def test_split_disabled_when_no_display_panel_selected(self):
-        test_case = SplitCase(selected_data_items_indices=[0], selected_workspace_panels_indices=[], total_data_items=1)
-        self.run_disabled_split_test(test_case, self.perform_split_selection)
-
-    def test_split_disabled_when_too_many_items_selected(self):
-        test_case = SplitCase(selected_data_items_indices=[x for x in range(0, 102)], selected_workspace_panels_indices=[0], total_data_items=102)
-        self.run_disabled_split_test(test_case, self.perform_split_selection)
-
-    def test_split_disabled_when_too_many_display_panels_selected(self):
-        test_case = SplitCase(selected_data_items_indices=[0], selected_workspace_panels_indices=[0, 1], total_data_items=1, initial_layout_id="2x1")
-        self.run_disabled_split_test(test_case, self.perform_split_selection)
-
-    def test_split_inserts_single_item(self):
-        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(1, 1), total_expected_panels=1, selected_data_items_indices=[0], total_data_items=1)
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_inserts_two_items(self):
-        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(2, 1), total_expected_panels=2, selected_data_items_indices=[0, 1], total_data_items=2)
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_inserts_five_items(self):
-        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(3, 2), total_expected_panels=6, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5)
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_with_panel_item(self):  # 1 panel with an existing data item, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(3, 2), total_expected_panels=6, selected_data_items_indices=[1, 2, 3, 4], total_data_items=5, workspace_data_items_indices=[(0, 0)])
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_with_right_selected(self):  # 2 panels right selected, 5 data items split will be 3x2 with one empty
-        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5, initial_layout_id="2x1")
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_with_bottom_selected(self):   # 2 panels bottom selected, 5 data items split will be 3x2 with one empty
-        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5, initial_layout_id="2x1")
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_with_existing_item(self):  # 2 panels, second with an existing data item and selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[1, 2, 3, 4], total_data_items=5, workspace_data_items_indices=[(1, 0)], initial_layout_id="2x1")
-        self.run_split_test(test_case, self.perform_split_selection)
-
-    def test_split_with_existing_items(self):  # 2 panels with an existing data items, only second selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[1, 2, 3, 4], total_data_items=6, workspace_data_items_indices=[(0, 5), (1, 0)], initial_layout_id="2x1")
-        self.run_split_test(test_case, self.perform_split_selection)
+        Setup the selection using the test_case and then run perform_func with the document controller to call the action.
+        """
+        with TestContext.create_memory_context() as test_context:
+            document_controller, _ = self.__setup_split_test(test_context, test_case)
+            workspace_controller = document_controller.workspace_controller
+            starting_display_panels = workspace_controller.display_panels
+            perform_func(document_controller)
+            self.assertEqual(starting_display_panels, workspace_controller.display_panels)
 
     def perform_new_workspace_from_selection(self, document_controller: DocumentController.DocumentController) -> None:
         """The perform_func to be passed into the run_split_test function for the workspace.new_workspace_from_selection tests.

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -15,7 +15,7 @@ import weakref
 import numpy
 
 # local libraries
-from nion.swift import Application
+from nion.swift import Application, DataPanel
 from nion.swift import DisplayPanel
 from nion.swift import DocumentController
 from nion.swift import MimeTypes
@@ -103,37 +103,27 @@ class MimeData:
 
 
 class SplitCase:
-    def __init__(self, selected_workspace_panels_indices: int | list[int], total_data_items: int, selected_data_items_indices: list[int] | None = None,
-                 expected_split_shape: tuple[int, int] | None = None, total_expected_panels: int = 0,
-                 workspace_data_items_indices: list[tuple[int, int]] | None = None, initial_layout_id: str = "1x1") \
-            -> None:
-        """Contains setup and the expected outcome for a specific split case testing the new workspace and split from selection functions.
+    def __init__(self, total_data_items: int, selected_data_items_indices: list[int] | None = None,
+                 expected_split_shape: tuple[int, int] | None = None,
+                 initial_layout_id: str = "1x1", is_disabled: bool = False) -> None:
+        """Contains setup and the expected outcome for a specific split case testing the new workspace from selection functions.
 
-        @param selected_workspace_panels_indices: either a single index or list of indices of the selected workspace panels used to set up a test.
         @param total_data_items: the total number of data items created for a test.
         @param selected_data_items_indices: indices of selected data panel items, None means no data items are selected.
-        @param workspace_data_items_indices: data panels with data items used to set up the test, where the tuples are (index of display panel, index of data item in panel), None is when there are no data panels with items.
         @param initial_layout_id: a string identifier used by get_layout when setting up the initial workspace for a test.
         @param expected_split_shape: the expected split to be created, (horizontal, vertical), None is used when the test is disabled.
-        @param total_expected_panels: the total number of panels expected in the workspace after a split.
         """
-        self.selected_workspace_panels_indices = selected_workspace_panels_indices if isinstance(selected_workspace_panels_indices, list) else [selected_workspace_panels_indices]
         self.expected_h, self.expected_w = expected_split_shape if expected_split_shape else (0, 0)
         self.expected_split_shape: tuple[int, int] = expected_split_shape or (0, 0)
-        self.total_expected_panels = total_expected_panels
         self.selected_data_items_indices: list[int] = selected_data_items_indices or []
-        self.workspace_display_data_items_indices: list[tuple[int, int]] = workspace_data_items_indices or []
         self.initial_layout_id = initial_layout_id
         self.total_data_items = total_data_items
-        if isinstance(selected_workspace_panels_indices, list):
-            self.selected_panel_index = selected_workspace_panels_indices[0] if len(selected_workspace_panels_indices) > 0 else -1
-        else:
-            self.selected_panel_index = selected_workspace_panels_indices
         initial_shape_chars = initial_layout_id.split("x")
         original_shape = [int(value) for value in initial_shape_chars[:2]]
         assert len(original_shape) == 2
         self.initial_shape = tuple(original_shape)
-
+        self.total_expected_panels = self.expected_h * self.expected_w
+        self.is_disabled = is_disabled
 
 class TestWorkspaceClass(unittest.TestCase):
 
@@ -1856,224 +1846,83 @@ class TestWorkspaceClass(unittest.TestCase):
                     for returned_panel, layout_panel in zip(returned_display_panels, workspace_controller.display_panels):
                         self.assertEqual(returned_panel, layout_panel)
 
-    def __setup_split_test(self, test_context: TestContext.MemoryProfileContext, test_case: SplitCase) \
+    @staticmethod
+    def __setup_split_test(test_context: TestContext.MemoryProfileContext, test_case: SplitCase) \
             -> tuple[DocumentController.DocumentController, list[DataItem.DataItem]]:
-        """Use the test_case to set up the initial environment for a split test, returning the document controller and the ordered list of selected data items."""
-
-        def __setup_test_data_items(data_item_count: int) -> list[DataItem.DataItem]:
-            """Create the data items for a test and add them to the document model.
-
-            Returns the data items.
-            """
-            data_items: list[DataItem.DataItem] = []
-            for i in range(data_item_count - 1, -1, -1):  # Items are ordered by last created, so item #0 needs to be created last
-                data_item = DataItem.DataItem(numpy.zeros((1, 1)))
-                data_item.title = f"#{i}"  # Title is useful for debugging failures
-                data_items.insert(0, data_item)
-
-            for data_item in data_items:
-                document_controller.document_model.append_data_item(data_item)
-
-            return data_items
-
-        def __setup_data_panel_selection(selected_data_items_indices, data_items) -> list[DataItem.DataItem]:
-            """Set up the selection of items in the data panel returning the ordered selection of items"""
-            selected_data_items = []
-            for index, data_item in enumerate(data_items):
-                if index in selected_data_items_indices:
-                    selected_data_items.append(data_item)
-            document_controller.select_data_items_in_data_panel(selected_data_items)
-            return selected_data_items
-
-        def __setup_initial_workspace(initial_workspace_layout, selected_workspace_panels_indices) \
-                -> None:
-            """Set up the workspace before preforming the split tests.
-
-            After the workspace is created the display panels are iterated through and set as selected based on if it appears in the selected_workspace_panels_indices.
-            The document controller's selected display panel is set along with any secondary display panels in the selection.
-            """
-            _, layout_d = get_layout(initial_workspace_layout)
-
-            workspace = document_controller.workspace_controller.new_workspace("layout", layout=layout_d)
-
-            workspace_controller = document_controller.workspace_controller
-            workspace_controller.change_workspace(workspace)
-
-            selected_display_panels = []
-            for index, display_panel in enumerate(workspace_controller.display_panels):
-                is_selected = index in selected_workspace_panels_indices
-                display_panel.set_selected(is_selected)
-                if is_selected:
-                    selected_display_panels.append(display_panel)
-                    if len(selected_display_panels) == 1:  # Only set the selected_display_panel for the first one, any others will be secondary.
-                        document_controller.selected_display_panel = display_panel
-                        document_controller.selected_display_panel.request_focus()  # This ensures the focus_widget is valid
-
-            document_controller.clear_secondary_display_panels()
-            for display_panel in selected_display_panels:
-                if display_panel != document_controller.selected_display_panel:
-                    document_controller.add_secondary_display_panel(display_panel)
-
-        def __setup_display_panels(workspace_data_display_panels_indices,
-                                   selected_workspace_panels_indices, selected_data_items, data_items) \
-                -> list[DataItem.DataItem]:
-            """Set the data items of display panels that are meant to have one, adding any that are selected to the ordered selected data item list which is then returned.
-
-            The selected display panels with items are expected to come in order before any data panel items.
-            """
-            selected_display_panels_data_items = []
-            for display_panel_index, data_item_index in workspace_data_display_panels_indices:
-                data_item = data_items[data_item_index]
-                document_controller.workspace_controller.display_panels[display_panel_index].set_displayed_data_item(data_item)
-                if display_panel_index in selected_workspace_panels_indices:
-                    selected_display_panels_data_items.append(data_item)
-
-            selected_display_panels_data_items.extend(selected_data_items)  # The selections data panel items come after any selected display panel data items
-            return selected_display_panels_data_items
-
+        """Use the test_case to set up the initial environment for a split test, returning the document controller and the selected data items."""
         document_controller = test_context.create_document_controller()
-        all_data_items = __setup_test_data_items(test_case.total_data_items)
-        ordered_selected_data_items = __setup_data_panel_selection(test_case.selected_data_items_indices, all_data_items)
-        __setup_initial_workspace(test_case.initial_layout_id, test_case.selected_workspace_panels_indices)
-        ordered_selected_data_items = __setup_display_panels(test_case.workspace_display_data_items_indices, test_case.selected_workspace_panels_indices, ordered_selected_data_items, all_data_items)
-        return document_controller, ordered_selected_data_items
+        workspace_controller = document_controller.workspace_controller
+        assert workspace_controller is not None
 
-    def copy_display_panel_uuids(self, display_panels: typing.Sequence[DisplayPanel.DisplayPanel]) -> list[tuple[uuid.UUID, uuid.UUID | None]]:
-        return [(display_panel.uuid, display_panel.data_item.uuid if display_panel.data_item is not None else None) for display_panel in display_panels]
+        # Create the data items
+        data_items: list[DataItem.DataItem] = []
+        for i in range(test_case.total_data_items - 1, -1, -1):  # Items are ordered by last created, so item #0 needs to be created last
+            data_item = DataItem.DataItem(numpy.zeros((1, 1)))
+            data_item.title = f"#{i}"  # Title is useful for debugging failures
+            data_items.insert(0, data_item)
 
-    def _verify_split_results(self, document_controller: DocumentController.DocumentController, selected_data_items: list[DataItem.DataItem], test_case: SplitCase, initial_display_panels: list[tuple[uuid.UUID, uuid.UUID | None]]) -> None:
-        """Verify the number, shape, and order of the created panels, as well as the undo and redo."""
+        # Add the data items to the document model
+        for data_item in data_items:
+            document_controller.document_model.append_data_item(data_item)
 
-        def _verify_created_panels_order(selected_panel_index: int) -> None:
-            """Assert that the new panels are in the expected order
+        # Set up the initial workspace
+        _, layout_d = get_layout(test_case.initial_layout_id)
 
-            The expected order is passed in the selected_data_items.
-            The new display panels are sliced from the document controller's display panels from the selected_panel_index.
-            """
-            new_panels = document_controller.workspace_controller.display_panels[selected_panel_index:selected_panel_index + len(selected_data_items)]
-            for new_display_panel, selected_item in zip(new_panels, selected_data_items):
-                self.assertEqual(new_display_panel.data_item, selected_item, msg=f"Order mismatch for newly created items {new_display_panel.data_item.title}!={selected_item.title}")
+        workspace = workspace_controller.new_workspace("layout", layout=layout_d)
+        workspace_controller.change_workspace(workspace)
+        document_controller.workspace_controller.display_panels[0].request_focus()  # This ensures the focus_widget is valid
 
-        def _verify_layout_shape(expected_h: int, expected_w: int, parent: CanvasItem.CanvasItemComposition | None = None) -> None:
-            """Assert that the shape of the new panels is the expected (h, w).
+        # Set up the selection
+        selected_data_items = [data_item for data_item in data_items if data_items.index(data_item) in test_case.selected_data_items_indices]
+        document_controller.select_data_items_in_data_panel(selected_data_items)
 
-            The first selected display panel's parent is used to get the number of panels in that row, then checked against the expected horizonal.
-            If there is a vertical split, the parent's parent is used to get the number of panels in the column which is checked against the expected vertical.
-            """
-            if parent is None:
-                parent: CanvasItem.CanvasItemComposition | None = None
-                for display_panel in document_controller.workspace_controller.display_panels:
-                    if display_panel.data_item in selected_data_items:
-                        parent = display_panel.container
-                        break
-            self.assertIsNotNone(parent, msg="No selected items were in the display panels, unable to determine the new panels shape.")
-            if expected_h == expected_w == 1:
-                self.assertEqual(1, parent.canvas_items_count, msg="Parent of the selected item contained more than one child.")
-            else:
-                if expected_w != 1:
-                    self.assertIsNotNone(parent.container, msg="No parent contain, unable to determine vertical split where one was expected.")
-                    self.assertEqual(expected_w, parent.container.canvas_items_count, msg="Incorrect Vertical split.")
+        data_panel = typing.cast(DataPanel.DataPanel, document_controller.find_dock_panel("data-panel"))
+        data_panel._request_focus_for_test()  # This ensures the focus widget is set for the data panel, which is required for the action to run
+        return document_controller, selected_data_items
 
-                self.assertEqual(expected_h, parent.canvas_items_count, msg="Incorrect Horizontal split.")
+    def _verify_split_results(self, document_controller: DocumentController.DocumentController, selected_data_items: list[DataItem.DataItem], test_case: SplitCase) -> None:
+        """Verify the number and order of the created panels."""
+        workspace_controller = document_controller.workspace_controller
+        assert workspace_controller is not None
+        self.assertEqual(test_case.total_expected_panels, len(workspace_controller.display_panels))
+        for new_display_panel, selected_item in zip(workspace_controller.display_panels, selected_data_items):
+            self.assertEqual(new_display_panel.data_item, selected_item, msg=f"Order mismatch for newly created items {new_display_panel.data_item.title}!={selected_item.title}")
 
-        def _verify_undo_redo_works() -> None:
-            workspace_controller = document_controller.workspace_controller
-            document_controller.handle_undo()
-            self.assertEqual(len(initial_display_panels), len(workspace_controller.display_panels))
-
-            for (initial_panel_uuid, initial_display_item_uuid), current_panel in zip(initial_display_panels, workspace_controller.display_panels):
-                self.assertEqual(initial_panel_uuid, current_panel.uuid)
-                if initial_display_item_uuid is not None or current_panel.data_item is not None:
-                    self.assertEqual(initial_display_item_uuid, current_panel.data_item.uuid)
-
-            initial_h, initial_w = test_case.initial_shape
-            _verify_layout_shape(initial_h, initial_w, workspace_controller.display_panels[0].container)
-
-            document_controller.handle_redo()  # now redo
-            _verify_layout_shape(test_case.expected_h, test_case.expected_w)
-            _verify_created_panels_order(test_case.selected_panel_index)
-
-        self.assertEqual(test_case.total_expected_panels, len(document_controller.workspace_controller.display_panels))
-        _verify_layout_shape(test_case.expected_h, test_case.expected_w)
-        _verify_created_panels_order(test_case.selected_panel_index)
-        _verify_undo_redo_works()
-
-    def run_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]) -> None:
-        """Test a split in test_case against the expected result.
-
-        Set up the selection using the test_case and then run perform_func with the document controller to call the action.
-        """
+    def run_split_test(self, test_case: SplitCase) -> None:
+        """Test a split in test_case against the expected result."""
         with TestContext.create_memory_context() as test_context:
             document_controller, selected_data_items = self.__setup_split_test(test_context, test_case)
-            initial_display_panels = self.copy_display_panel_uuids(document_controller.workspace_controller.display_panels)
 
-            perform_func(document_controller)
-            self._verify_split_results(document_controller, selected_data_items, test_case, initial_display_panels)
+            # Since invoke would bring up a UI input dialog for the name, the context needs to be setup with the name already defined
+            action_context = document_controller._get_action_context()
+            new_workspace_action = Window.actions["workspace.new_workspace_from_selection"]
+            new_workspace_action.set_string_property(action_context, "name", "New Workspace")
 
+            if test_case.is_disabled:
+                self.assertFalse(new_workspace_action.is_enabled(action_context))  # Check the action is disabled
+                return
 
-    def run_disabled_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]):
-        """Test there is no change for invalid test cases.
+            if new_workspace_action.is_enabled(action_context):
+                _ = new_workspace_action.execute(action_context)
 
-        Setup the selection using the test_case and then run perform_func with the document controller to call the action.
-        """
-        with TestContext.create_memory_context() as test_context:
-            document_controller, _ = self.__setup_split_test(test_context, test_case)
-            workspace_controller = document_controller.workspace_controller
-            starting_display_panels = workspace_controller.display_panels
-            perform_func(document_controller)
-            self.assertEqual(starting_display_panels, workspace_controller.display_panels)
-
-    def perform_new_workspace_from_selection(self, document_controller: DocumentController.DocumentController) -> None:
-        """The perform_func to be passed into the run_split_test function for the workspace.new_workspace_from_selection tests.
-
-        Since invoke would bring up a text input dialog for the name, the context needs to be setup with the name already defined
-        then execute the action if it is enabled.
-        """
-        action_context = document_controller._get_action_context()
-        new_workspace_action = Window.actions["workspace.new_workspace_from_selection"]
-        new_workspace_action.set_string_property(action_context, "name", "New Workspace")
-        if new_workspace_action.is_enabled(action_context):
-            _ = new_workspace_action.execute(action_context)
+            self._verify_split_results(document_controller, selected_data_items, test_case)
 
     def test_new_workspace_disabled_no_item(self):  # No selected data items, no change
-        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[], total_data_items=0, initial_layout_id="2x1")
-        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_disabled_too_many_items(self):  # Too many selected items, no change
-        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[x for x in range(0, 102)], total_data_items=101, initial_layout_id="2x1")
-        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
+        test_case = SplitCase(selected_data_items_indices=[], total_data_items=0, initial_layout_id="2x1", is_disabled=True)
+        self.run_split_test(test_case)
 
     def test_new_workspace_disabled_too_many_total(self):  # Total selected data items (6 display panel items, 95 data panel items) is too large, no change
-        test_case = SplitCase(selected_workspace_panels_indices=[i for i in range(0, 6)], selected_data_items_indices=[x for x in range(6, 102)], total_data_items=101, initial_layout_id="3x2", workspace_data_items_indices=[(i, i) for i in range(0, 6)])
-        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
+        item_count = DocumentController.CreateWorkspaceFromSelectionAction.max_split + 1
+        test_case = SplitCase(selected_data_items_indices=[x for x in range(0, item_count)], total_data_items=item_count, initial_layout_id="3x2", is_disabled=True)
+        self.run_split_test(test_case)
 
     def test_new_workspace_single_item(self):  # 1 data item selected becomes a workspace with that item
-        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[0], total_expected_panels=1, total_data_items=1, initial_layout_id="2x1", expected_split_shape=(1, 1))
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+        test_case = SplitCase(selected_data_items_indices=[0], total_data_items=1, initial_layout_id="2x1", expected_split_shape=(1, 1))
+        self.run_split_test(test_case)
 
     def test_new_workspace_five_items(self):  # 5 data items selected becomes a workspace split 3x2
-        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[0, 1, 2, 3, 4], total_expected_panels=6, total_data_items=5, initial_layout_id="2x1", expected_split_shape=(3, 2))
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_panel_item(self):  # 1 workspace panel item selected becomes a workspace with that item
-        test_case = SplitCase(selected_workspace_panels_indices=[0], selected_data_items_indices=[], total_expected_panels=1, total_data_items=1, initial_layout_id="2x1", expected_split_shape=(1, 1), workspace_data_items_indices=[(0, 0)])
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_five_panel_items(self):  # 5 data panel items selected becomes a workspace split 3x2
-        test_case = SplitCase(selected_workspace_panels_indices=[0, 1, 2, 3, 4], selected_data_items_indices=[], total_expected_panels=6, total_data_items=5, initial_layout_id="6x1", expected_split_shape=(3, 2), workspace_data_items_indices=[(i, i) for i in range(0, 5)])
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_two_in_mixed_selection(self):  # 1 data panel item and 1 display panel item selected becomes a workspace split 2x1
-        test_case = SplitCase(selected_workspace_panels_indices=[0], selected_data_items_indices=[0], total_expected_panels=2, total_data_items=2, initial_layout_id="6x1", expected_split_shape=(2, 1), workspace_data_items_indices=[(0, 1)])
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_five_in_mixed_selection(self):  # 2 data panel items and 3 display panel items selected becomes a workspace split 3x2
-        test_case = SplitCase(selected_workspace_panels_indices=[i for i in range(0, 3)], selected_data_items_indices=[0, 1], total_expected_panels=6, total_data_items=5, initial_layout_id="3x1", expected_split_shape=(3, 2), workspace_data_items_indices=[(i - 2, i) for i in range(2, 5)])
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
-
-    def test_new_workspace_empty_panels_in_selection(self):  # 4 data panel items and 4 display panel items selected becomes a workspace split 4x2, the empty display panels that are selected are not used
-        test_case = SplitCase(selected_workspace_panels_indices=[0, 1, 2, 3, 4, 5], selected_data_items_indices=[4, 5, 6, 7], total_expected_panels=8, total_data_items=8, initial_layout_id="6x1", expected_split_shape=(4, 2), workspace_data_items_indices=[(i, i) for i in range(0, 4)])
-        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+        test_case = SplitCase(selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5, initial_layout_id="2x1", expected_split_shape=(3, 2))
+        self.run_split_test(test_case)
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -20,7 +20,7 @@ from nion.swift import DisplayPanel
 from nion.swift import DocumentController
 from nion.swift import MimeTypes
 from nion.swift import Workspace
-from nion.swift.model import DataItem
+from nion.swift.model import DataItem, DisplayItem
 from nion.swift.test import DocumentController_test, TestContext
 from nion.ui import CanvasItem
 from nion.ui import Window
@@ -78,6 +78,14 @@ def get_layout(layout_id):
             {"type": "splitter", "orientation": "horizontal", "splits": [0.5, 0.5],
                 "children": [{"type": "image", "uuid": uuid5, "identifier": "e"},
                     {"type": "image", "uuid": uuid6, "identifier": "f"}]}]}
+    elif layout_id == "6x1":
+        d = {"type": "splitter", "orientation": "vertical", "splits": [1.0 / 6 for _ in range(6)],
+             "children": [{"type": "image", "uuid": uuid1, "identifier": "a", "selected": True},
+                          {"type": "image", "uuid": uuid2, "identifier": "b"},
+                          {"type": "image", "uuid": uuid2, "identifier": "c"},
+                          {"type": "image", "uuid": uuid4, "identifier": "d"},
+                          {"type": "image", "uuid": uuid5, "identifier": "e"},
+                          {"type": "image", "uuid": uuid6, "identifier": "f"}]}
     else:  # default 1x1
         layout_id = "1x1"
         d = {"type": "image", "uuid": uuid1, "identifier": "a", "selected": True}
@@ -92,6 +100,39 @@ class MimeData:
         return format_str == self.type
     def data_as_string(self, format_str):
         return self.content
+
+
+class SplitCase:
+    def __init__(self, selected_workspace_panels_indices: int | list[int], total_data_items: int, selected_data_items_indices: list[int] | None = None,
+                 expected_split_shape: tuple[int, int] | None = None, total_expected_panels: int = 0,
+                 workspace_data_items_indices: list[tuple[int, int]] | None = None, initial_layout_id: str = "1x1") \
+            -> None:
+        """Contains setup and the expected outcome for a specific split case testing the new workspace and split from selection functions.
+
+        @param selected_workspace_panels_indices: either a single index or list of indices of the selected workspace panels used to set up a test.
+        @param total_data_items: the total number of data items created for a test.
+        @param selected_data_items_indices: indices of selected data panel items, None means no data items are selected.
+        @param workspace_data_items_indices: data panels with data items used to set up the test, where the tuples are (index of display panel, index of data item in panel), None is when there are no data panels with items.
+        @param initial_layout_id: a string identifier used by get_layout when setting up the initial workspace for a test.
+        @param expected_split_shape: the expected split to be created, (horizontal, vertical), None is used when the test is disabled.
+        @param total_expected_panels: the total number of panels expected in the workspace after a split.
+        """
+        self.selected_workspace_panels_indices = selected_workspace_panels_indices if isinstance(selected_workspace_panels_indices, list) else [selected_workspace_panels_indices]
+        self.expected_h, self.expected_w = expected_split_shape if expected_split_shape else (0, 0)
+        self.expected_split_shape: tuple[int, int] = expected_split_shape or (0, 0)
+        self.total_expected_panels = total_expected_panels
+        self.selected_data_items_indices: list[int] = selected_data_items_indices or []
+        self.workspace_display_data_items_indices: list[tuple[int, int]] = workspace_data_items_indices or []
+        self.initial_layout_id = initial_layout_id
+        self.total_data_items = total_data_items
+        if isinstance(selected_workspace_panels_indices, list):
+            self.selected_panel_index = selected_workspace_panels_indices[0] if len(selected_workspace_panels_indices) > 0 else -1
+        else:
+            self.selected_panel_index = selected_workspace_panels_indices
+        initial_shape_chars = initial_layout_id.split("x")
+        original_shape = [int(value) for value in initial_shape_chars[:2]]
+        assert len(original_shape) == 2
+        self.initial_shape = tuple(original_shape)
 
 
 class TestWorkspaceClass(unittest.TestCase):
@@ -1790,237 +1831,6 @@ class TestWorkspaceClass(unittest.TestCase):
             document_controller.periodic()
             self.assertTrue(document_controller.title.endswith(new_name))
 
-    class SplitLayoutCase:
-        def __init__(self, selected_data_items: list[int], expected_layout_shape: tuple[int, int], selected_workspace_panels: list[int], initial_layout_id: str = "1x1", should_layout_change: bool = True,
-                     workspace_display_panels: list[tuple[int, int]] | None = None) -> None:
-            self.selected_data_items = selected_data_items  # List of indices into the data_items
-            self.initial_workspace_layout = initial_layout_id  # str ID of the initial layout from get_layout
-            self.selected_workspace_panels = selected_workspace_panels  # List indices of the workspace panels that should be selected
-            self.expected_layout_shape = expected_layout_shape
-            self.should_layout_change = should_layout_change
-            self.workspace_display_panels = workspace_display_panels or []  # map the index of display panel to the index of display item, for display panels that have an existing display item
-
-    def _setup_split_tests(self, document_controller: DocumentController.DocumentController, test_case: SplitLayoutCase,
-                           data_items: list[DataItem.DataItem], selected_data_items: list[DataItem.DataItem]) \
-            -> list[DataItem.DataItem]:
-        """Set up the current workspace before preforming the split tests"""
-        document_controller.select_data_items_in_data_panel(selected_data_items)
-        _, layout_d = get_layout(test_case.initial_workspace_layout)
-        new_layout = self._setup_layout_selection(layout_d, test_case.selected_workspace_panels)
-
-        workspace = document_controller.workspace_controller.new_workspace("layout", layout=new_layout)
-
-        workspace_controller = document_controller.workspace_controller
-        workspace_controller.change_workspace(workspace)
-
-        # Setup any display panels that already have a data item
-        for display_panel_index, data_item_index in test_case.workspace_display_panels:
-            data_item = data_items[data_item_index]
-            workspace_controller.display_panels[display_panel_index].set_displayed_data_item(data_item)
-            if display_panel_index in test_case.selected_workspace_panels:
-                selected_data_items.insert(0, data_item)
-
-        return selected_data_items
-
-    def _traverse_layout(self, recursive_dict: dict[str, typing.Any], current_index: int,
-                         image_callback: typing.Callable[[dict[str, typing.Any], int], tuple[dict[str, typing.Any], int]]) \
-            -> tuple[dict[str, typing.Any], int, int, int]:
-        """Post Order traversal of a layout's images, calling image_callback on any images"""
-        horizontal, vertical = 1, 1
-        if recursive_dict.get("children"):
-            children = []
-            for child in recursive_dict["children"]:
-                new_child, current_index, child_h, child_v = self._traverse_layout(child, current_index, image_callback)
-                horizontal = child_h if child_h > 1 else horizontal
-                vertical = child_v if child_v > 1 else vertical
-                children.append(new_child)
-            if len(recursive_dict.get("splits")) > 1:
-                if recursive_dict.get("orientation") == "horizontal":
-                    horizontal = len(recursive_dict.get("splits"))
-                elif recursive_dict.get("orientation") == "vertical":
-                    vertical = len(recursive_dict.get("splits"))
-            recursive_dict["children"] = children
-        elif recursive_dict.get("type") == 'image':
-            recursive_dict, current_index = image_callback(recursive_dict, current_index)
-        return recursive_dict, current_index, horizontal, vertical
-
-    def _setup_layout_selection(self, layout: dict[str, typing.Any], selected_workspace_panels: list[int]) -> dict[str, typing.Any]:
-        """Correctly set the 'selected' attribute for image indexes in the selected_workspace_panels list"""
-        def select_image_callback(image_dict: dict[str, typing.Any], current_index: int) -> tuple[dict[str, typing.Any], int]:
-            if current_index not in selected_workspace_panels:
-                if image_dict.get('selected'):
-                    del image_dict['selected']
-            else:
-                image_dict['selected'] = True
-            current_index += 1
-            return image_dict, current_index
-
-        new_layout, _, _, _ = self._traverse_layout(layout, 0, select_image_callback)
-        return new_layout
-
-    def _layout_to_display_panel_uuids(self, starting_display_panel: DisplayPanel.DisplayPanel | dict[str, typing.Any],
-                                       total_expected_panels: int, workspace_controller: Workspace.Workspace)\
-            -> tuple[list[uuid.UUID], int, int]:
-        """Get the display panel uuids from the layout dictionary in order"""
-        if isinstance(starting_display_panel, DisplayPanel.DisplayPanel):
-            # Get the container of the new display panels
-            starting_container = starting_display_panel.container if total_expected_panels > 1 else starting_display_panel
-            if 1 < total_expected_panels != len(starting_container.canvas_items):
-                starting_container = starting_container.container
-
-            end_layout = workspace_controller._deconstruct(starting_container)
-        else:
-            end_layout = starting_display_panel
-
-        uuids: list[uuid.UUID] = []
-
-        def append_image_uuid_callback(image_dict: dict[str, typing.Any], current_index: int) -> tuple[dict[str, typing.Any], int]:
-            if image_dict.get('display_item_specifier') and image_dict.get('uuid'):  # Empty panels have a UUID but only display items have the specifier
-                uuids.append(uuid.UUID(image_dict.get('uuid')))
-            return image_dict, current_index
-
-        _, _, horizontal, vertical = self._traverse_layout(end_layout, 0, append_image_uuid_callback)
-        return uuids, horizontal, vertical
-
-    def test_workspace_split_from_selection(self):
-        test_cases = [
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], expected_layout_shape=(1, 1), selected_workspace_panels=[0], should_layout_change=False),  # No selected data items, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(0, 102)], expected_layout_shape=(1, 1), selected_workspace_panels=[0], should_layout_change=False),  # Too many selected items, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), selected_workspace_panels=[], should_layout_change=False),  # No selected panels, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), initial_layout_id="2x1", selected_workspace_panels=[0, 1], should_layout_change=False),  # Too many selected workspace panels so no change
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], expected_layout_shape=(1, 1), selected_workspace_panels=[0]),  # 1 panel, 1 data item, result is the selected panel gets a data item inserted
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1], expected_layout_shape=(2, 1), selected_workspace_panels=[0]),  # 1 panel, 2 data items, the result is the panel is split down the middle
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4, 5], expected_layout_shape=(3, 2), selected_workspace_panels=[0]),  # 1 panel, 6 data items split will result with 3x2
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], expected_layout_shape=(3, 2), selected_workspace_panels=[0]),  # 1 panel, 5 data items split will be 3x2 with one empty
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="2x1", selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels right selected, 5 data items split will be 3x2 with one empty
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="1x2", selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels bottom selected, 5 data items split will be 3x2 with one empty
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], workspace_display_panels=[(0, 0)], selected_workspace_panels=[0], expected_layout_shape=(3, 2)),  # 1 panel with an existing data item, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], initial_layout_id="2x1", workspace_display_panels=[(1, 0)], selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panels, second with an existing data item and selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[1, 2, 3, 4], initial_layout_id="2x1", workspace_display_panels=[(0, 5), (1, 7)], selected_workspace_panels=[1], expected_layout_shape=(3, 2)),  # 2 panel with an existing data item only second selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
-        ]
-
-        data_items = []
-        for i in range(102):
-            data_item = DataItem.DataItem(numpy.zeros((1, 1)))
-            data_item.title = f"#{i}"  # Title is useful for debugging failures
-            data_items.append(data_item)
-
-        with (TestContext.create_memory_context() as test_context):
-            document_controller = test_context.create_document_controller()
-            document_model = document_controller.document_model
-            for data_item in reversed(data_items):  # Items are ordered by last added, reversing the list means #0 will be last
-                document_model.append_data_item(data_item)
-
-            for index, test_case in enumerate(test_cases):
-                with self.subTest(f"test case #{index}: {test_case}"):
-                    # select_data_items_in_data_panel needs the input list reversed, otherwise the selection become #0, #2, #1 instead of #2, #1, #0
-                    selected_data_items = [data_items[i] for i in reversed(test_case.selected_data_items)]
-                    expected_w, expected_h = test_case.expected_layout_shape
-                    total_expected_panels = expected_w * expected_h  # Only the total is checked
-
-                    selected_data_items = self._setup_split_tests(document_controller, test_case, data_items, selected_data_items)
-
-                    workspace_controller = document_controller.workspace_controller
-                    starting_display_panels = workspace_controller.display_panels
-
-                    document_controller.perform_action("workspace.split_from_selection")
-
-                    if not test_case.should_layout_change:  # Layout expected to be unchanged
-                        self.assertEqual(starting_display_panels, workspace_controller.display_panels)
-                        continue
-
-                    assert len(test_case.selected_workspace_panels) == 1
-                    # Find the start and end indices of the new panels
-                    selected_display_panel_index = test_case.selected_workspace_panels[0]
-                    starting_index = workspace_controller.display_panels.index(starting_display_panels[selected_display_panel_index])
-                    end_index = workspace_controller.display_panels.index(starting_display_panels[selected_display_panel_index + 1]) if len(starting_display_panels) < selected_display_panel_index + 1 else len(workspace_controller.display_panels)
-
-                    new_display_panels = list(workspace_controller.display_panels[starting_index:end_index])
-                    self.assertEqual(len(new_display_panels), total_expected_panels)
-
-                    # Get the display panel uuids from the layout of the new panels
-                    image_uuids, new_horizontal, new_vertical = self._layout_to_display_panel_uuids(starting_display_panels[selected_display_panel_index], total_expected_panels, workspace_controller)
-                    self.assertTrue(new_horizontal == expected_h and new_vertical == expected_w, msg=f"Incorrect Layout shape got h {new_horizontal} expected {expected_h}, got v {new_vertical} expected {expected_w}")
-                    self.assertEqual(len(image_uuids), len(selected_data_items))
-                    # The order of the data panel items should be the same as the selection order
-                    for image_uuid in image_uuids:
-                        image_display_panel = workspace_controller.get_display_panel_by_uuid(image_uuid)
-                        self.assertIsNotNone(image_display_panel, msg=f"Display Panel {image_uuid} was not in the workspace display panels")
-                        current_data_item = selected_data_items.pop(0)
-                        self.assertEqual(image_display_panel.data_item, current_data_item, msg=f"not equal {image_display_panel.data_item.title}!={current_data_item.title}")
-
-    def test_new_workspace_from_selection(self):
-        test_cases = [
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[], should_layout_change=False),  # No selected data items, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[0, 1], should_layout_change=False),  # No data items in selected panels, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(0, 102)], initial_layout_id="2x1", expected_layout_shape=(2, 1), selected_workspace_panels=[], should_layout_change=False),  # Too many selected items, no change
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[x for x in range(6, 102)], initial_layout_id="3x2", expected_layout_shape=(3, 2), selected_workspace_panels=[i for i in range(0, 6)], workspace_display_panels=[(i, i) for i in range(0, 6)], should_layout_change=False),  # Total selected data items (6 display panel items, 95 data panel items) is too large, no change
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], initial_layout_id="2x1", expected_layout_shape=(1, 1), selected_workspace_panels=[]),  # 1 data item selected becomes a workspace with that item
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1, 2, 3, 4], initial_layout_id="2x1", expected_layout_shape=(3, 2), selected_workspace_panels=[]),  # 5 data items selected becomes a workspace split 3x2
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="2x1", expected_layout_shape=(1, 1), selected_workspace_panels=[0], workspace_display_panels=[(0, 0)]),  # 1 data panel item selected becomes a workspace with that item
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[], initial_layout_id="3x2", expected_layout_shape=(3, 2), selected_workspace_panels=[0, 1, 2, 3, 4], workspace_display_panels=[(i, i) for i in range(0, 5)]),  # 5 data panel items selected becomes a workspace split 3x2
-
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0], initial_layout_id="3x2", expected_layout_shape=(2, 1), selected_workspace_panels=[0], workspace_display_panels=[(0, 1)]),  # 1 data panel item and 1 display panel item selected becomes a workspace split 2x1
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[0, 1], initial_layout_id="3x1", expected_layout_shape=(3, 2), selected_workspace_panels=[i for i in range(0, 3)], workspace_display_panels=[(i - 2, i) for i in range(2, 5)]),  # 2 data panel items and 3 display panel items selected becomes a workspace split 3x2
-            TestWorkspaceClass.SplitLayoutCase(selected_data_items=[4, 5, 6, 7], initial_layout_id="3x2", expected_layout_shape=(4, 2), selected_workspace_panels=[0, 1, 2, 3, 4, 5], workspace_display_panels=[(i, i) for i in range(0, 4)]),  # 4 data panel items and 4 display panel items selected becomes a workspace split 4x2, the empty display panels that are selected are not used
-        ]
-
-        data_items = []
-        for i in range(102):
-            data_item = DataItem.DataItem(numpy.zeros((1, 1)))
-            data_item.title = f"#{i}"  # Title is useful for debugging failures
-            data_items.append(data_item)
-
-        with (TestContext.create_memory_context() as test_context):
-            document_controller = test_context.create_document_controller()
-            document_model = document_controller.document_model
-            for data_item in reversed(data_items):  # Items are ordered by last added, reversing the list means #0 will be last
-                document_model.append_data_item(data_item)
-
-            for index, test_case in enumerate(test_cases):
-                with self.subTest(f"test case #{index}: {test_case}"):
-                    # select_data_items_in_data_panel needs the input list reversed, otherwise the selection become #0, #2, #1 instead of #2, #1, #0
-                    selected_data_items = [data_items[i] for i in reversed(test_case.selected_data_items)]
-                    expected_w, expected_h = test_case.expected_layout_shape
-                    total_expected_panels = expected_w * expected_h  # Only the total is checked
-
-                    selected_data_items = self._setup_split_tests(document_controller, test_case, data_items, selected_data_items)
-
-                    starting_display_panels = document_controller.workspace_controller.display_panels
-                    document_controller.workspace_controller.select_sibling_display_panels([starting_display_panels[i] for i in reversed(test_case.selected_workspace_panels) if starting_display_panels[i] != document_controller.selected_display_panel])
-
-                    # Execute the action from the test since invoke would bring up a text input dialog for the name
-                    new_workspace_action = Window.actions["workspace.new_workspace_from_selection"]
-                    action_context = document_controller._get_action_context()
-                    new_workspace_action.set_string_property(action_context, "name", "New Workspace")
-                    if new_workspace_action.is_enabled(action_context):
-                        _ = new_workspace_action.execute(action_context)
-
-                    workspace_controller = document_controller.workspace_controller
-
-                    if not test_case.should_layout_change:  # Layout expected to be unchanged
-                        self.assertEqual(starting_display_panels, workspace_controller.display_panels)
-                        continue
-
-                    self.assertEqual(len(workspace_controller.display_panels), total_expected_panels)
-
-                    # Get the display panel uuids from the layout of the new workspace panels
-                    layout_d = workspace_controller.deconstruct()
-                    image_uuids, new_horizontal, new_vertical = self._layout_to_display_panel_uuids(layout_d, total_expected_panels, workspace_controller)
-                    self.assertTrue(new_horizontal == expected_h and new_vertical == expected_w, msg=f"Incorrect Layout shape got h {new_horizontal} expected {expected_h}, got v {new_vertical} expected {expected_w}")
-                    self.assertEqual(len(image_uuids), len(selected_data_items))
-                    # The order of the data panel items should be the same as the selection order
-                    for image_uuid in image_uuids:
-                        image_display_panel = workspace_controller.get_display_panel_by_uuid(image_uuid)
-                        self.assertIsNotNone(image_display_panel, msg=f"Display Panel {image_uuid} was not in the workspace display panels")
-                        current_data_item = selected_data_items.pop(0)
-                        self.assertEqual(image_display_panel.data_item, current_data_item, msg=f"not equal {image_display_panel.data_item.title}!={current_data_item.title}")
-
     # def test_display_panel_controller_initially_displays_existing_data(self):
     #     # cannot implement until common code for display controllers is moved into document model
     #     pass
@@ -2045,6 +1855,277 @@ class TestWorkspaceClass(unittest.TestCase):
                     self.assertEqual(len(returned_display_panels), total_new_panels)
                     for returned_panel, layout_panel in zip(returned_display_panels, workspace_controller.display_panels):
                         self.assertEqual(returned_panel, layout_panel)
+
+    def __setup_split_test(self, test_context: TestContext.MemoryProfileContext, test_case: SplitCase) \
+            -> tuple[DocumentController.DocumentController, list[DataItem.DataItem]]:
+        """Use the test_case to set up the initial environment for a split test, returning the document controller and the ordered list of selected data items."""
+
+        def __setup_test_data_items(data_item_count: int) -> list[DataItem.DataItem]:
+            """Create the data items for a test and add them to the document model.
+
+            Returns the data items.
+            """
+            data_items: list[DataItem.DataItem] = []
+            for i in range(data_item_count - 1, -1, -1):  # Items are ordered by last created, so item #0 needs to be created last
+                data_item = DataItem.DataItem(numpy.zeros((1, 1)))
+                data_item.title = f"#{i}"  # Title is useful for debugging failures
+                data_items.insert(0, data_item)
+
+            for data_item in data_items:
+                document_controller.document_model.append_data_item(data_item)
+
+            return data_items
+
+        def __setup_data_panel_selection(selected_data_items_indices, data_items) -> list[DataItem.DataItem]:
+            """Set up the selection of items in the data panel returning the ordered selection of items"""
+            selected_data_items = []
+            for index, data_item in enumerate(data_items):
+                if index in selected_data_items_indices:
+                    selected_data_items.append(data_item)
+            document_controller.select_data_items_in_data_panel(selected_data_items)
+            return selected_data_items
+
+        def __setup_initial_workspace(initial_workspace_layout, selected_workspace_panels_indices) \
+                -> None:
+            """Set up the workspace before preforming the split tests.
+
+            After the workspace is created the display panels are iterated through and set as selected based on if it appears in the selected_workspace_panels_indices.
+            The document controller's selected display panel is set along with any secondary display panels in the selection.
+            """
+            _, layout_d = get_layout(initial_workspace_layout)
+
+            workspace = document_controller.workspace_controller.new_workspace("layout", layout=layout_d)
+
+            workspace_controller = document_controller.workspace_controller
+            workspace_controller.change_workspace(workspace)
+
+            selected_display_panels = []
+            for index, display_panel in enumerate(workspace_controller.display_panels):
+                is_selected = index in selected_workspace_panels_indices
+                display_panel.set_selected(is_selected)
+                if is_selected:
+                    selected_display_panels.append(display_panel)
+                    if len(selected_display_panels) == 1:  # Only set the selected_display_panel for the first one, any others will be secondary.
+                        document_controller.selected_display_panel = display_panel
+                        document_controller.selected_display_panel.request_focus()  # This ensures the focus_widget is valid
+
+            document_controller.clear_secondary_display_panels()
+            for display_panel in selected_display_panels:
+                if display_panel != document_controller.selected_display_panel:
+                    document_controller.add_secondary_display_panel(display_panel)
+
+        def __setup_display_panels(workspace_data_display_panels_indices,
+                                   selected_workspace_panels_indices, selected_data_items, data_items) \
+                -> list[DataItem.DataItem]:
+            """Set the data items of display panels that are meant to have one, adding any that are selected to the ordered selected data item list which is then returned.
+
+            The selected display panels with items are expected to come in order before any data panel items.
+            """
+            selected_display_panels_data_items = []
+            for display_panel_index, data_item_index in workspace_data_display_panels_indices:
+                data_item = data_items[data_item_index]
+                document_controller.workspace_controller.display_panels[display_panel_index].set_displayed_data_item(data_item)
+                if display_panel_index in selected_workspace_panels_indices:
+                    selected_display_panels_data_items.append(data_item)
+
+            selected_display_panels_data_items.extend(selected_data_items)  # The selections data panel items come after any selected display panel data items
+            return selected_display_panels_data_items
+
+        document_controller = test_context.create_document_controller()
+        all_data_items = __setup_test_data_items(test_case.total_data_items)
+        ordered_selected_data_items = __setup_data_panel_selection(test_case.selected_data_items_indices, all_data_items)
+        __setup_initial_workspace(test_case.initial_layout_id, test_case.selected_workspace_panels_indices)
+        ordered_selected_data_items = __setup_display_panels(test_case.workspace_display_data_items_indices, test_case.selected_workspace_panels_indices, ordered_selected_data_items, all_data_items)
+        return document_controller, ordered_selected_data_items
+
+    def copy_display_panel_uuids(self, display_panels: typing.Sequence[DisplayPanel.DisplayPanel]) -> list[tuple[uuid.UUID, uuid.UUID | None]]:
+        return [(display_panel.uuid, display_panel.data_item.uuid if display_panel.data_item is not None else None) for display_panel in display_panels]
+
+    def run_disabled_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]):
+        """Test there is no change for invalid test cases.
+
+        Setup the selection using the test_case and then run perform_func with the document controller to call the action.
+        """
+        with TestContext.create_memory_context() as test_context:
+            document_controller, _ = self.__setup_split_test(test_context, test_case)
+            workspace_controller = document_controller.workspace_controller
+            starting_display_panels = workspace_controller.display_panels
+            perform_func(document_controller)
+            self.assertEqual(starting_display_panels, workspace_controller.display_panels)
+
+    def _verify_split_results(self, document_controller: DocumentController.DocumentController, selected_data_items: list[DataItem.DataItem], test_case: SplitCase, initial_display_panels: list[tuple[uuid.UUID, uuid.UUID | None]]) -> None:
+        """Verify the number, shape, and order of the created panels, as well as the undo and redo."""
+
+        def _verify_created_panels_order(selected_panel_index: int) -> None:
+            """Assert that the new panels are in the expected order
+
+            The expected order is passed in the selected_data_items.
+            The new display panels are sliced from the document controller's display panels from the selected_panel_index.
+            """
+            new_panels = document_controller.workspace_controller.display_panels[selected_panel_index:selected_panel_index + len(selected_data_items)]
+            for new_display_panel, selected_item in zip(new_panels, selected_data_items):
+                self.assertEqual(new_display_panel.data_item, selected_item, msg=f"Order mismatch for newly created items {new_display_panel.data_item.title}!={selected_item.title}")
+
+        def _verify_layout_shape(expected_h: int, expected_w: int, parent: CanvasItem.CanvasItemComposition | None = None) -> None:
+            """Assert that the shape of the new panels is the expected (h, w).
+
+            The first selected display panel's parent is used to get the number of panels in that row, then checked against the expected horizonal.
+            If there is a vertical split, the parent's parent is used to get the number of panels in the column which is checked against the expected vertical.
+            """
+            if parent is None:
+                parent: CanvasItem.CanvasItemComposition | None = None
+                for display_panel in document_controller.workspace_controller.display_panels:
+                    if display_panel.data_item in selected_data_items:
+                        parent = display_panel.container
+                        break
+            self.assertIsNotNone(parent, msg="No selected items were in the display panels, unable to determine the new panels shape.")
+            if expected_h == expected_w == 1:
+                self.assertEqual(1, parent.canvas_items_count, msg="Parent of the selected item contained more than one child.")
+            else:
+                if expected_w != 1:
+                    self.assertIsNotNone(parent.container, msg="No parent contain, unable to determine vertical split where one was expected.")
+                    self.assertEqual(expected_w, parent.container.canvas_items_count, msg="Incorrect Vertical split.")
+
+                self.assertEqual(expected_h, parent.canvas_items_count, msg="Incorrect Horizontal split.")
+
+        def _verify_undo_redo_works() -> None:
+            workspace_controller = document_controller.workspace_controller
+            document_controller.handle_undo()
+            self.assertEqual(len(initial_display_panels), len(workspace_controller.display_panels))
+
+            for (initial_panel_uuid, initial_display_item_uuid), current_panel in zip(initial_display_panels, workspace_controller.display_panels):
+                self.assertEqual(initial_panel_uuid, current_panel.uuid)
+                if initial_display_item_uuid is not None or current_panel.data_item is not None:
+                    self.assertEqual(initial_display_item_uuid, current_panel.data_item.uuid)
+
+            initial_h, initial_w = test_case.initial_shape
+            _verify_layout_shape(initial_h, initial_w, workspace_controller.display_panels[0].container)
+
+            document_controller.handle_redo()  # now redo
+            _verify_layout_shape(test_case.expected_h, test_case.expected_w)
+            _verify_created_panels_order(test_case.selected_panel_index)
+
+        self.assertEqual(test_case.total_expected_panels, len(document_controller.workspace_controller.display_panels))
+        _verify_layout_shape(test_case.expected_h, test_case.expected_w)
+        _verify_created_panels_order(test_case.selected_panel_index)
+        _verify_undo_redo_works()
+
+    def run_split_test(self, test_case: SplitCase, perform_func: typing.Callable[[DocumentController.DocumentController], None]) -> None:
+        """Test a split in test_case against the expected result.
+
+        Set up the selection using the test_case and then run perform_func with the document controller to call the action.
+        """
+        with TestContext.create_memory_context() as test_context:
+            document_controller, selected_data_items = self.__setup_split_test(test_context, test_case)
+            initial_display_panels = self.copy_display_panel_uuids(document_controller.workspace_controller.display_panels)
+
+            perform_func(document_controller)
+            self._verify_split_results(document_controller, selected_data_items, test_case, initial_display_panels)
+
+    def perform_split_selection(self, document_controller: DocumentController.DocumentController):
+        """The perform_func to be passed into the run_split_test function for the workspace.split_from_selection tests"""
+        action_context = document_controller._get_action_context()
+        document_controller.perform_action_in_context("workspace.split_from_selection", action_context)
+
+    def test_split_disabled_when_no_data_panel_items_selected(self):
+        test_case = SplitCase(selected_data_items_indices=[], selected_workspace_panels_indices=[0], total_data_items=1)
+        self.run_disabled_split_test(test_case, self.perform_split_selection)
+
+    def test_split_disabled_when_no_display_panel_selected(self):
+        test_case = SplitCase(selected_data_items_indices=[0], selected_workspace_panels_indices=[], total_data_items=1)
+        self.run_disabled_split_test(test_case, self.perform_split_selection)
+
+    def test_split_disabled_when_too_many_items_selected(self):
+        test_case = SplitCase(selected_data_items_indices=[x for x in range(0, 102)], selected_workspace_panels_indices=[0], total_data_items=102)
+        self.run_disabled_split_test(test_case, self.perform_split_selection)
+
+    def test_split_disabled_when_too_many_display_panels_selected(self):
+        test_case = SplitCase(selected_data_items_indices=[0], selected_workspace_panels_indices=[0, 1], total_data_items=1, initial_layout_id="2x1")
+        self.run_disabled_split_test(test_case, self.perform_split_selection)
+
+    def test_split_inserts_single_item(self):
+        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(1, 1), total_expected_panels=1, selected_data_items_indices=[0], total_data_items=1)
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_inserts_two_items(self):
+        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(2, 1), total_expected_panels=2, selected_data_items_indices=[0, 1], total_data_items=2)
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_inserts_five_items(self):
+        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(3, 2), total_expected_panels=6, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5)
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_with_panel_item(self):  # 1 panel with an existing data item, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+        test_case = SplitCase(selected_workspace_panels_indices=0, expected_split_shape=(3, 2), total_expected_panels=6, selected_data_items_indices=[1, 2, 3, 4], total_data_items=5, workspace_data_items_indices=[(0, 0)])
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_with_right_selected(self):  # 2 panels right selected, 5 data items split will be 3x2 with one empty
+        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5, initial_layout_id="2x1")
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_with_bottom_selected(self):   # 2 panels bottom selected, 5 data items split will be 3x2 with one empty
+        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[0, 1, 2, 3, 4], total_data_items=5, initial_layout_id="2x1")
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_with_existing_item(self):  # 2 panels, second with an existing data item and selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[1, 2, 3, 4], total_data_items=5, workspace_data_items_indices=[(1, 0)], initial_layout_id="2x1")
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def test_split_with_existing_items(self):  # 2 panels with an existing data items, only second selected, 4 selected data items, will be split into 3x2 since the existing makes the total 5
+        test_case = SplitCase(selected_workspace_panels_indices=1, expected_split_shape=(3, 2), total_expected_panels=7, selected_data_items_indices=[1, 2, 3, 4], total_data_items=6, workspace_data_items_indices=[(0, 5), (1, 0)], initial_layout_id="2x1")
+        self.run_split_test(test_case, self.perform_split_selection)
+
+    def perform_new_workspace_from_selection(self, document_controller: DocumentController.DocumentController) -> None:
+        """The perform_func to be passed into the run_split_test function for the workspace.new_workspace_from_selection tests.
+
+        Since invoke would bring up a text input dialog for the name, the context needs to be setup with the name already defined
+        then execute the action if it is enabled.
+        """
+        action_context = document_controller._get_action_context()
+        new_workspace_action = Window.actions["workspace.new_workspace_from_selection"]
+        new_workspace_action.set_string_property(action_context, "name", "New Workspace")
+        if new_workspace_action.is_enabled(action_context):
+            _ = new_workspace_action.execute(action_context)
+
+    def test_new_workspace_disabled_no_item(self):  # No selected data items, no change
+        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[], total_data_items=0, initial_layout_id="2x1")
+        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_disabled_too_many_items(self):  # Too many selected items, no change
+        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[x for x in range(0, 102)], total_data_items=101, initial_layout_id="2x1")
+        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_disabled_too_many_total(self):  # Total selected data items (6 display panel items, 95 data panel items) is too large, no change
+        test_case = SplitCase(selected_workspace_panels_indices=[i for i in range(0, 6)], selected_data_items_indices=[x for x in range(6, 102)], total_data_items=101, initial_layout_id="3x2", workspace_data_items_indices=[(i, i) for i in range(0, 6)])
+        self.run_disabled_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_single_item(self):  # 1 data item selected becomes a workspace with that item
+        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[0], total_expected_panels=1, total_data_items=1, initial_layout_id="2x1", expected_split_shape=(1, 1))
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_five_items(self):  # 5 data items selected becomes a workspace split 3x2
+        test_case = SplitCase(selected_workspace_panels_indices=0, selected_data_items_indices=[0, 1, 2, 3, 4], total_expected_panels=6, total_data_items=5, initial_layout_id="2x1", expected_split_shape=(3, 2))
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_panel_item(self):  # 1 workspace panel item selected becomes a workspace with that item
+        test_case = SplitCase(selected_workspace_panels_indices=[0], selected_data_items_indices=[], total_expected_panels=1, total_data_items=1, initial_layout_id="2x1", expected_split_shape=(1, 1), workspace_data_items_indices=[(0, 0)])
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_five_panel_items(self):  # 5 data panel items selected becomes a workspace split 3x2
+        test_case = SplitCase(selected_workspace_panels_indices=[0, 1, 2, 3, 4], selected_data_items_indices=[], total_expected_panels=6, total_data_items=5, initial_layout_id="6x1", expected_split_shape=(3, 2), workspace_data_items_indices=[(i, i) for i in range(0, 5)])
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_two_in_mixed_selection(self):  # 1 data panel item and 1 display panel item selected becomes a workspace split 2x1
+        test_case = SplitCase(selected_workspace_panels_indices=[0], selected_data_items_indices=[0], total_expected_panels=2, total_data_items=2, initial_layout_id="6x1", expected_split_shape=(2, 1), workspace_data_items_indices=[(0, 1)])
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_five_in_mixed_selection(self):  # 2 data panel items and 3 display panel items selected becomes a workspace split 3x2
+        test_case = SplitCase(selected_workspace_panels_indices=[i for i in range(0, 3)], selected_data_items_indices=[0, 1], total_expected_panels=6, total_data_items=5, initial_layout_id="3x1", expected_split_shape=(3, 2), workspace_data_items_indices=[(i - 2, i) for i in range(2, 5)])
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
+
+    def test_new_workspace_empty_panels_in_selection(self):  # 4 data panel items and 4 display panel items selected becomes a workspace split 4x2, the empty display panels that are selected are not used
+        test_case = SplitCase(selected_workspace_panels_indices=[0, 1, 2, 3, 4, 5], selected_data_items_indices=[4, 5, 6, 7], total_expected_panels=8, total_data_items=8, initial_layout_id="6x1", expected_split_shape=(4, 2), workspace_data_items_indices=[(i, i) for i in range(0, 4)])
+        self.run_split_test(test_case, self.perform_new_workspace_from_selection)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


Fixes #1805
New Workspace from Selection - Creates a new workspace and populates the display layout with the selected items
The action is in the Workspace menu drop down as well as when you right click in the data panel or workspace display panel. 
The splitting of the workspace uses the number of selected items and finds the closest split to a 5:3 ratio. If the number of selected items is not exact the result will have some empty display panels at the end.
The maximum allowed split selection is 60 creating a 10x6 split.
The drop down menu name contains the outcome of the split, i.e. 2x2 as well as the number of items in the selection.

Workspace Menu from Data Panel Selection of 5 items, New Workspace from Selection is available.
<img width="250" height="196" alt="image" src="https://github.com/user-attachments/assets/4e23b47e-3347-4970-ad82-55f117a0c0bf" />

Workspace Menu when disabled.
<img width="250" height="125" alt="Screenshot 2026-04-15 105042" src="https://github.com/user-attachments/assets/fd151582-6ad0-402b-8846-871a1fafabee" />
