### PR TITLE
Add a converter for Bytes for the generator popup.

### DIFF
--- a/nion/swift/GeneratorDialog.py
+++ b/nion/swift/GeneratorDialog.py
@@ -56,50 +56,51 @@ class GenerateDataDialog(Declarative.WindowHandler):
 
         self.int_converter = Converter.IntegerToStringConverter()
 
-        self.bytes_string_model: Model.PropertyModel[str] = Model.PropertyModel("- Bytes")
+        self.bytes_string_model: Model.PropertyModel[str] = Model.PropertyModel("- Bytes")  # Temporary string before first calculating
 
-        def update_bytes_string(*_: typing.Any | None) -> None:
+        def update_bytes_string(*_: typing.Any) -> None:
+            """Recalculate the number of bytes that will be used based on the selected sequence, collection and datam options."""
             data_size = 4  # data_type_model needs to drive this when it is made to drive anything as it currently doesn't do anything.
             if self.is_sequence_model.value == 1:
                 sequence_size = self.sequence_size_model.value or 1
                 data_size *= sequence_size
 
-            if self.collection_rank_model.value == 1:
+            if self.collection_rank_model.value == 1:  # Line selected in combo box
                 line_size = self.line_size_model.value or 1
                 data_size *= line_size
-            elif self.collection_rank_model.value == 2:
+            elif self.collection_rank_model.value == 2:  # Scan selected in combo box
                 scan_height = self.scan_height_model.value or 1
                 scan_width = self.scan_width_model.value or 1
                 data_size *= scan_height * scan_width
 
-            if self.datum_rank_model.value == 0:
+            if self.datum_rank_model.value == 0:  # Spectrum selected in combo box
                 spectrum_size = self.spectrum_size_model.value or 1
                 data_size *= spectrum_size
-            elif self.datum_rank_model.value == 1:
+            elif self.datum_rank_model.value == 1:  # Image selected in combo box
                 image_height = self.image_height_model.value or 1
                 image_width = self.image_width_model.value or 1
                 data_size *= image_height * image_width
-            elif self.datum_rank_model.value == 2:
+            elif self.datum_rank_model.value == 2:  # Array selected in combo box
                 array_height = self.array_height_model.value or 1
                 array_width = self.array_width_model.value or 1
                 data_size *= array_height * array_width
             self.bytes_string_model.value = Utility.format_with_binary_prefix(data_size)
 
-        self.bytes_update_stream: BYTES_UPDATE_STREAM_TYPE  = Stream.CombineLatestStream([
-                Stream.PropertyChangedEventStream(self.is_sequence_model, "value"),
-                Stream.PropertyChangedEventStream(self.sequence_size_model, "value"),
-                Stream.PropertyChangedEventStream(self.collection_rank_model, "value"),
-                Stream.PropertyChangedEventStream(self.line_size_model, "value"),
-                Stream.PropertyChangedEventStream(self.scan_height_model, "value"),
-                Stream.PropertyChangedEventStream(self.scan_width_model, "value"),
-                Stream.PropertyChangedEventStream(self.datum_rank_model, "value"),
-                Stream.PropertyChangedEventStream(self.spectrum_size_model, "value"),
-                Stream.PropertyChangedEventStream(self.image_height_model, "value"),
-                Stream.PropertyChangedEventStream(self.image_width_model, "value"),
-                Stream.PropertyChangedEventStream(self.array_height_model, "value"),
-                Stream.PropertyChangedEventStream(self.array_width_model, "value")
-            ], value_fn=update_bytes_string)
-        update_bytes_string(_)
+        self.bytes_update_stream: BYTES_UPDATE_STREAM_TYPE = Stream.CombineLatestStream([
+            Stream.PropertyChangedEventStream(self.is_sequence_model, "value"),
+            Stream.PropertyChangedEventStream(self.sequence_size_model, "value"),
+            Stream.PropertyChangedEventStream(self.collection_rank_model, "value"),
+            Stream.PropertyChangedEventStream(self.line_size_model, "value"),
+            Stream.PropertyChangedEventStream(self.scan_height_model, "value"),
+            Stream.PropertyChangedEventStream(self.scan_width_model, "value"),
+            Stream.PropertyChangedEventStream(self.datum_rank_model, "value"),
+            Stream.PropertyChangedEventStream(self.spectrum_size_model, "value"),
+            Stream.PropertyChangedEventStream(self.image_height_model, "value"),
+            Stream.PropertyChangedEventStream(self.image_width_model, "value"),
+            Stream.PropertyChangedEventStream(self.array_height_model, "value"),
+            Stream.PropertyChangedEventStream(self.array_width_model, "value")
+        ], value_fn=update_bytes_string)
+        update_bytes_string()
 
         u = Declarative.DeclarativeUI()
 

