### PR TITLE
Disable Edit Title for invalid selections

### DIFF
--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3395,7 +3395,7 @@ class OpenTitleEditAction(Window.Action):
     def invoke(self, context: Window.ActionContext) -> Window.ActionResult:
         context = typing.cast(DocumentController.ActionContext, context)
         window = typing.cast(DocumentController, context.window)
-        display_item = typing.cast(DisplayItem.DisplayItem, context.display_item)
+        display_item = context.display_item
         if window and display_item:
             from nion.swift import DisplayEditPopup
             size = Geometry.IntSize(width=400, height=40)
@@ -3413,7 +3413,7 @@ class OpenTitleEditAction(Window.Action):
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
         context = typing.cast(DocumentController.ActionContext, context)
-        return bool(context.display_item) and len(context.display_items) == 1
+        return context.display_item is not None  # context.display_item will be None when there's selection or the selection contains more than one item
 
 
 class ToggleFilterAction(Window.Action):


### PR DESCRIPTION
Fixes #1807. Adds the is_enabled method to verify there is a display item and there is only one display item selected.