--- a/nion/swift/GeneratorDialog.py
+++ b/nion/swift/GeneratorDialog.py
@@ -18,8 +18,6 @@ from nion.utils import Converter
 from nion.utils import Stream
 from nion.utils import Model
 
-BYTES_UPDATE_STREAM_TYPE = Stream.CombineLatestStream[typing.Sequence[Stream.PropertyChangedEventStream[Model.PropertyModel[int]]], typing.Callable[[typing.Any], None]]
-
 if typing.TYPE_CHECKING:
     from nion.swift import DocumentController
 
@@ -33,34 +31,33 @@ class GenerateDataDialog(Declarative.WindowHandler):
 
         self.__document_controller = document_controller
 
-        self.title_model: Model.PropertyModel[str] = Model.PropertyModel(_("Generated Data"))
-        self.data_type_model: Model.PropertyModel[int] = Model.PropertyModel(0)
-        self.is_sequence_model: Model.PropertyModel[int] = Model.PropertyModel(0)
-        self.collection_rank_model: Model.PropertyModel[int] = Model.PropertyModel(0)
-        self.datum_rank_model: Model.PropertyModel[int] = Model.PropertyModel(1)
+        self.title_model = Model.PropertyModel(_("Generated Data"))
+        self.data_type_model = Model.PropertyModel(0)
+        self.is_sequence_model = Model.PropertyModel(0)
+        self.collection_rank_model = Model.PropertyModel(0)
+        self.datum_rank_model = Model.PropertyModel(1)
 
-        self.sequence_size_model: Model.PropertyModel[int] = Model.PropertyModel(16)
+        self.sequence_size_model = Model.PropertyModel(16)
 
-        self.line_size_model: Model.PropertyModel[int] = Model.PropertyModel(512)
+        self.line_size_model = Model.PropertyModel(512)
 
-        self.scan_width_model: Model.PropertyModel[int] = Model.PropertyModel(256)
-        self.scan_height_model: Model.PropertyModel[int] = Model.PropertyModel(256)
+        self.scan_width_model = Model.PropertyModel(256)
+        self.scan_height_model = Model.PropertyModel(256)
 
-        self.spectrum_size_model: Model.PropertyModel[int] = Model.PropertyModel(1024)
+        self.spectrum_size_model = Model.PropertyModel(1024)
 
-        self.image_width_model: Model.PropertyModel[int] = Model.PropertyModel(1024)
-        self.image_height_model: Model.PropertyModel[int] = Model.PropertyModel(1024)
+        self.image_width_model = Model.PropertyModel(1024)
+        self.image_height_model = Model.PropertyModel(1024)
 
-        self.array_width_model: Model.PropertyModel[int] = Model.PropertyModel(1024)
-        self.array_height_model: Model.PropertyModel[int] = Model.PropertyModel(256)
+        self.array_width_model = Model.PropertyModel(1024)
+        self.array_height_model = Model.PropertyModel(256)
 
         self.int_converter = Converter.IntegerToStringConverter()
 
-        self.bytes_string_model: Model.PropertyModel[str] = Model.PropertyModel("- Bytes")  # Temporary string before first calculating
-
-        def update_bytes_string(*_: typing.Any) -> None:
-            """Recalculate the number of bytes that will be used based on the selected sequence, collection and datam options."""
+        def update_bytes_string(*args: typing.Any) -> str:
+            """Recalculate the number of bytes that will be used based on the selected sequence, collection and datum options."""
             data_size = 4  # data_type_model needs to drive this when it is made to drive anything as it currently doesn't do anything.
+
             if self.is_sequence_model.value == 1:
                 sequence_size = self.sequence_size_model.value or 1
                 data_size *= sequence_size
@@ -84,9 +81,9 @@ class GenerateDataDialog(Declarative.WindowHandler):
                 array_height = self.array_height_model.value or 1
                 array_width = self.array_width_model.value or 1
                 data_size *= array_height * array_width
-            self.bytes_string_model.value = Utility.format_with_binary_prefix(data_size)
+            return Utility.make_pretty_size_str(data_size)
 
-        self.bytes_update_stream: BYTES_UPDATE_STREAM_TYPE = Stream.CombineLatestStream([
+        input_streams: typing.Sequence[Stream.PropertyChangedEventStream[typing.Any]] = [
             Stream.PropertyChangedEventStream(self.is_sequence_model, "value"),
             Stream.PropertyChangedEventStream(self.sequence_size_model, "value"),
             Stream.PropertyChangedEventStream(self.collection_rank_model, "value"),
@@ -99,8 +96,10 @@ class GenerateDataDialog(Declarative.WindowHandler):
             Stream.PropertyChangedEventStream(self.image_width_model, "value"),
             Stream.PropertyChangedEventStream(self.array_height_model, "value"),
             Stream.PropertyChangedEventStream(self.array_width_model, "value")
-        ], value_fn=update_bytes_string)
-        update_bytes_string()
+        ]
+
+        # create a model from the bytes string stream that updates whenever any of the inputs that affect the data size are changed.
+        self.bytes_string_model = Model.StreamValueModel(Stream.CombineLatestStream(input_streams, update_bytes_string))
 
         u = Declarative.DeclarativeUI()
 

--- a/nion/swift/GeneratorDialog.py
+++ b/nion/swift/GeneratorDialog.py
@@ -12,9 +12,13 @@ import scipy.stats
 from nion.data import Calibration
 from nion.data import DataAndMetadata
 from nion.swift.model import DataItem
+from nion.swift.model import Utility
 from nion.ui import Declarative
 from nion.utils import Converter
+from nion.utils import Stream
 from nion.utils import Model
+
+BYTES_UPDATE_STREAM_TYPE = Stream.CombineLatestStream[typing.Sequence[Stream.PropertyChangedEventStream[Model.PropertyModel[int]]], typing.Callable[[typing.Any], None]]
 
 if typing.TYPE_CHECKING:
     from nion.swift import DocumentController
@@ -51,6 +55,51 @@ class GenerateDataDialog(Declarative.WindowHandler):
         self.array_height_model: Model.PropertyModel[int] = Model.PropertyModel(256)
 
         self.int_converter = Converter.IntegerToStringConverter()
+
+        self.bytes_string_model: Model.PropertyModel[str] = Model.PropertyModel("- Bytes")
+
+        def update_bytes_string(*_: typing.Any | None) -> None:
+            data_size = 4  # data_type_model needs to drive this when it is made to drive anything as it currently doesn't do anything.
+            if self.is_sequence_model.value == 1:
+                sequence_size = self.sequence_size_model.value or 1
+                data_size *= sequence_size
+
+            if self.collection_rank_model.value == 1:
+                line_size = self.line_size_model.value or 1
+                data_size *= line_size
+            elif self.collection_rank_model.value == 2:
+                scan_height = self.scan_height_model.value or 1
+                scan_width = self.scan_width_model.value or 1
+                data_size *= scan_height * scan_width
+
+            if self.datum_rank_model.value == 0:
+                spectrum_size = self.spectrum_size_model.value or 1
+                data_size *= spectrum_size
+            elif self.datum_rank_model.value == 1:
+                image_height = self.image_height_model.value or 1
+                image_width = self.image_width_model.value or 1
+                data_size *= image_height * image_width
+            elif self.datum_rank_model.value == 2:
+                array_height = self.array_height_model.value or 1
+                array_width = self.array_width_model.value or 1
+                data_size *= array_height * array_width
+            self.bytes_string_model.value = Utility.format_with_binary_prefix(data_size)
+
+        self.bytes_update_stream: BYTES_UPDATE_STREAM_TYPE  = Stream.CombineLatestStream([
+                Stream.PropertyChangedEventStream(self.is_sequence_model, "value"),
+                Stream.PropertyChangedEventStream(self.sequence_size_model, "value"),
+                Stream.PropertyChangedEventStream(self.collection_rank_model, "value"),
+                Stream.PropertyChangedEventStream(self.line_size_model, "value"),
+                Stream.PropertyChangedEventStream(self.scan_height_model, "value"),
+                Stream.PropertyChangedEventStream(self.scan_width_model, "value"),
+                Stream.PropertyChangedEventStream(self.datum_rank_model, "value"),
+                Stream.PropertyChangedEventStream(self.spectrum_size_model, "value"),
+                Stream.PropertyChangedEventStream(self.image_height_model, "value"),
+                Stream.PropertyChangedEventStream(self.image_width_model, "value"),
+                Stream.PropertyChangedEventStream(self.array_height_model, "value"),
+                Stream.PropertyChangedEventStream(self.array_width_model, "value")
+            ], value_fn=update_bytes_string)
+        update_bytes_string(_)
 
         u = Declarative.DeclarativeUI()
 
@@ -131,7 +180,9 @@ class GenerateDataDialog(Declarative.WindowHandler):
         datum_stack = u.create_stack(spectrum_column, image_column, array_column,
                                      current_index="@binding(datum_rank_model.value)")
 
-        button_row = u.create_row(u.create_stretch(),
+        bytes_size_row = u.create_row(u.create_label(text="@binding(bytes_string_model.value)"))
+
+        button_row = u.create_row(bytes_size_row, u.create_stretch(),
                                   u.create_push_button(text=_("Cancel"), on_clicked="close_window"),
                                   u.create_push_button(text=_("Generate"), on_clicked="generate"), spacing=8)
 

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -1443,7 +1443,7 @@ class DataItem(Persistence.PersistentObject):
         data_dtype = self.data_dtype
         if dimensional_shape is not None and data_dtype is not None:
             total_bytes = typing.cast(int, numpy.prod(dimensional_shape + (numpy.dtype(data_dtype).itemsize,), dtype=numpy.int64))
-            return Utility.format_with_binary_prefix(total_bytes)
+            return Utility.make_pretty_size_str(total_bytes)
         return str()
 
     @property

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -1442,32 +1442,8 @@ class DataItem(Persistence.PersistentObject):
         dimensional_shape = self.dimensional_shape
         data_dtype = self.data_dtype
         if dimensional_shape is not None and data_dtype is not None:
-
-            # see https://stackoverflow.com/questions/12523586/python-format-size-application-converting-b-to-kb-mb-gb-tb
-            def humanbytes(b: int) -> str:
-                """Return the given bytes as a human friendly KB, MB, GB, or TB string."""
-                B = float(b)
-                KB = float(1024)
-                MB = float(KB ** 2)  # 1,048,576
-                GB = float(KB ** 3)  # 1,073,741,824
-                TB = float(KB ** 4)  # 1,099,511,627,776
-
-                if B < KB:
-                    return '{0} {1}'.format(B, 'Bytes' if B != 1 else 'Byte')
-                elif KB <= B < MB:
-                    return '{0:.2f} KB'.format(B / KB)
-                elif MB <= B < GB:
-                    return '{0:.2f} MB'.format(B / MB)
-                elif GB <= B < TB:
-                    return '{0:.2f} GB'.format(B / GB)
-                elif TB <= B:
-                    return '{0:.2f} TB'.format(B / TB)
-                else:
-                    return "{0} Bytes".format(B)
-
             total_bytes = typing.cast(int, numpy.prod(dimensional_shape + (numpy.dtype(data_dtype).itemsize,), dtype=numpy.int64))
-
-            return humanbytes(total_bytes)
+            return Utility.format_with_binary_prefix(total_bytes)
         return str()
 
     @property

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -540,7 +540,7 @@ def make_pretty_size_str(total_bytes: int | float) -> str:
     if total_bytes < gigabyte:
         return f"{total_bytes / megabyte:.2f} MB"
 
-    terabyte = 1099511627776  # 1024 ** 4
+    terabyte = 1099511627776.0  # 1024 ** 4
     if total_bytes < terabyte:
         return f"{total_bytes / gigabyte:.2f} GB"
     else:

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -522,7 +522,7 @@ class Timer:
         self.last_time_ns = current_time
 
 
-def format_with_binary_prefix(total_bytes: int | float) -> str:
+def make_pretty_size_str(total_bytes: int | float) -> str:
     """Format a number into a string with units Byte(s), KB, MB, GB, or TB formatted to two decimal places.
 
     See https://stackoverflow.com/a/31631711.

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -528,20 +528,20 @@ def format_with_binary_prefix(total_bytes: int | float) -> str:
     See https://stackoverflow.com/a/31631711.
     """
     total_bytes = float(total_bytes)
-    kilobytes = 1024.0
-    if total_bytes < kilobytes:
-        return '{0} {1}'.format(total_bytes, 'Bytes' if total_bytes != 1 else 'Byte')
+    kilobyte = 1024.0
+    if total_bytes < kilobyte:
+        return f"{total_bytes} {'Bytes' if total_bytes != 1 else 'Byte'}"
 
-    megabytes = 1048576.0  # 1024 ** 2
-    if total_bytes < megabytes:
-        return '{0:.2f} KB'.format(total_bytes / kilobytes)
+    megabyte = 1048576.0  # 1024 ** 2
+    if total_bytes < megabyte:
+        return f"{total_bytes / kilobyte:.2f} KB"
 
-    gigabytes = 1073741824.0  # 1024 ** 3
-    if total_bytes < gigabytes:
-        return '{0:.2f} MB'.format(total_bytes / megabytes)
+    gigabyte = 1073741824.0  # 1024 ** 3
+    if total_bytes < gigabyte:
+        return f"{total_bytes / megabyte:.2f} MB"
 
-    terabytes = 1099511627776  # 1024 ** 4
-    if total_bytes < terabytes:
-        return '{0:.2f} GB'.format(total_bytes / gigabytes)
+    terabyte = 1099511627776  # 1024 ** 4
+    if total_bytes < terabyte:
+        return f"{total_bytes / gigabyte:.2f} GB"
     else:
-        return '{0:.2f} TB'.format(total_bytes / terabytes)
+        return f"{total_bytes / terabyte:.2f} TB"

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -520,3 +520,28 @@ class Timer:
         if self.threshold == 0.0 or (current_time - self.last_time_ns) // 1E9 > self.threshold:
             print(f"{title}: {(current_time - self.start_time_ns) // 1E6}ms +{(current_time - self.last_time_ns) // 1E6}ms")
         self.last_time_ns = current_time
+
+
+def format_with_binary_prefix(total_bytes: int | float) -> str:
+    """Format a number into a string with units Byte(s), KB, MB, GB, or TB formatted to two decimal places.
+
+    See https://stackoverflow.com/a/31631711.
+    """
+    total_bytes = float(total_bytes)
+    kilobytes = 1024.0
+    if total_bytes < kilobytes:
+        return '{0} {1}'.format(total_bytes, 'Bytes' if total_bytes != 1 else 'Byte')
+
+    megabytes = 1048576.0  # 1024 ** 2
+    if total_bytes < megabytes:
+        return '{0:.2f} KB'.format(total_bytes / kilobytes)
+
+    gigabytes = 1073741824.0  # 1024 ** 3
+    if total_bytes < gigabytes:
+        return '{0:.2f} MB'.format(total_bytes / megabytes)
+
+    terabytes = 1099511627776  # 1024 ** 4
+    if total_bytes < terabytes:
+        return '{0:.2f} GB'.format(total_bytes / gigabytes)
+    else:
+        return '{0:.2f} TB'.format(total_bytes / terabytes)


### PR DESCRIPTION
Fixes #1815

Adds a converter in the DataItem that converts a number to a string formatted to bytes. This is then used by the Generator to display the number of bytes that will be made when generating a data item.
<img width="240" height="193" alt="image" src="https://github.com/user-attachments/assets/21c496ed-a3f5-4d93-9018-3fea1d1abbcb" />
