### PR TITLE
Change display panel to wrap display canvas items in threaded canvas item

### DIFF
--- a/nion/swift/DisplayCanvasItem.py
+++ b/nion/swift/DisplayCanvasItem.py
@@ -103,7 +103,7 @@ class DisplayCanvasItem(CanvasItem.CanvasItemComposition):
 
         Key contexts provide an ordered list of contexts that are used to determine
         which actions are valid at a given time. The contexts are checked in reverse
-        order (i.e. last added have highest precedence).
+        order (i.e. last added have the highest precedence).
         """
         return list()
 
@@ -119,6 +119,9 @@ class DisplayCanvasItem(CanvasItem.CanvasItemComposition):
     def update_display_data_delta(self, display_data_delta: DisplayItem.DisplayDataDelta) -> None: ...
 
     def set_focused(self, is_focused: bool) -> None: ...
+
+    def _update_canvas_items(self) -> None:
+        pass
 
     def _wait_for_update(self) -> None:
         pass

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1073,7 +1073,7 @@ class DisplayTracker:
         # callbacks
         self.on_clear_display: typing.Optional[typing.Callable[[], None]] = None
         self.on_title_changed: typing.Optional[typing.Callable[[str], None]] = None
-        self.on_replace_display_canvas_item: typing.Optional[typing.Callable[[DisplayCanvasItem.DisplayCanvasItem, DisplayCanvasItem.DisplayCanvasItem], None]] = None
+        self.on_replace_display_canvas_item: typing.Optional[typing.Callable[[DisplayCanvasItem.DisplayCanvasItem], None]] = None
 
         def clear_display() -> None:
             if callable(self.on_clear_display):
@@ -1104,10 +1104,9 @@ class DisplayTracker:
         def display_type_changed(display_type: typing.Optional[str]) -> None:
             # called when the display type of the data item changes.
             self.__display_data_delta_stream_action = typing.cast(typing.Any, None)
-            old_display_canvas_item = self.__display_canvas_item
             new_display_canvas_item = create_display_canvas_item(display_item, ui_settings, self.__delegate, self.__event_loop, draw_background=self.__draw_background)
             if callable(self.on_replace_display_canvas_item):
-                self.on_replace_display_canvas_item(old_display_canvas_item, new_display_canvas_item)
+                self.on_replace_display_canvas_item(new_display_canvas_item)
             self.__display_canvas_item = new_display_canvas_item
             self.__display_data_delta_stream_action = Stream.ValueStreamAction[DisplayItem.DisplayDataDelta](display_item.display_data_delta_stream, handle_display_data_delta)
             display_data_delta = display_item.display_data_delta_stream.value
@@ -2527,8 +2526,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         if did_display_change:
 
             # remove any existing display canvas item
-            if len(self.__display_composition_canvas_item.canvas_items) > 0:
-                self.__display_composition_canvas_item.remove_canvas_item(self.__display_composition_canvas_item.canvas_items[0])
+            self.__display_composition_canvas_item.remove_all_canvas_items()
 
             old_display_tracker = self.__display_tracker
             self.__display_tracker = None
@@ -2567,8 +2565,11 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                     display_canvas_item.add_display_control(c1_slider_row)
                     self.__related_icons_canvas_item = related_icons_canvas_item
 
-                def replace_display_canvas_item(old_display_canvas_item: DisplayCanvasItem.DisplayCanvasItem, new_display_canvas_item: DisplayCanvasItem.DisplayCanvasItem) -> None:
-                    self.__display_composition_canvas_item.replace_canvas_item(old_display_canvas_item, new_display_canvas_item)
+                def replace_display_canvas_item(new_display_canvas_item: DisplayCanvasItem.DisplayCanvasItem) -> None:
+                    self.__display_composition_canvas_item.remove_all_canvas_items()
+                    threaded_canvas_item = CanvasItem.ThreadedCanvasItem(new_display_canvas_item)
+                    threaded_canvas_item.on_will_repaint = new_display_canvas_item._update_canvas_items
+                    self.__display_composition_canvas_item.add_canvas_item(threaded_canvas_item)
                     add_display_controls(new_display_canvas_item)
                     # whenever focus or the display canvas item changes, update the focused status
                     new_display_canvas_item.set_focused(self.__content_canvas_item.focused)
@@ -2578,9 +2579,11 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 self.__display_tracker.on_title_changed = handle_title_changed
                 self.__display_tracker.on_replace_display_canvas_item = replace_display_canvas_item
 
-                add_display_controls(self.__display_tracker.display_canvas_item)
-
-                self.__display_composition_canvas_item.insert_canvas_item(0, self.__display_tracker.display_canvas_item)
+                new_display_canvas_item = self.__display_tracker.display_canvas_item
+                threaded_canvas_item = CanvasItem.ThreadedCanvasItem(new_display_canvas_item)
+                threaded_canvas_item.on_will_repaint = new_display_canvas_item._update_canvas_items
+                self.__display_composition_canvas_item.add_canvas_item(threaded_canvas_item)
+                add_display_controls(new_display_canvas_item)
 
             if old_display_tracker:
                 old_display_tracker.close()
@@ -2867,7 +2870,11 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         return self.__show_context_menu([self.__display_item] if self.__display_item else [], gx, gy)
 
     def _context_menu_event_for_testing(self, x: int, y: int) -> bool:
-        canvas_items = self.canvas_items_at_point(x, y)
+        canvas_items = list[CanvasItem.AbstractCanvasItem]()
+        if self.__display_tracker:
+            display_canvas_item = self.__display_tracker.display_canvas_item
+            canvas_items = display_canvas_item.canvas_items_at_point(x, y)
+        canvas_items.extend(self.canvas_items_at_point(x, y))
         for canvas_item in canvas_items:
             canvas_item_point = self.map_to_canvas_item(Geometry.IntPoint(y=y, x=x), canvas_item)
             if canvas_item.context_menu_event(canvas_item_point.x, canvas_item_point.y, x, y):
@@ -3371,5 +3378,6 @@ def preview(ui_settings: UISettings.UISettings, display_item: DisplayItem.Displa
             display_canvas_item.update_display_data_delta(display_data_delta)
             with drawing_context.saver():
                 display_canvas_item._wait_for_update()
+                display_canvas_item._update_canvas_items()
                 display_canvas_item.repaint_immediate(drawing_context, pixel_shape)
     return drawing_context

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -1797,3 +1797,6 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def move_down(self, amount: float = 10.0) -> None:
         self.apply_move_command(Geometry.FloatSize(-amount, 0.0))
+
+    def _update_canvas_items_for_testing(self) -> None:
+        pass  # parallel method to line plot; future use.

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -1612,7 +1612,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def key_contexts(self) -> typing.Sequence[str]:
         # key contexts provide an ordered list of contexts that are used to determine
         # which actions are valid at a given time. the contexts are checked in reverse
-        # order (i.e. last added have highest precedence).
+        # order (i.e. last added have the highest precedence).
         key_contexts = ["display_panel"]
         if self.__data_shape is not None:
             key_contexts.append("raster_display")
@@ -1797,6 +1797,3 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def move_down(self, amount: float = 10.0) -> None:
         self.apply_move_command(Geometry.FloatSize(-amount, 0.0))
-
-    def _update_canvas_items_for_testing(self) -> None:
-        pass  # parallel method to line plot; future use.

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -62,47 +62,38 @@ def nice_label(value: float, precision: int) -> str:
         return (u"{0:0." + u"{0:d}".format(precision) + "f}").format(value)
 
 
-class DataStyle(typing.Protocol):
+class AxisScale(typing.Protocol):
 
     @property
-    def style_id(self) -> str: ...
+    def axis_scale_id(self) -> str: ...
 
     def make_ticker(self, display_min: float, display_max: float) -> Geometry.Ticker: ...
 
-    def convert_calibrated_value_to_mapped_calibrated_value(self, value_cal: float) -> float: ...
+    def convert_calibrated_value_to_scaled_value(self, calibrated_value: float) -> float: ...
 
-    def convert_mapped_calibrated_value_to_calibrated_value(self, value_disp: float) -> float: ...
+    def convert_scaled_value_to_calibrated_value(self, scaled_value: float) -> float: ...
 
-    def convert_uncalibrated_array_to_mapped_calibrated_values(self, xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None: ...
+    def convert_calibrated_array_to_scaled_array(self, calibrated_xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None: ...
 
     def display_origin(self, display_min: float, display_max: float) -> float: ...
 
     def adjust_calibrated_limits(self, calibrated_min: float | None, calibrated_max: float | None, min_specified: bool, max_specified: bool) -> tuple[float, float]: ...
 
 
-class _LinearStyle(DataStyle):
-    style_id = "linear"
+class LinearAxisScale(AxisScale):
+    axis_scale_id = "linear"
 
     def make_ticker(self, display_min: float, display_max: float) -> Geometry.Ticker:
         return Geometry.LinearTicker(display_min, display_max)
 
-    def convert_calibrated_value_to_mapped_calibrated_value(self, value_cal: float) -> float:
-        return value_cal
+    def convert_calibrated_value_to_scaled_value(self, calibrated_value: float) -> float:
+        return calibrated_value
 
-    def convert_mapped_calibrated_value_to_calibrated_value(self, value_disp: float) -> float:
-        return value_disp
+    def convert_scaled_value_to_calibrated_value(self, scaled_value: float) -> float:
+        return scaled_value
 
-    def convert_uncalibrated_array_to_mapped_calibrated_values(self, xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None:
-        intensity_calibration = xdata.intensity_calibration
-        if intensity_calibration:
-            data = xdata.data if not xdata.is_data_rgb_type else Image.convert_to_grayscale(xdata.data)
-            calibrated = intensity_calibration.offset + intensity_calibration.scale * data
-            return DataAndMetadata.new_data_and_metadata(
-                calibrated,
-                intensity_calibration=Calibration.Calibration(units=intensity_calibration.units),
-                dimensional_calibrations=xdata.dimensional_calibrations
-            )
-        return xdata
+    def convert_calibrated_array_to_scaled_array(self, calibrated_xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None:
+        return calibrated_xdata
 
     def display_origin(self, display_min: float, display_max: float) -> float:
         if display_min <= 0.0 <= display_max:
@@ -117,31 +108,25 @@ class _LinearStyle(DataStyle):
         return calibrated_min, calibrated_max
 
 
-class _LogStyle(DataStyle):
-    style_id = "log"
+class LogAxisScale(AxisScale):
+    axis_scale_id = "log"
 
     def make_ticker(self, display_min: float, display_max: float) -> Geometry.Ticker:
         return Geometry.LogTicker(display_min, display_max)
 
-    def convert_calibrated_value_to_mapped_calibrated_value(self, value_cal: float) -> float:
-        return math.log10(value_cal) if value_cal > 0 else float("-inf")
+    def convert_calibrated_value_to_scaled_value(self, calibrated_value: float) -> float:
+        return math.log10(calibrated_value) if calibrated_value > 0 else float("-inf")
 
-    def convert_mapped_calibrated_value_to_calibrated_value(self, value_disp: float) -> float:
-        return math.pow(10, value_disp)
+    def convert_scaled_value_to_calibrated_value(self, scaled_value: float) -> float:
+        return math.pow(10, scaled_value)
 
-    def convert_uncalibrated_array_to_mapped_calibrated_values(self, xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None:
-        intensity_calibration = xdata.intensity_calibration
-        if intensity_calibration:
-            data = xdata.data if not xdata.is_data_rgb_type else Image.convert_to_grayscale(xdata.data)
-            calibrated = intensity_calibration.offset + intensity_calibration.scale * data
-            calibrated[calibrated <= 0] = numpy.nan
-            numpy.log10(calibrated, out=calibrated)
-            return DataAndMetadata.new_data_and_metadata(
-                calibrated,
-                intensity_calibration=Calibration.Calibration(units=intensity_calibration.units),
-                dimensional_calibrations=xdata.dimensional_calibrations
-            )
-        return xdata
+    def convert_calibrated_array_to_scaled_array(self, calibrated_xdata: DataAndMetadata.DataAndMetadata) -> DataAndMetadata.DataAndMetadata | None:
+        scaled_data = numpy.log10(numpy.where(calibrated_xdata.data <= 0, numpy.nan, calibrated_xdata.data.astype(float)))
+        return DataAndMetadata.new_data_and_metadata(
+            scaled_data,
+            intensity_calibration=Calibration.Calibration(units=calibrated_xdata.intensity_calibration.units),
+            dimensional_calibrations=calibrated_xdata.dimensional_calibrations
+        )
 
     def display_origin(self, display_min: float, display_max: float) -> float:
         return display_min
@@ -152,86 +137,101 @@ class _LogStyle(DataStyle):
         return min_val, max_val
 
 
-_data_styles: dict[str, DataStyle] = {
-    "linear": _LinearStyle(),
-    "log": _LogStyle()
+_axis_scale_types: dict[str, AxisScale] = {
+    "linear": LinearAxisScale(),
+    "log": LogAxisScale()
 }
 
-def _get_data_style(data_style_id: str | None) -> DataStyle:
-    # return the data style for the optional data_style_id, or the linear style if not found
-    data_style = _data_styles.get(data_style_id, None) if data_style_id else None
-    return data_style if data_style else _LinearStyle()
+def _get_axis_scale(axis_scale_id: str | None) -> AxisScale:
+    # return the axis scale for the optional axis_scale_id, or the linear style if not found
+    axis_scale = _axis_scale_types.get(axis_scale_id, None) if axis_scale_id else None
+    return axis_scale if axis_scale else LinearAxisScale()
 
 
-def calculate_y_axis(xdata_list: typing.Sequence[DataAndMetadata.DataAndMetadata | None], data_min: float | None, data_max: float | None, data_style_id: str | None) -> tuple[float, float, Geometry.Ticker]:
+def calculate_scaled_xdata(xdata: DataAndMetadata.DataAndMetadata, axis_scale: AxisScale) -> DataAndMetadata.DataAndMetadata | None:
+    """Calculate the 'scaled xdata' for the given xdata and axis scale.
+
+    The 'scaled xdata' is the xdata (with a calibration) but with a new intensity calibration where origin=0 and scale=1.
+    """
+    scalar_uncalibrated_data = xdata.data if not xdata.is_data_rgb_type else Image.convert_to_grayscale(xdata.data)
+    calibrated_data = xdata.intensity_calibration.convert_array_to_calibrated_value(scalar_uncalibrated_data)
+    calibrated_xdata = DataAndMetadata.new_data_and_metadata(
+        calibrated_data,
+        intensity_calibration=Calibration.Calibration(units=xdata.intensity_calibration.units),
+        dimensional_calibrations=xdata.dimensional_calibrations
+    )
+    return axis_scale.convert_calibrated_array_to_scaled_array(calibrated_xdata)
+
+
+def calculate_y_axis(xdata_list: typing.Sequence[DataAndMetadata.DataAndMetadata | None], data_min: float | None, data_max: float | None, axis_scale_id: str | None) -> tuple[float, float, Geometry.Ticker]:
     """Calculate the calibrated min/max and y-axis ticker for list of xdata.
 
     xdata_list is the original calibrated data
     data_min and data_max are calibrated values
 
-    Returns mapped_calibrated_data_min, mapped_calibrated_data_max, ticker
+    Returns scaled_data_min, scaled_data_max, ticker
     """
-    data_style = _get_data_style(data_style_id)
-
     min_specified = data_min is not None
     max_specified = data_max is not None
 
-    mapped_calibrated_data_min_opt: float | None = None
-    mapped_calibrated_data_max_opt: float | None = None
+    scaled_data_min_opt: float | None = None
+    scaled_data_max_opt: float | None = None
+
+    axis_scale = _get_axis_scale(axis_scale_id)
 
     # Determine min/max in calibrated data space before converting to display space
     for xdata in xdata_list:
         if xdata and xdata.data_shape[-1] > 0:
-            mapped_calibrated_xdata = data_style.convert_uncalibrated_array_to_mapped_calibrated_values(xdata)
-            if mapped_calibrated_xdata is not None:
-                mapped_calibrated_data = mapped_calibrated_xdata.data if numpy.issubdtype(mapped_calibrated_xdata.data.dtype, numpy.floating) else mapped_calibrated_xdata.data.astype(float)
-                if mapped_calibrated_data is not None and mapped_calibrated_data.size > 0:
+            scaled_xdata = calculate_scaled_xdata(xdata, axis_scale)
+            if scaled_xdata is not None:
+                scaled_data = scaled_xdata.data if numpy.issubdtype(scaled_xdata.data.dtype, numpy.floating) else scaled_xdata.data.astype(float)
+                if scaled_data is not None and scaled_data.size > 0:
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore", category=RuntimeWarning)
-                        mapped_calibrated_data_min = float(numpy.nanmin(mapped_calibrated_data))
-                        mapped_calibrated_data_max = float(numpy.nanmax(mapped_calibrated_data))
-                    if numpy.isfinite(mapped_calibrated_data_min):
-                        mapped_calibrated_data_min_opt = mapped_calibrated_data_min if mapped_calibrated_data_min_opt is None else min(mapped_calibrated_data_min_opt, mapped_calibrated_data_min)
-                    if numpy.isfinite(mapped_calibrated_data_max):
-                        mapped_calibrated_data_max_opt = mapped_calibrated_data_max if mapped_calibrated_data_max_opt is None else max(mapped_calibrated_data_max_opt, mapped_calibrated_data_max)
+                        scaled_data_min = float(numpy.nanmin(scaled_data))
+                        scaled_data_max = float(numpy.nanmax(scaled_data))
+                    if numpy.isfinite(scaled_data_min):
+                        scaled_data_min_opt = scaled_data_min if scaled_data_min_opt is None else min(scaled_data_min_opt, scaled_data_min)
+                    if numpy.isfinite(scaled_data_max):
+                        scaled_data_max_opt = scaled_data_max if scaled_data_max_opt is None else max(scaled_data_max_opt, scaled_data_max)
 
     if min_specified:
         calibrated_min = typing.cast(float, data_min)
     else:
-        if mapped_calibrated_data_min_opt is not None:
-            calibrated_min = data_style.convert_mapped_calibrated_value_to_calibrated_value(mapped_calibrated_data_min_opt)
+        if scaled_data_min_opt is not None:
+            calibrated_min = axis_scale.convert_scaled_value_to_calibrated_value(scaled_data_min_opt)
         else:
             calibrated_min = None
 
     if max_specified:
         calibrated_max = typing.cast(float, data_max)
     else:
-        if mapped_calibrated_data_max_opt is not None:
-            calibrated_max = data_style.convert_mapped_calibrated_value_to_calibrated_value(mapped_calibrated_data_max_opt)
+        if scaled_data_max_opt is not None:
+            calibrated_max = axis_scale.convert_scaled_value_to_calibrated_value(scaled_data_max_opt)
         else:
             calibrated_max = None
 
-    calibrated_min, calibrated_max = data_style.adjust_calibrated_limits(calibrated_min, calibrated_max, min_specified, max_specified)
+    adjusted_calibrated_min, adjusted_calibrated_max = axis_scale.adjust_calibrated_limits(calibrated_min, calibrated_max, min_specified, max_specified)
 
     # Convert calibrated limits to display space
-    mapped_calibrated_data_min = data_style.convert_calibrated_value_to_mapped_calibrated_value(calibrated_min)
-    mapped_calibrated_data_max = data_style.convert_calibrated_value_to_mapped_calibrated_value(calibrated_max)
-    if math.isnan(mapped_calibrated_data_min) or math.isinf(mapped_calibrated_data_min):
-        mapped_calibrated_data_min = 0.0
-    if math.isnan(mapped_calibrated_data_max) or math.isinf(mapped_calibrated_data_max):
-        mapped_calibrated_data_max = 0.0
-    mapped_calibrated_data_min, mapped_calibrated_data_max = min(mapped_calibrated_data_min, mapped_calibrated_data_max), max(mapped_calibrated_data_min, mapped_calibrated_data_max)
-    if mapped_calibrated_data_min == mapped_calibrated_data_max:
-        mapped_calibrated_data_min -= 1.0
-        mapped_calibrated_data_max += 1.0
+    scaled_data_min = axis_scale.convert_calibrated_value_to_scaled_value(adjusted_calibrated_min)
+    scaled_data_max = axis_scale.convert_calibrated_value_to_scaled_value(adjusted_calibrated_max)
+    if math.isnan(scaled_data_min) or math.isinf(scaled_data_min):
+        scaled_data_min = 0.0
+    if math.isnan(scaled_data_max) or math.isinf(scaled_data_max):
+        scaled_data_max = 0.0
+    scaled_data_min, scaled_data_max = min(scaled_data_min, scaled_data_max), max(scaled_data_min, scaled_data_max)
+    if scaled_data_min == scaled_data_max:
+        scaled_data_min -= 1.0
+        scaled_data_max += 1.0
 
-    ticker = data_style.make_ticker(mapped_calibrated_data_min, mapped_calibrated_data_max)
+    ticker = axis_scale.make_ticker(scaled_data_min, scaled_data_max)
     if not min_specified:
-        mapped_calibrated_data_min = ticker.minimum
+        scaled_data_min = ticker.minimum
     if not max_specified:
-        mapped_calibrated_data_max = ticker.maximum
+        scaled_data_max = ticker.maximum
 
-    return mapped_calibrated_data_min, mapped_calibrated_data_max, ticker
+    return scaled_data_min, scaled_data_max, ticker
 
 
 @dataclasses.dataclass
@@ -244,9 +244,9 @@ class LegendEntry:
 class LineGraphAxes:
     """Track information about line graph axes."""
 
-    def __init__(self, data_scale: float, mapped_calibrated_data_min: float, mapped_calibrated_data_max: float, data_left: int,
+    def __init__(self, data_scale: float, scaled_data_min: float, scaled_data_max: float, data_left: int,
                  data_right: int, x_calibration: typing.Optional[Calibration.Calibration],
-                 y_calibration: typing.Optional[Calibration.Calibration], data_style_id: typing.Optional[str],
+                 y_calibration: typing.Optional[Calibration.Calibration], axis_scale_id: typing.Optional[str],
                  y_ticker: Geometry.Ticker) -> None:
         assert x_calibration is None or x_calibration.is_valid
         assert y_calibration is None or y_calibration.is_valid
@@ -256,13 +256,13 @@ class LineGraphAxes:
         self.__uncalibrated_right_channel = data_right
         self.x_calibration = x_calibration
         self.y_calibration = y_calibration
-        self.data_style = _get_data_style(data_style_id)
-        self.__mapped_calibrated_data_min = mapped_calibrated_data_min
-        self.__mapped_calibrated_data_max = mapped_calibrated_data_max
+        self.axis_scale = _get_axis_scale(axis_scale_id)
+        self.__scaled_data_min = scaled_data_min
+        self.__scaled_data_max = scaled_data_max
         self.__y_ticker = y_ticker
 
     def __repr__(self) -> str:
-        return f"Axes {self.drawn_left_channel}:{self.drawn_right_channel} [{self.mapped_calibrated_data_min},{self.mapped_calibrated_data_max} {self.x_calibration} {self.y_calibration} {self.data_style} {self.data_scale}"
+        return f"Axes {self.drawn_left_channel}:{self.drawn_right_channel} [{self.scaled_data_min},{self.scaled_data_max} {self.x_calibration} {self.y_calibration} {self.axis_scale} {self.data_scale}"
 
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, LineGraphAxes):
@@ -272,13 +272,13 @@ class LineGraphAxes:
                 self.__uncalibrated_right_channel == other.__uncalibrated_right_channel and
                 self.x_calibration == other.x_calibration and
                 self.y_calibration == other.y_calibration and
-                self.data_style.style_id == other.data_style.style_id and
-                self.__mapped_calibrated_data_min == other.__mapped_calibrated_data_min and
-                self.__mapped_calibrated_data_max == other.__mapped_calibrated_data_max and
+                self.axis_scale.axis_scale_id == other.axis_scale.axis_scale_id and
+                self.__scaled_data_min == other.__scaled_data_min and
+                self.__scaled_data_max == other.__scaled_data_max and
                 self.__y_ticker == other.__y_ticker)
 
     def __hash__(self) -> int:
-        return hash((self.data_scale, self.__uncalibrated_left_channel, self.__uncalibrated_right_channel, self.x_calibration, self.y_calibration, self.data_style.style_id, self.__mapped_calibrated_data_min, self.__mapped_calibrated_data_max, self.__y_ticker))
+        return hash((self.data_scale, self.__uncalibrated_left_channel, self.__uncalibrated_right_channel, self.x_calibration, self.y_calibration, self.axis_scale.axis_scale_id, self.__scaled_data_min, self.__scaled_data_max, self.__y_ticker))
 
     @property
     def y_ticker(self) -> Geometry.Ticker:
@@ -287,30 +287,32 @@ class LineGraphAxes:
     @property
     def uncalibrated_data_min(self) -> float:
         y_calibration = self.y_calibration if self.y_calibration else Calibration.Calibration()
-        calibrated_value_min = self.data_style.convert_mapped_calibrated_value_to_calibrated_value(self.mapped_calibrated_data_min)
+        calibrated_value_min = self.axis_scale.convert_scaled_value_to_calibrated_value(self.scaled_data_min)
         return y_calibration.convert_from_calibrated_value(calibrated_value_min)
 
     @property
     def uncalibrated_data_max(self) -> float:
         y_calibration = self.y_calibration if self.y_calibration else Calibration.Calibration()
-        calibrated_value_max = self.data_style.convert_mapped_calibrated_value_to_calibrated_value(self.mapped_calibrated_data_max)
+        calibrated_value_max = self.axis_scale.convert_scaled_value_to_calibrated_value(self.scaled_data_max)
         return y_calibration.convert_from_calibrated_value(calibrated_value_max)
 
     @property
-    def mapped_calibrated_data_min(self) -> float:
-        return self.__mapped_calibrated_data_min
+    def scaled_data_min(self) -> float:
+        return self.__scaled_data_min
 
     @property
-    def mapped_calibrated_data_max(self) -> float:
-        return self.__mapped_calibrated_data_max
+    def scaled_data_max(self) -> float:
+        return self.__scaled_data_max
 
     @property
     def calibrated_value_max(self) -> float:
-        return self.data_style.convert_mapped_calibrated_value_to_calibrated_value(self.__mapped_calibrated_data_max)
+        calibrated_value = self.axis_scale.convert_scaled_value_to_calibrated_value(self.__scaled_data_max)
+        return calibrated_value
 
     @property
     def calibrated_value_min(self) -> float:
-        return self.data_style.convert_mapped_calibrated_value_to_calibrated_value(self.__mapped_calibrated_data_min)
+        calibrated_value = self.axis_scale.convert_scaled_value_to_calibrated_value(self.__scaled_data_min)
+        return calibrated_value
 
     @property
     def drawn_left_channel(self) -> int:
@@ -331,8 +333,8 @@ class LineGraphAxes:
     def calculate_y_ticks(self, plot_height: int, flag_minor: bool = False) -> typing.Sequence[typing.Tuple[float, str, bool]]:
         """Calculate the y-axis items dependent on the plot height."""
 
-        calibrated_data_min = self.mapped_calibrated_data_min
-        calibrated_data_max = self.mapped_calibrated_data_max
+        calibrated_data_min = self.scaled_data_min
+        calibrated_data_max = self.scaled_data_max
         calibrated_data_range = calibrated_data_max - calibrated_data_min
 
         ticker = self.y_ticker
@@ -351,8 +353,8 @@ class LineGraphAxes:
 
         return y_ticks
 
-    def convert_mapped_calibrated_y_value_to_uncalibrated_value(self, mapped_calibrated_y_value: float) -> float:
-        calibrated_y_value = self.data_style.convert_mapped_calibrated_value_to_calibrated_value(mapped_calibrated_y_value)
+    def convert_scaled_y_value_to_uncalibrated_value(self, scaled_y_value: float) -> float:
+        calibrated_y_value = self.axis_scale.convert_scaled_value_to_calibrated_value(scaled_y_value)
         y_calibration = self.y_calibration
         if y_calibration:
             return y_calibration.convert_from_calibrated_value(calibrated_y_value)
@@ -385,12 +387,12 @@ class LineGraphAxes:
 
         return x_ticks
 
-    def convert_uncalibrated_array_to_mapped_calibrated_values(self, xdata: DataAndMetadata.DataAndMetadata) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+    def convert_calibrated_array_to_scaled_array(self, xdata: DataAndMetadata.DataAndMetadata) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
         """Calculate the 'calibrated xdata'.
 
          The 'calibrated xdata' is the xdata (with a calibration) but with a new intensity calibration where origin=0 and scale=1.
          """
-        return self.data_style.convert_uncalibrated_array_to_mapped_calibrated_values(xdata)
+        return calculate_scaled_xdata(xdata, self.axis_scale)
 
 
 def draw_background(drawing_context: DrawingContext.DrawingContext, plot_rect: Geometry.IntRect, background_color: typing.Optional[typing.Union[str, DrawingContext.LinearGradient]]) -> None:
@@ -485,29 +487,29 @@ class LineGraphSegment:
 
 
 def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
-                    mapped_calibrated_xdata: DataAndMetadata.DataAndMetadata, mapped_calibrated_data_min: float,
-                    mapped_calibrated_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
-                    line_graph_x_calibration: Calibration.Calibration,
-                    rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
-                    data_style: DataStyle) -> typing.Tuple[typing.List[LineGraphSegment], int]:
+                         scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                         scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                         line_graph_x_calibration: Calibration.Calibration,
+                         rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                         axis_scale: AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
     """Calculate the line graph segments for the given parameters.
 
-    Note: line_graph_x_calibration may not match the calibration of mapped_calibrated_xdata since the x_calibration
+    Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
     represents the calibration of the graph itself, which may include multiple data items with different
     calibrations. the units will match.
     """
-    x_calibration = mapped_calibrated_xdata.dimensional_calibrations[-1]
+    x_calibration = scaled_xdata.dimensional_calibrations[-1]
     assert x_calibration.units == line_graph_x_calibration.units
     if line_graph_x_calibration.scale < 0:
         # note: x_calibration is the same as calibrated_xdata_calibration. it is the x-dimension. use short names.
         calibrated_min_channel = min(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
-        calibrated_max_channel = max(calibrated_right_channel, x_calibration.convert_to_calibrated_value(mapped_calibrated_xdata.dimensional_shape[-1]))
+        calibrated_max_channel = max(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel <= calibrated_right_channel or calibrated_max_channel >= calibrated_left_channel:
             return list(), 0  # data is outside drawing area
     else:
         # note: x_calibration is the same as calibrated_xdata_calibration. it is the x-dimension. use short names.
         calibrated_min_channel = max(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
-        calibrated_max_channel = min(calibrated_right_channel, x_calibration.convert_to_calibrated_value(mapped_calibrated_xdata.dimensional_shape[-1]))
+        calibrated_max_channel = min(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel >= calibrated_right_channel or calibrated_max_channel <= calibrated_left_channel:
             return list(), 0  # data is outside drawing area
     # calculate the left/right channels as indexes into the data arrays and the left/right pixels for drawing.
@@ -520,14 +522,14 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     plot_width = right_pixel - left_pixel
     plot_origin_x = left_pixel
     # calculate the subset of data that is visible in the graph
-    if 0 <= left_channel_index < right_channel_index and right_channel_index <= mapped_calibrated_xdata.dimensional_shape[-1]:
-        visible_mapped_calibrated_xdata = mapped_calibrated_xdata[left_channel_index:right_channel_index]
+    if 0 <= left_channel_index < right_channel_index and right_channel_index <= scaled_xdata.dimensional_shape[-1]:
+        visible_scaled_xdata = scaled_xdata[left_channel_index:right_channel_index]
     else:
         return list(), 0
-    visible_x_calibration = visible_mapped_calibrated_xdata.dimensional_calibrations[-1]
+    visible_x_calibration = visible_scaled_xdata.dimensional_calibrations[-1]
     # these variables are repurposed. TODO: pick better names
     visible_calibrated_left_channel = visible_x_calibration.convert_to_calibrated_value(0)
-    visible_calibrated_right_channel = visible_x_calibration.convert_to_calibrated_value(visible_mapped_calibrated_xdata.dimensional_shape[-1])
+    visible_calibrated_right_channel = visible_x_calibration.convert_to_calibrated_value(visible_scaled_xdata.dimensional_shape[-1])
 
     uncalibrated_visible_left_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_left_channel)
     uncalibrated_visible_right_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_right_channel)
@@ -538,14 +540,14 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     line_commands = segment.line_commands
     # segment_path = segment.path  # partially optimized; see note below
     # note: testing performance using a loop around drawing commands in test_line_plot_handle_calibrated_x_axis_with_negative_scale
-    if mapped_calibrated_data_range != 0.0 and uncalibrated_visible_width > 0.0:
-        origin_display = data_style.display_origin(mapped_calibrated_data_min, mapped_calibrated_data_min + mapped_calibrated_data_range)
-        baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - mapped_calibrated_data_min) / mapped_calibrated_data_range)
+    if scaled_data_range != 0.0 and uncalibrated_visible_width > 0.0:
+        origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
+        baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
 
         baseline = min(plot_origin_y + plot_height, baseline)
         baseline = max(plot_origin_y, baseline)
         # rebin so that uncalibrated_visible_width corresponds to plot width
-        calibrated_data = visible_mapped_calibrated_xdata._data_ex
+        calibrated_data = visible_scaled_xdata._data_ex
         binned_length = int(calibrated_data.shape[-1] * plot_width / uncalibrated_visible_width)
         did_draw = False
         if binned_length > 0:
@@ -561,7 +563,7 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
                     data_value = binned_data[binned_index]
                     # plot_origin_y is the TOP of the drawing
                     # py extends DOWNWARDS
-                    py = plot_origin_y + plot_height - (plot_height * (data_value - mapped_calibrated_data_min) / mapped_calibrated_data_range)
+                    py = plot_origin_y + plot_height - (plot_height * (data_value - scaled_data_min) / scaled_data_range)
                     py = max(plot_origin_y, py)
                     py = min(plot_origin_y + plot_height, py)
                     if did_draw:
@@ -676,34 +678,34 @@ class MappedCalibratedDataAndMetadataCacheItem:
         return id(self.xdata.data) if self.xdata else None, self.axes
 
     def calculate(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        return self.axes.convert_uncalibrated_array_to_mapped_calibrated_values(self.xdata) if self.axes and self.xdata else None
+        return self.axes.convert_calibrated_array_to_scaled_array(self.xdata) if self.axes  and self.xdata else None
 
 
 @dataclasses.dataclass(frozen=True)
 class SegmentsCacheItem:
-    mapped_calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
+    scaled_xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
     axes: typing.Optional[LineGraphAxes]
     canvas_bounds: Geometry.IntRect
 
     def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LineGraphAxes], Geometry.IntRect]:
-        return id(self.mapped_calibrated_xdata.data) if self.mapped_calibrated_xdata else None, self.axes, self.canvas_bounds
+        return id(self.scaled_xdata.data) if self.scaled_xdata else None, self.axes, self.canvas_bounds
 
     def calculate(self) -> typing.Tuple[typing.List[LineGraphSegment], float]:
-        mapped_calibrated_xdata = self.mapped_calibrated_xdata
+        scaled_xdata = self.scaled_xdata
         axes = self.axes
         canvas_bounds = self.canvas_bounds
         segments: typing.List[LineGraphSegment] = list()
         baseline = 0.0
-        if mapped_calibrated_xdata is not None and axes:
+        if scaled_xdata is not None and axes:
             plot_width = canvas_bounds.width - 1
             plot_height = canvas_bounds.height - 1
             plot_origin_x = canvas_bounds.left
             plot_origin_y = canvas_bounds.top
 
             # extract the data we need for drawing y-axis
-            mapped_calibrated_data_min = axes.mapped_calibrated_data_min
-            mapped_calibrated_data_max = axes.mapped_calibrated_data_max
-            mapped_calibrated_data_range = mapped_calibrated_data_max - mapped_calibrated_data_min
+            scaled_data_min = axes.scaled_data_min
+            scaled_data_max = axes.scaled_data_max
+            scaled_data_range = scaled_data_max - scaled_data_min
 
             # extract the data we need for drawing x-axis
             calibrated_left_channel = axes.calibrated_left_channel
@@ -711,13 +713,13 @@ class SegmentsCacheItem:
             x_calibration = axes.x_calibration
 
             # draw the line plot itself
-            if x_calibration and x_calibration.units == mapped_calibrated_xdata.dimensional_calibrations[-1].units:
+            if x_calibration and x_calibration.units == scaled_xdata.dimensional_calibrations[-1].units:
                 segments, baseline = calculate_line_graph(plot_height, plot_width, plot_origin_y, plot_origin_x,
-                                                          mapped_calibrated_xdata,
-                                                          mapped_calibrated_data_min, mapped_calibrated_data_range,
+                                                          scaled_xdata,
+                                                          scaled_data_min, scaled_data_range,
                                                           calibrated_left_channel,
                                                           calibrated_right_channel, x_calibration,
-                                                          None, axes.data_style)
+                                                          None, axes.axis_scale)
         return segments, baseline
 
 
@@ -778,28 +780,28 @@ class LineGraphLayer:
 
     def draw_fills(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> typing.Tuple[CanvasItem.CacheValue, ...]:
         if self.fill_color:
-            mapped_calibrated_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes)
-            mapped_calibrated_xdata_cache_value = composer_cache.get_cache_value(mapped_calibrated_data_and_metadata_cache_item)
-            mapped_calibrated_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], mapped_calibrated_xdata_cache_value.value)
-            segments_cache_item = SegmentsCacheItem(mapped_calibrated_xdata, self.__axes, canvas_bounds)
+            scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes)
+            scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
+            scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
+            segments_cache_item = SegmentsCacheItem(scaled_xdata, self.__axes, canvas_bounds)
             segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
             segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
             for segment in segments:
                 segment.fill(drawing_context, baseline, Color.Color(self.fill_color))
-            return mapped_calibrated_xdata_cache_value, segments_cache_value
+            return scaled_xdata_cache_value, segments_cache_value
         return tuple()
 
     def draw_strokes(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> typing.Tuple[CanvasItem.CacheValue, ...]:
         if self.stroke_color:
-            mapped_calibrated_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes)
-            mapped_calibrated_xdata_cache_value = composer_cache.get_cache_value(mapped_calibrated_data_and_metadata_cache_item)
-            mapped_calibrated_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], mapped_calibrated_xdata_cache_value.value)
-            segments_cache_item = SegmentsCacheItem(mapped_calibrated_xdata, self.__axes, canvas_bounds)
+            scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(self.__xdata, self.__axes)
+            scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
+            scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
+            segments_cache_item = SegmentsCacheItem(scaled_xdata, self.__axes, canvas_bounds)
             segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
             segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
             for segment in segments:
                 segment.stroke(drawing_context, baseline, Color.Color(self.stroke_color), self.stroke_width)
-            return mapped_calibrated_xdata_cache_value, segments_cache_value
+            return scaled_xdata_cache_value, segments_cache_value
         return tuple()
 
 
@@ -853,7 +855,7 @@ class LineGraphLayerCanvasItem(CanvasItem.AbstractCanvasItem):
             self.update()
 
     @property
-    def mapped_calibrated_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+    def scaled_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
         return MappedCalibratedDataAndMetadataCacheItem(self._xdata, self._axes).calculate()
 
 
@@ -918,7 +920,7 @@ class LineGraphLayersCanvasItem(CanvasItem.CanvasItemComposition):
             line_graph_layer_canvas_item.update_line_graph_layer(line_graph_layer, False)
 
     @property
-    def mapped_calibrated_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+    def scaled_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
         return MappedCalibratedDataAndMetadataCacheItem(self._xdata, self._axes).calculate()
 
     def _get_composition_composer(self, child_composers: typing.Sequence[CanvasItem.BaseComposer], composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -840,14 +840,6 @@ class LineGraphLayerCanvasItem(CanvasItem.AbstractCanvasItem):
         else:
             return CanvasItem.EmptyCanvasItemComposer(self, self.layout_sizing, composer_cache)
 
-    @property
-    def _xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        return self.__line_graph_layer.xdata if self.__line_graph_layer else None
-
-    @property
-    def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
-        return self.__line_graph_layer.axes if self.__line_graph_layer else None
-
     def update_line_graph_layer(self, line_graph_layer: LineGraphLayer, is_fill: bool) -> None:
         if self.__line_graph_layer != line_graph_layer or self.__is_fill != is_fill:
             self.__line_graph_layer = line_graph_layer
@@ -855,8 +847,16 @@ class LineGraphLayerCanvasItem(CanvasItem.AbstractCanvasItem):
             self.update()
 
     @property
-    def scaled_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        return MappedCalibratedDataAndMetadataCacheItem(self._xdata, self._axes).calculate()
+    def _xdata_for_testing(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return self.__line_graph_layer.xdata if self.__line_graph_layer else None
+
+    @property
+    def _axes_for_testing(self) -> typing.Optional[LineGraphAxes]:
+        return self.__line_graph_layer.axes if self.__line_graph_layer else None
+
+    @property
+    def _scaled_xdata_for_testing(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return MappedCalibratedDataAndMetadataCacheItem(self._xdata_for_testing, self._axes_for_testing).calculate()
 
 
 class LineGraphLayersCanvasItemCompositionComposer(CanvasItem.CanvasItemCompositionComposer):
@@ -898,14 +898,6 @@ class LineGraphLayersCanvasItem(CanvasItem.CanvasItemComposition):
         self.__display_frame_rate_id = value
         self.update()
 
-    @property
-    def _xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        return typing.cast(LineGraphLayerCanvasItem, self.canvas_items[0])._xdata if self.canvas_items else None
-
-    @property
-    def _axes(self) -> typing.Optional[LineGraphAxes]:  # for testing only
-        return typing.cast(LineGraphLayerCanvasItem, self.canvas_items[0])._axes if self.canvas_items else None
-
     def update_line_graph_layers(self, line_graph_layers: typing.Sequence[LineGraphLayer]) -> None:
         line_graph_layers = list(line_graph_layers)
         while len(self.canvas_items) < len(line_graph_layers) * 2:
@@ -919,12 +911,20 @@ class LineGraphLayersCanvasItem(CanvasItem.CanvasItemComposition):
             line_graph_layer_canvas_item = typing.cast(LineGraphLayerCanvasItem, canvas_item)
             line_graph_layer_canvas_item.update_line_graph_layer(line_graph_layer, False)
 
-    @property
-    def scaled_xdata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
-        return MappedCalibratedDataAndMetadataCacheItem(self._xdata, self._axes).calculate()
-
     def _get_composition_composer(self, child_composers: typing.Sequence[CanvasItem.BaseComposer], composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphLayersCanvasItemCompositionComposer(self, self.layout_sizing, composer_cache, self.layout.copy(), child_composers, self.background_color, self.border_color, self.__display_frame_rate_id)
+
+    @property
+    def _xdata_for_testing(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return typing.cast(LineGraphLayerCanvasItem, self.canvas_items[0])._xdata_for_testing if self.canvas_items else None
+
+    @property
+    def _axes_for_testing(self) -> typing.Optional[LineGraphAxes]:
+        return typing.cast(LineGraphLayerCanvasItem, self.canvas_items[0])._axes_for_testing if self.canvas_items else None
+
+    @property
+    def _scaled_xdata_for_testing(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
+        return MappedCalibratedDataAndMetadataCacheItem(self._xdata_for_testing, self._axes_for_testing).calculate()
 
 
 class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -664,9 +664,9 @@ class LineGraphBackgroundCanvasItem(CanvasItem.AbstractCanvasItem):
         return LineGraphBackgroundCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.draw_grid, self.background_color)
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.update()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1170,9 +1170,9 @@ class LineGraphHorizontalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(self.sizing.with_fixed_height(self.__tick_height))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphHorizontalAxisTicksCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__tick_height)
@@ -1212,9 +1212,9 @@ class LineGraphHorizontalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(self.sizing.with_fixed_height(self.__font_size + 4))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphHorizontalAxisScaleCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)
@@ -1266,10 +1266,10 @@ class LineGraphHorizontalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(new_sizing)
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.size_to_content()
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.size_to_content()
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphHorizontalAxisLabelCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)
@@ -1310,9 +1310,9 @@ class LineGraphVerticalAxisTicksCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(self.sizing.with_fixed_width(self.__tick_width))
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphVerticalAxisTicksCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__tick_width)
@@ -1453,10 +1453,10 @@ class LineGraphVerticalAxisScaleCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(new_sizing)
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.size_to_content()
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.size_to_content()
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphVerticalAxisScaleCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size, self.__fonts, self.__ui_settings)
@@ -1514,10 +1514,10 @@ class LineGraphVerticalAxisLabelCanvasItem(CanvasItem.AbstractCanvasItem):
         self.update_sizing(new_sizing)
 
     def set_axes(self, axes: typing.Optional[LineGraphAxes]) -> None:
-        # assume this is only called when axes changes
-        self.__axes = axes
-        self.size_to_content()
-        self.update()
+        if self.__axes != axes:
+            self.__axes = axes
+            self.size_to_content()
+            self.update()
 
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer:
         return LineGraphVerticalAxisLabelCanvasItemComposer(self, self.layout_sizing, composer_cache, self.__axes, self.__font_size)

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -21,6 +21,7 @@ from nion.swift.model import DisplayItem
 from nion.swift.model import Graphics
 from nion.swift.model import UISettings
 from nion.ui import CanvasItem
+from nion.ui import DrawingContext
 from nion.utils import Color
 from nion.utils import Geometry
 from nion.utils import Registry
@@ -624,7 +625,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         # trigger an update
         self.update()
 
-    def __update_canvas_items(self) -> None:
+    def _update_canvas_items(self) -> None:
         # this is a separate method so that it can be used from tests.
 
         line_plot_display_info = self.__line_plot_display_info
@@ -659,10 +660,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             self.__line_graph_regions_canvas_item.set_regions(line_plot_display_info.regions)
 
         self.__last_axes = line_plot_display_info.axes
-
-    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer | None:
-        self.__update_canvas_items()
-        return super()._get_composer(composer_cache)
 
     def set_focused(self, is_focused: bool) -> None:
         self.__line_graph_regions_canvas_item.set_is_focused(is_focused)
@@ -1239,9 +1236,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             self.delegate.push_undo_command(command)
 
         return "ignore"
-
-    def _update_canvas_items_for_testing(self) -> None:
-        self.__update_canvas_items()
 
     @property
     def _axes_for_testing(self) -> LineGraphCanvasItem.LineGraphAxes | None:

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -342,8 +342,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
         self.__update_lock = threading.RLock()
 
-        self.__last_xdata_list: typing.List[typing.Optional[DataAndMetadata.DataAndMetadata]] = list()
-
         self.__line_graph_area_stack = CanvasItem.CanvasItemComposition()
         self.__line_graph_background_canvas_item = LineGraphCanvasItem.LineGraphBackgroundCanvasItem()
         self.__line_graph_layers_canvas_item = LineGraphCanvasItem.LineGraphLayersCanvasItem()

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 # standard libraries
 import copy
-import dataclasses
 import math
 import operator
 import threading
@@ -29,7 +28,6 @@ from nion.utils import Registry
 if typing.TYPE_CHECKING:
     from nion.swift.model import Persistence
     from nion.swift import Undo
-    from nion.ui import DrawingContext
     from nion.ui import UserInterface
 
 _NDArray = numpy.typing.NDArray[typing.Any]
@@ -114,22 +112,39 @@ MAX_LAYER_COUNT = 16
 
 
 class LinePlotDisplayInfo:
-    def __init__(self, display_calibration_info: typing.Optional[DisplayItem.DisplayCalibrationInfo], display_properties: Persistence.PersistentDictType, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]], display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo]) -> None:
+    """Represents the information needed to display a line plot, including the data, calibrations, axes and legend information.
+
+    This object is effectively immutable, i.e. outside of caching.
+    """
+
+    def __init__(
+            self,
+            display_calibration_info: DisplayItem.DisplayCalibrationInfo | None,
+            display_properties: Persistence.PersistentDictType,
+            display_values_list: typing.Sequence[DisplayItem.DisplayValues | None],
+            display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo],
+            graphics: typing.Sequence[Graphics.Graphic],
+            graphic_selection: DisplayItem.GraphicSelection | None
+    ) -> None:
         self.__display_calibration_info = display_calibration_info
+        self.__display_properties = copy.deepcopy(display_properties)
+        self.__display_values_list = list(display_values_list)
+        self.__display_layers = list(display_layers)
+        self.__graphics = list(graphics)
+        self.__graphic_selection = copy.copy(graphic_selection)
+
+        # cached values
         self.__y_min: float | None = display_properties.get("y_min", None)
         self.__y_max: float | None = display_properties.get("y_max", None)
         self.__y_axis_scale_id: str | None = display_properties.get("y_style", "linear")  # 'y_style' for backward compatibility
         self.__left_channel: int | None = display_properties.get("left_channel", None)
         self.__right_channel: int | None = display_properties.get("right_channel", None)
         self.__legend_position: str | None = display_properties.get("legend_position", None)
-        self.__display_values_list = list(display_values_list)
-        self.__display_layers = list(display_layers)
-
-        # cached values
         self.__xdata_list: typing.Optional[typing.List[typing.Optional[DataAndMetadata.DataAndMetadata]]] = None
         self.__axes: typing.Optional[LineGraphCanvasItem.LineGraphAxes] = None
         self.__line_graph_layers: typing.Optional[typing.List[LineGraphCanvasItem.LineGraphLayer]] = None
         self.__legend_entries: typing.Optional[typing.List[LineGraphCanvasItem.LegendEntry]] = None
+        self.__regions: typing.Sequence[LineGraphCanvasItem.RegionInfo] | None = None
 
         # for testing
         self._has_valid_drawn_graph_data = False
@@ -137,6 +152,74 @@ class LinePlotDisplayInfo:
     @property
     def is_valid(self) -> bool:
         return self.__display_calibration_info is not None
+
+    @property
+    def display_layers(self) -> typing.Sequence[DisplayItem.DisplayLayerInfo]:
+        return self.__display_layers
+
+    @property
+    def graphics(self) -> typing.Sequence[Graphics.Graphic]:
+        return self.__graphics
+
+    @property
+    def graphic_selection(self) -> DisplayItem.GraphicSelection | None:
+        return self.__graphic_selection
+
+    @property
+    def regions(self) -> typing.Sequence[LineGraphCanvasItem.RegionInfo]:
+        display_calibration_info = self.__display_calibration_info
+        if self.__regions is None and display_calibration_info:
+            dimensional_scales = display_calibration_info.displayed_dimensional_scales
+            graphics = self.__graphics
+            graphic_selection = self.__graphic_selection or DisplayItem.GraphicSelection()
+            regions = list[LineGraphCanvasItem.RegionInfo]()
+            if dimensional_scales and graphics:
+                data_scale = dimensional_scales[-1]
+                dimensional_calibration = display_calibration_info.displayed_dimensional_calibrations[-1] if len(
+                    display_calibration_info.displayed_dimensional_calibrations) > 0 else Calibration.Calibration(
+                    scale=data_scale)
+
+                def convert_to_calibrated_value_str(f: float) -> str:
+                    return u"{0}".format(
+                        dimensional_calibration.convert_to_calibrated_value_str(f, value_range=(0, data_scale),
+                                                                                samples=round(data_scale),
+                                                                                include_units=False))
+
+                def convert_to_calibrated_size_str(f: float) -> str:
+                    return u"{0}".format(
+                        dimensional_calibration.convert_to_calibrated_size_str(f, value_range=(0, data_scale),
+                                                                               samples=round(data_scale),
+                                                                               include_units=False))
+
+                for graphic_index, graphic in enumerate(graphics):
+                    if isinstance(graphic, Graphics.IntervalGraphic):
+                        graphic_start, graphic_end = graphic.start, graphic.end
+                        graphic_start, graphic_end = min(graphic_start, graphic_end), max(graphic_start, graphic_end)
+                        left_channel = graphic_start * data_scale
+                        right_channel = graphic_end * data_scale
+                        left_text = convert_to_calibrated_value_str(left_channel)
+                        right_text = convert_to_calibrated_value_str(right_channel)
+                        middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
+                        region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end),
+                                                                graphic_selection.contains(graphic_index),
+                                                                graphic_index, left_text, right_text, middle_text,
+                                                                graphic.label, None, graphic.color)
+                        regions.append(region)
+                    elif isinstance(graphic, Graphics.ChannelGraphic):
+                        graphic_start, graphic_end = graphic.position, graphic.position
+                        graphic_start, graphic_end = min(graphic_start, graphic_end), max(graphic_start, graphic_end)
+                        left_channel = graphic_start * data_scale
+                        right_channel = graphic_end * data_scale
+                        left_text = convert_to_calibrated_value_str(left_channel)
+                        right_text = convert_to_calibrated_value_str(right_channel)
+                        middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
+                        region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end),
+                                                                graphic_selection.contains(graphic_index),
+                                                                graphic_index, left_text, right_text, middle_text,
+                                                                graphic.label, "tag", graphic.color)
+                        regions.append(region)
+            self.__regions = regions
+        return self.__regions or list()
 
     @property
     def data_scale(self) -> float:
@@ -306,6 +389,18 @@ class LinePlotDisplayInfo:
             self.__legend_entries = legend_entries
         return self.__legend_entries
 
+    def apply_display_data_delta(self, display_data_delta: DisplayItem.DisplayDataDelta) -> LinePlotDisplayInfo:
+        """Apply the display data delta changes to this display info and return a new display info with the changes applied."""
+
+        display_calibration_info = display_data_delta.display_calibration_info if display_data_delta.display_calibration_info_changed else self.__display_calibration_info
+        display_properties = copy.deepcopy(display_data_delta.display_properties if display_data_delta.display_properties_changed else self.__display_properties)
+        display_values_list = list(display_data_delta.display_values_list if display_data_delta.display_values_list_changed else self.__display_values_list)
+        display_layers = list(display_data_delta.display_layers_list if display_data_delta.display_layers_list_changed else self.__display_layers)
+        graphics = list(display_data_delta.graphics if display_data_delta.graphics_changed else self.__graphics)
+        graphic_selection = copy.copy(display_data_delta.graphic_selection if display_data_delta.graphic_selection_changed else self.__graphic_selection)
+
+        return LinePlotDisplayInfo(display_calibration_info, display_properties, display_values_list, display_layers, graphics, graphic_selection)
+
 
 class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     """A canvas item to display a line plot.
@@ -339,8 +434,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
         self.__closing_lock = threading.RLock()
         self.__closed = False
-
-        self.__update_lock = threading.RLock()
 
         self.__line_graph_area_stack = CanvasItem.CanvasItemComposition()
         self.__line_graph_background_canvas_item = LineGraphCanvasItem.LineGraphBackgroundCanvasItem()
@@ -450,13 +543,12 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__graphic_drag_start_pos: Geometry.IntPoint = Geometry.IntPoint()
         self.__graphic_drag_changed = False
 
-        self.__line_plot_display_info = LinePlotDisplayInfo(None, dict(), list(), list())
+        # track last axes separately to avoid having to calculate it on the main thread.
+        # calculating axes can trigger a display computation.
+        self.__last_axes: LineGraphCanvasItem.LineGraphAxes | None = None
 
-        self.__axes: typing.Optional[LineGraphCanvasItem.LineGraphAxes] = None
-        self.__legend_entries: typing.Optional[typing.List[LineGraphCanvasItem.LegendEntry]] = None
+        self.__line_plot_display_info = LinePlotDisplayInfo(None, dict(), list(), list(), list(), None)
 
-        self.__graphics: typing.List[Graphics.Graphic] = list()
-        self.__graphic_selection: typing.Optional[DisplayItem.GraphicSelection] = None
         self.__pending_interval: typing.Optional[Graphics.IntervalGraphic] = None
 
     def close(self) -> None:
@@ -473,21 +565,16 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         return self.__line_graph_layers_canvas_item
 
     @property
-    def _axes(self) -> typing.Optional[LineGraphCanvasItem.LineGraphAxes]:
-        return self.__axes
-
-    @property
     def _has_valid_drawn_graph_data(self) -> bool:
         return self.__line_plot_display_info._has_valid_drawn_graph_data
 
-    def __update_legend_origin(self) -> None:
+    def __update_legend_origin(self, legend_position: str | None) -> None:
         line_graph_legend_row_visible = False
         line_graph_legend_row_canvas_item0_visible = False
         line_graph_legend_row_canvas_item2_visible = False
         line_graph_outer_right_column_visible = False
         line_graph_outer_left_column_visible = False
 
-        legend_position = self.__line_plot_display_info.legend_position
         if legend_position == "top-left":
             line_graph_legend_row_visible= True
             line_graph_legend_row_canvas_item2_visible = True
@@ -512,87 +599,73 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             self.__display_controls.add_canvas_item(display_control_canvas_item)
 
     def update_display_data_delta(self, display_data_delta: DisplayItem.DisplayDataDelta) -> None:
-        # ensure that this method is only entered once and updates are done in a batch to avoid repainting
-        # intermediate states.
-        with self.__update_lock, self.batch_update():
-            if display_data_delta.display_values_list_changed:
-                self.__update_display_values(display_data_delta.display_values_list)
-            if display_data_delta.display_values_list_changed or display_data_delta.display_calibration_info_changed or display_data_delta.display_layers_list_changed or display_data_delta.display_properties_changed:
-                self.__update_display_properties_and_layers(display_data_delta.display_calibration_info,
-                                                            display_data_delta.display_properties,
-                                                            display_data_delta.display_layers_list)
-            if display_data_delta.graphics_changed or display_data_delta.graphic_selection_changed or display_data_delta.display_calibration_info_changed:
-                self.__update_graphics_coordinate_system(display_data_delta.graphics,
-                                                         display_data_delta.graphic_selection,
-                                                         display_data_delta.display_calibration_info)
+        """Update the state of the display.
 
-    def set_focused(self, is_focused: bool) -> None:
-        self.__line_graph_regions_canvas_item.set_is_focused(is_focused)
-
-    def __update_display_values(self, display_values_list: typing.Sequence[typing.Optional[DisplayItem.DisplayValues]]) -> None:
-        self.__display_values_list = list(display_values_list)
-
-    def __update_display_properties_and_layers(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo,
-                                               display_properties: Persistence.PersistentDictType,
-                                               display_layers: typing.Sequence[DisplayItem.DisplayLayerInfo]) -> None:
-        """Update the display values. Called from display panel.
-
-        This method saves the display values and data and triggers an update. It should be as fast as possible.
-
-        As a layer, this canvas item will respond to the update by calling prepare_render on the layer's rendering
-        thread.
-
-        The inefficiencies in this process are that the layer must re-render on each call to this function. There is
-        also a cost within the constituent canvas items to check whether the axes or their data has changed.
-
-        When the display is associated with a single data item, the data will be
+        display_data_delta contains changes to the state of the display. For any item that is marked as changed,
+        update the corresponding state in this canvas item. After updating the state, trigger an update of the display by
+        calling update().
         """
 
-        # may be called from thread; prevent a race condition with closing.
-        with self.__closing_lock:
-            if self.__closed:
-                return
+        # update the line plot display info.
+        self.__line_plot_display_info = self.__line_plot_display_info.apply_display_data_delta(display_data_delta)
 
-            self.__line_plot_display_info = LinePlotDisplayInfo(display_calibration_info, display_properties, self.__display_values_list, display_layers)
-            self.__display_layers = display_layers
+        # update the frame rate info
+        display_values_list = display_data_delta.display_values_list
+        if display_values_list:
+            for display_values in display_values_list:
+                if display_values:
+                    data_metadata = display_values.element_data_metadata
+                    if data_metadata:
+                        self.__update_frame(data_metadata.metadata)
 
-            if self.__display_values_list:
-                for display_values in self.__display_values_list:
-                    if display_values:
-                        data_metadata = display_values.element_data_metadata
-                        if data_metadata:
-                            self.__update_frame(data_metadata.metadata)
+        # update the cursor info
+        self.__update_cursor_info()
 
-            # update the cursor info
-            self.__update_cursor_info()
+        # trigger an update
+        self.update()
 
-            # tell the other canvas items to update
-            line_plot_display_info = self.__line_plot_display_info
+    def __update_canvas_items(self) -> None:
+        # this is a separate method so that it can be used from tests.
+
+        line_plot_display_info = self.__line_plot_display_info
+
+        with self.batch_update():
+            # update the line graph layers
             line_graph_layers = line_plot_display_info.line_graph_layers
-            legend_entries = line_plot_display_info.legend_entries
             self.__line_graph_layers_canvas_item.update_line_graph_layers(line_graph_layers)
             self.__line_graph_regions_canvas_item.update_line_graph_layers(line_graph_layers)
 
-            # update the canvas items
-            self.__update_legend_origin()
-            if self.__legend_entries != legend_entries:
-                self.__legend_entries = legend_entries
-                self.__line_graph_legend_canvas_item.set_legend_entries(legend_entries)
-                self.__line_graph_outer_left_legend.set_legend_entries(legend_entries)
-                self.__line_graph_outer_right_legend.set_legend_entries(legend_entries)
-            axes = line_plot_display_info.axes
-            if not are_axes_equal(self.__axes, axes):
-                self.__axes = axes
-                self.__line_graph_background_canvas_item.set_axes(axes)
-                self.__line_graph_frame_canvas_item.set_draw_frame(bool(axes))
-                self.__line_graph_vertical_axis_label_canvas_item.set_axes(axes)
-                self.__line_graph_vertical_axis_scale_canvas_item.set_axes(axes)
-                self.__line_graph_vertical_axis_ticks_canvas_item.set_axes(axes)
-                self.__line_graph_horizontal_axis_label_canvas_item.set_axes(axes)
-                self.__line_graph_horizontal_axis_scale_canvas_item.set_axes(axes)
-                self.__line_graph_horizontal_axis_ticks_canvas_item.set_axes(axes)
+            # update the legend position
+            self.__update_legend_origin(line_plot_display_info.legend_position)
 
-            self.update()
+            # update the legend entries
+            legend_entries = line_plot_display_info.legend_entries
+            self.__line_graph_legend_canvas_item.set_legend_entries(legend_entries)
+            self.__line_graph_outer_left_legend.set_legend_entries(legend_entries)
+            self.__line_graph_outer_right_legend.set_legend_entries(legend_entries)
+
+            # update the axes
+            axes = line_plot_display_info.axes
+            self.__line_graph_background_canvas_item.set_axes(axes)
+            self.__line_graph_frame_canvas_item.set_draw_frame(bool(axes))
+            self.__line_graph_vertical_axis_label_canvas_item.set_axes(axes)
+            self.__line_graph_vertical_axis_scale_canvas_item.set_axes(axes)
+            self.__line_graph_vertical_axis_ticks_canvas_item.set_axes(axes)
+            self.__line_graph_horizontal_axis_label_canvas_item.set_axes(axes)
+            self.__line_graph_horizontal_axis_scale_canvas_item.set_axes(axes)
+            self.__line_graph_horizontal_axis_ticks_canvas_item.set_axes(axes)
+
+            # update the graphics
+            self.__line_graph_regions_canvas_item.set_regions(line_plot_display_info.regions)
+
+        self.__last_axes = line_plot_display_info.axes
+
+    def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> CanvasItem.BaseComposer | None:
+        self.__update_canvas_items()
+        return super()._get_composer(composer_cache)
+
+    def set_focused(self, is_focused: bool) -> None:
+        self.__line_graph_regions_canvas_item.set_is_focused(is_focused)
 
     def __update_frame(self, metadata: DataAndMetadata.MetadataType) -> None:
         # update frame rate info
@@ -607,56 +680,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             frame_index = d.get("frame_index", 0)
 
             self.__frame_rate_canvas_item.frame_tick(frame_index)
-
-    def __update_graphics_coordinate_system(self, graphics: typing.Sequence[Graphics.Graphic],
-                                            graphic_selection: DisplayItem.GraphicSelection,
-                                            display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> None:
-        dimensional_scales = display_calibration_info.displayed_dimensional_scales
-
-        self.__graphics = copy.copy(list(graphics))
-        self.__graphic_selection = copy.copy(graphic_selection)
-
-        if dimensional_scales is None or len(dimensional_scales) == 0:
-            return
-        assert dimensional_scales is not None
-
-        data_scale = dimensional_scales[-1]
-        dimensional_calibration = display_calibration_info.displayed_dimensional_calibrations[-1] if len(display_calibration_info.displayed_dimensional_calibrations) > 0 else Calibration.Calibration(scale=data_scale)
-
-        def convert_to_calibrated_value_str(f: float) -> str:
-            return u"{0}".format(dimensional_calibration.convert_to_calibrated_value_str(f, value_range=(0, data_scale),
-                                                                                         samples=round(data_scale),
-                                                                                         include_units=False))
-
-        def convert_to_calibrated_size_str(f: float) -> str:
-            return u"{0}".format(dimensional_calibration.convert_to_calibrated_size_str(f, value_range=(0, data_scale),
-                                                                                        samples=round(data_scale),
-                                                                                        include_units=False))
-
-        regions = list()
-        for graphic_index, graphic in enumerate(graphics):
-            if isinstance(graphic, Graphics.IntervalGraphic):
-                graphic_start, graphic_end = graphic.start, graphic.end
-                graphic_start, graphic_end = min(graphic_start, graphic_end), max(graphic_start, graphic_end)
-                left_channel = graphic_start * data_scale
-                right_channel = graphic_end * data_scale
-                left_text = convert_to_calibrated_value_str(left_channel)
-                right_text = convert_to_calibrated_value_str(right_channel)
-                middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, None, graphic.color)
-                regions.append(region)
-            elif isinstance(graphic, Graphics.ChannelGraphic):
-                graphic_start, graphic_end = graphic.position, graphic.position
-                graphic_start, graphic_end = min(graphic_start, graphic_end), max(graphic_start, graphic_end)
-                left_channel = graphic_start * data_scale
-                right_channel = graphic_end * data_scale
-                left_text = convert_to_calibrated_value_str(left_channel)
-                right_text = convert_to_calibrated_value_str(right_channel)
-                middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
-                region = LineGraphCanvasItem.RegionInfo((graphic_start, graphic_end), graphic_selection.contains(graphic_index), graphic_index, left_text, right_text, middle_text, graphic.label, "tag", graphic.color)
-                regions.append(region)
-
-        self.__line_graph_regions_canvas_item.set_regions(regions)
 
     def __view_to_intervals(self, data_and_metadata: DataAndMetadata.DataAndMetadata, intervals: typing.List[typing.Tuple[float, float]]) -> None:
         """Change the view to encompass the channels and data represented by the given intervals."""
@@ -732,10 +755,11 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
     def __view_to_selected_graphics(self, data_and_metadata: DataAndMetadata.DataAndMetadata) -> None:
         """Change the view to encompass the selected graphic intervals."""
-        all_graphics = self.__graphics
+        all_graphics = self.__line_plot_display_info.graphics
+        graphic_selection = self.__line_plot_display_info.graphic_selection
         graphics: typing.List[Graphics.Graphic]
-        if self.__graphic_selection:
-            graphics = [graphic for graphic_index, graphic in enumerate(all_graphics) if self.__graphic_selection.contains(graphic_index)]
+        if graphic_selection:
+            graphics = [graphic for graphic_index, graphic in enumerate(all_graphics) if graphic_selection.contains(graphic_index)]
         else:
             graphics = list()
         intervals = list()
@@ -792,7 +816,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             return True
         delegate = self.delegate
         if delegate and delegate.tool_mode == "pointer" and not self.__graphic_drag_items:
-            if self._axes:
+            axes = self.__last_axes
+            if axes:
                 pos = Geometry.IntPoint(x=x, y=y)
                 h_axis_canvas_bounds = self.line_graph_horizontal_axis_group_canvas_item.canvas_bounds
                 v_axis_canvas_bounds = self.__line_graph_vertical_axis_group_canvas_item.canvas_bounds
@@ -806,8 +831,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                         self.cursor_shape = "split_vertical"
                     else:
                         self.cursor_shape = "hand"
-                elif self.__graphics:
-                    graphics = self.__graphics
+                elif graphics := self.__line_plot_display_info.graphics:
                     for graphic_index, graphic in enumerate(graphics):
                         if graphic.has_attribute(Graphics.GraphicAttributeEnum.ONE_DIMENSIONAL):
                             widget_mapping = self.__get_mouse_mapping()
@@ -846,7 +870,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def mouse_pressed(self, x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
         if super().mouse_pressed(x, y, modifiers):
             return True
-        if not self._axes:
+        if not self.__last_axes:
             return False
         self.__undo_command = None
         pos = Geometry.IntPoint(x=x, y=y)
@@ -881,7 +905,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def mouse_released(self, x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
         if super().mouse_released(x, y, modifiers):
             return True
-        if not self._axes:
+        if not self.__last_axes:
             return False
         self.end_tracking(modifiers)
         delegate = self.delegate
@@ -913,7 +937,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def key_contexts(self) -> typing.Sequence[str]:
         key_contexts = ["display_panel"]
         key_contexts.append("line_plot_display")
-        if self.__graphic_selection and self.__graphic_selection.has_selection:
+        graphic_selection = self.__line_plot_display_info.graphic_selection
+        if graphic_selection and graphic_selection.has_selection:
             key_contexts.append("line_plot_display_graphics")
         return key_contexts
 
@@ -947,7 +972,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         canvas_bounds = self.__line_graph_regions_canvas_item.canvas_bounds
         assert canvas_bounds
         plot_rect = canvas_bounds.translated(plot_origin)
-        axes = self._axes
+        axes = self.__last_axes
         left_channel = axes.drawn_left_channel if axes else 0
         right_channel = axes.drawn_right_channel if axes else 0
         return LinePlotCanvasItemMapping(data_scale, plot_rect, left_channel, right_channel)
@@ -960,10 +985,12 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         # keep track of general drag information
         self.__graphic_drag_start_pos = pos
         self.__graphic_drag_changed = False
-        if self._axes and self.__graphic_selection:
+        axes = self.__last_axes
+        graphic_selection = self.__line_plot_display_info.graphic_selection
+        if axes and graphic_selection:
             self.__tracking_selections = True
-            graphics = self.__graphics
-            selection_indexes = self.__graphic_selection.indexes
+            graphics = self.__line_plot_display_info.graphics
+            selection_indexes = graphic_selection.indexes
             for graphic_index, graphic in enumerate(graphics):
                 if graphic.has_attribute(Graphics.GraphicAttributeEnum.ONE_DIMENSIONAL):
                     already_selected = graphic_index in selection_indexes
@@ -997,7 +1024,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def begin_tracking_horizontal(self, pos: Geometry.IntPoint, rescale: bool) -> None:
         plot_origin = self.line_graph_horizontal_axis_group_canvas_item.map_to_canvas_item(Geometry.IntPoint(), self)
         canvas_bounds = self.line_graph_horizontal_axis_group_canvas_item.canvas_bounds
-        if canvas_bounds and (axes := self._axes):
+        if canvas_bounds and (axes := self.__last_axes):
             plot_rect = canvas_bounds.translated(plot_origin)
             self.__tracking_horizontal = True
             self.__tracking_rescale = rescale
@@ -1011,7 +1038,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def begin_tracking_vertical(self, pos: Geometry.IntPoint, rescale: bool) -> None:
         graph_area_canvas_bounds = self.__line_graph_area_stack.canvas_bounds
         v_axis_canvas_bounds = self.__line_graph_vertical_axis_group_canvas_item.canvas_bounds
-        if graph_area_canvas_bounds and v_axis_canvas_bounds and (axes := self._axes):
+        if graph_area_canvas_bounds and v_axis_canvas_bounds and (axes := self.__last_axes):
             plot_height = graph_area_canvas_bounds.height - 1
             self.__tracking_vertical = True
             self.__tracking_rescale = rescale
@@ -1036,8 +1063,9 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         delegate = self.delegate
         if not delegate:
             return False
+        graphic_selection = self.__line_plot_display_info.graphic_selection
         if self.__tracking_selections:
-            if self.__graphic_drag_item is None and not self.__graphic_drag_changed and self.__graphic_selection:
+            if self.__graphic_drag_item is None and not self.__graphic_drag_changed and graphic_selection:
                 widget_mapping = self.__get_mouse_mapping()
                 x = widget_mapping.map_point_widget_to_channel_norm(self.__graphic_drag_start_pos.to_float_point())
                 if not self.__pending_interval:
@@ -1054,8 +1082,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                     self.__undo_command = delegate.add_and_select_region(region)
                 else:
                     region = None
-                selection_indexes = self.__graphic_selection.indexes
-                for graphic_index, graphic in enumerate(self.__graphics):
+                selection_indexes = graphic_selection.indexes
+                for graphic_index, graphic in enumerate(self.__line_plot_display_info.graphics):
                     if graphic == region:
                         part, specific = graphic.test(widget_mapping, self.__ui_settings, pos.to_float_point(), False)
                         if part:
@@ -1104,7 +1132,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if not self.__undo_command:
                 self.__undo_command = delegate.create_change_display_command()
             v_axis_canvas_bounds = self.__line_graph_vertical_axis_group_canvas_item.canvas_bounds
-            axes = self._axes
+            axes = self.__last_axes
             if axes:
                 if v_axis_canvas_bounds and self.__tracking_rescale:
                     plot_origin = self.__line_graph_vertical_axis_group_canvas_item.map_to_canvas_item(Geometry.IntPoint(), self)
@@ -1137,8 +1165,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         if not self.__graphic_drag_items and not modifiers.control:
             delegate.clear_selection()
         if self.__tracking_selections and self.__graphic_drag_item:
-            graphics = self.__graphics
-            if self._axes and graphics is not None:
+            graphics = self.__line_plot_display_info.graphics
+            if self.__last_axes and graphics is not None:
                 for index in self.__graphic_drag_indexes:
                     graphic = graphics[index]
                     graphic.end_drag(self.__graphic_part_data[index])
@@ -1173,7 +1201,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
 
         if self.__mouse_in and self.__last_mouse:
             pos_1d = None
-            axes = self._axes
+            axes = self.__last_axes
             line_graph_layers_canvas_item = self.line_graph_layers_canvas_item
             if axes:
                 mouse = self.map_to_canvas_item(self.__last_mouse, line_graph_layers_canvas_item)
@@ -1205,9 +1233,16 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         if source_display_item:
             from_index = legend_data["index"]
             # if we aren't the source item, move the display layer between display items
-            command = self.delegate.create_move_display_layer_command(source_display_item, from_index, len(self.__display_layers))
+            command = self.delegate.create_move_display_layer_command(source_display_item, from_index, len(self.__line_plot_display_info.display_layers))
             # TODO: perform only if the display channel doesn't exist in the target
             command.perform()
             self.delegate.push_undo_command(command)
 
         return "ignore"
+
+    def _update_canvas_items_for_testing(self) -> None:
+        self.__update_canvas_items()
+
+    @property
+    def _axes_for_testing(self) -> LineGraphCanvasItem.LineGraphAxes | None:
+        return self.__line_plot_display_info.axes

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -44,15 +44,15 @@ def are_axes_equal(axes1: typing.Optional[LineGraphCanvasItem.LineGraphAxes], ax
         return False
     if axes1.drawn_right_channel != axes2.drawn_right_channel:
         return False
-    if axes1.mapped_calibrated_data_min != axes2.mapped_calibrated_data_min:
+    if axes1.scaled_data_min != axes2.scaled_data_min:
         return False
-    if axes1.mapped_calibrated_data_max != axes2.mapped_calibrated_data_max:
+    if axes1.scaled_data_max != axes2.scaled_data_max:
         return False
     if axes1.x_calibration != axes2.x_calibration:
         return False
     if axes1.y_calibration != axes2.y_calibration:
         return False
-    if axes1.data_style.style_id != axes2.data_style.style_id:
+    if axes1.axis_scale.axis_scale_id != axes2.axis_scale.axis_scale_id:
         return False
     return True
 
@@ -118,7 +118,7 @@ class LinePlotDisplayInfo:
         self.__display_calibration_info = display_calibration_info
         self.__y_min: float | None = display_properties.get("y_min", None)
         self.__y_max: float | None = display_properties.get("y_max", None)
-        self.__y_style: str | None = display_properties.get("y_style", "linear")
+        self.__y_axis_scale_id: str | None = display_properties.get("y_style", "linear")  # 'y_style' for backward compatibility
         self.__left_channel: int | None = display_properties.get("left_channel", None)
         self.__right_channel: int | None = display_properties.get("right_channel", None)
         self.__legend_position: str | None = display_properties.get("legend_position", None)
@@ -215,7 +215,7 @@ class LinePlotDisplayInfo:
             displayed_intensity_calibration = self.displayed_intensity_calibration
             y_min = self.__y_min
             y_max = self.__y_max
-            y_style = self.__y_style
+            y_axis_scale_id = self.__y_axis_scale_id
             left_channel_opt = self.__left_channel
             right_channel_opt = self.__right_channel
             data_scale = self.data_scale
@@ -234,18 +234,18 @@ class LinePlotDisplayInfo:
                 y_max_calibration = displayed_intensity_calibration.convert_to_calibrated_value(y_max)
             else:
                 y_max_calibration = None
-            mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis(xdata_list,
+            scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis(xdata_list,
                                                                                                       y_min_calibrated,
                                                                                                       y_max_calibration,
-                                                                                                      y_style)
+                                                                                                      y_axis_scale_id)
             self.__axes = LineGraphCanvasItem.LineGraphAxes(data_scale,
-                                                            mapped_calibrated_data_min,
-                                                            mapped_calibrated_data_max,
+                                                            scaled_data_min,
+                                                            scaled_data_max,
                                                             left_channel,
                                                             right_channel,
                                                             displayed_dimensional_calibration,
                                                             displayed_intensity_calibration,
-                                                            y_style,
+                                                            y_axis_scale_id,
                                                             y_ticker)
         return self.__axes
 
@@ -1017,12 +1017,12 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             self.__tracking_vertical = True
             self.__tracking_rescale = rescale
             self.__tracking_start_pos = pos
-            self.__tracking_start_calibrated_data_min = axes.mapped_calibrated_data_min
-            self.__tracking_start_calibrated_data_max = axes.mapped_calibrated_data_max
+            self.__tracking_start_calibrated_data_min = axes.scaled_data_min
+            self.__tracking_start_calibrated_data_max = axes.scaled_data_max
             self.__tracking_start_calibrated_data_per_pixel = (self.__tracking_start_calibrated_data_max - self.__tracking_start_calibrated_data_min) / plot_height
             plot_origin = self.__line_graph_vertical_axis_group_canvas_item.map_to_canvas_item(Geometry.IntPoint(), self)
             plot_rect = v_axis_canvas_bounds.translated(plot_origin)
-            if 0.0 >= self.__tracking_start_calibrated_data_min and 0.0 <= self.__tracking_start_calibrated_data_max and axes.data_style.style_id == "linear":
+            if 0.0 >= self.__tracking_start_calibrated_data_min and 0.0 <= self.__tracking_start_calibrated_data_max and axes.axis_scale.axis_scale_id == "linear":
                 calibrated_unit_per_pixel = (self.__tracking_start_calibrated_data_max - self.__tracking_start_calibrated_data_min) / (plot_rect.height - 1) if plot_rect.height > 1 else 1.0
                 calibrated_unit_per_pixel = calibrated_unit_per_pixel if calibrated_unit_per_pixel else 1.0  # handle case where calibrated_unit_per_pixel is zero
                 origin_offset_pixels = (0.0 - self.__tracking_start_calibrated_data_min) / calibrated_unit_per_pixel
@@ -1117,16 +1117,16 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                     new_calibrated_data_per_pixel = calibrated_offset / pixel_offset
                     calibrated_data_min = self.__tracking_start_calibrated_origin - new_calibrated_data_per_pixel * self.__tracking_start_origin_y
                     calibrated_data_max = self.__tracking_start_calibrated_origin + new_calibrated_data_per_pixel * (plot_rect.height - 1 - self.__tracking_start_origin_y)
-                    uncalibrated_data_min = axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_min)
-                    uncalibrated_data_max = axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_max)
+                    uncalibrated_data_min = axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min)
+                    uncalibrated_data_max = axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_max)
                     delegate.update_display_properties({"y_min": uncalibrated_data_min, "y_max": uncalibrated_data_max})
                     return True
                 else:
                     delta = pos - self.__tracking_start_pos
                     calibrated_data_min = self.__tracking_start_calibrated_data_min + self.__tracking_start_calibrated_data_per_pixel * delta.y
                     calibrated_data_max = self.__tracking_start_calibrated_data_max + self.__tracking_start_calibrated_data_per_pixel * delta.y
-                    uncalibrated_data_min = axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_min)
-                    uncalibrated_data_max = axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_max)
+                    uncalibrated_data_min = axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min)
+                    uncalibrated_data_max = axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_max)
                     delegate.update_display_properties({"y_min": uncalibrated_data_min, "y_max": uncalibrated_data_max})
                     return True
         return False

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -472,7 +472,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
     def line_graph_layers_canvas_item(self) -> LineGraphCanvasItem.LineGraphLayersCanvasItem:
         return self.__line_graph_layers_canvas_item
 
-    # for testing
     @property
     def _axes(self) -> typing.Optional[LineGraphCanvasItem.LineGraphAxes]:
         return self.__axes

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -560,9 +560,9 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             if self.__display_values_list:
                 for display_values in self.__display_values_list:
                     if display_values:
-                        display_data_and_metadata = display_values.display_data_and_metadata
-                        if display_data_and_metadata:
-                            self.__update_frame(display_data_and_metadata.metadata)
+                        data_metadata = display_values.element_data_metadata
+                        if data_metadata:
+                            self.__update_frame(data_metadata.metadata)
 
             # update the cursor info
             self.__update_cursor_info()

--- a/nion/swift/MetadataPanel.py
+++ b/nion/swift/MetadataPanel.py
@@ -178,8 +178,8 @@ class ThreadedCanvasItem(CanvasItem.CanvasItemComposition):
         self.__thread_future: typing.Optional[concurrent.futures.Future[None]] = None
         self.__closing = False
         self.__pending = False
-        self.__visible = False
         self.on_content_size_changed = content_size_changed_fn
+        self._is_visible = False  # managed by the panel
 
         self.__draw(DrawingContext.DrawingContext())
 
@@ -208,7 +208,7 @@ class ThreadedCanvasItem(CanvasItem.CanvasItemComposition):
                     with Process.audit("draw_thread"):
                         self.__draw(drawing_context)
             with self.__thread_lock:
-                if not self.__pending or not self.__visible:
+                if not self.__pending:
                     self.__thread_future = None
                     break
 
@@ -269,18 +269,9 @@ class ThreadedCanvasItem(CanvasItem.CanvasItemComposition):
     def _trigger(self) -> None:
         with self.__thread_lock:
             self.__pending = True  # pending even if not visible.
-            if self.root_container and (canvas_widget := getattr(self.root_container, "canvas_widget", None)):
-                self.__visible = typing.cast(UserInterface.DockWidget, typing.cast(UserInterface.CanvasWidget, canvas_widget).root_container).visible
-                if self.__visible:
-                    # only launch thread if visible and not already running.
-                    if not self.__thread_future:
-                        self.__thread_future = ThreadedCanvasItem._executor.submit(self.__draw_thread)
-
-    # def _repaint_template(self, drawing_context: DrawingContext.DrawingContext, immediate: bool) -> None:
-    #     start = time.perf_counter_ns()
-    #     super()._repaint_template(drawing_context, immediate)
-    #     end = time.perf_counter_ns()
-    #     print(f"repaint {(end - start) / 1000}us")
+            # only launch thread if visible and not already running.
+            if not self.__thread_future and self._is_visible:
+                self.__thread_future = ThreadedCanvasItem._executor.submit(self.__draw_thread)
 
 
 class ThreadHelper:
@@ -376,10 +367,18 @@ class MetadataPanel(Panel.Panel):
 
         def handle_will_show() -> None:
             # this is called when the dock widget is shown. we need to trigger the metadata editor to
-            # reconstruct its contents.
+            # reconstruct its contents. also mark the metadata editor as visible so the draw thread will run.
             self.__metadata_source_changed(self.__metadata_model.data_item)
+            self.__metadata_editor_canvas_item._is_visible = True
+
+        def handle_will_hide() -> None:
+            # this is called when the dock widget is hidden. we need to clear the metadata editor to free up resources.
+            # also mark the metadata editor as not visible so the draw thread will not run.
+            self.__metadata_source_changed(None)
+            self.__metadata_editor_canvas_item._is_visible = False
 
         self.dock_widget.on_will_show = handle_will_show
+        self.dock_widget.on_will_hide = handle_will_hide
 
     def __metadata_source_changed(self, metadata_source: MetadataSource | None) -> None:
         self.__delegate.metadata_source = metadata_source

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -818,11 +818,6 @@ class DisplayValues:
         return self.__data_and_metadata.data_metadata if self.__data_and_metadata else None
 
     @property
-    def display_rgba_timestamp(self) -> typing.Optional[datetime.datetime]:
-        data_metadata = self.data_metadata
-        return data_metadata.timestamp if data_metadata else None
-
-    @property
     def element_data_and_metadata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:
         return typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], self.__element_data_processor.get_result("data"))
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -513,6 +513,26 @@ class ElementDataProcessor(ProcessorBase):
                                                                              flag16=False)
         self.set_result("data", data_and_metadata)
 
+    def get_data_metadata(self) -> DataAndMetadata.DataMetadata | None:
+        maybe_data_and_metadata = self._get_parameter("data")
+        if isinstance(maybe_data_and_metadata, DataAndMetadata.DataAndMetadata):
+            data_metadata = maybe_data_and_metadata.data_metadata
+            display_data_shape_info = DisplayDataShapeCalculator(data_metadata)
+            display_data_shape = display_data_shape_info.shape
+            display_data_dimensional_calibrations = display_data_shape_info.calibrations
+            if display_data_shape and data_metadata.data_dtype:
+                return DataAndMetadata.DataMetadata(
+                    data_shape=display_data_shape,
+                    data_dtype=data_metadata.data_dtype,
+                    intensity_calibration=data_metadata.intensity_calibration,
+                    dimensional_calibrations=display_data_dimensional_calibrations,
+                    metadata=data_metadata.metadata,
+                    data_descriptor=DataAndMetadata.DataDescriptor(False, 0, len(display_data_shape)),
+                    timestamp=data_metadata.timestamp,
+                    timezone=data_metadata.timezone,
+                    timezone_offset=data_metadata.timezone_offset
+                )
+        return None
 
 class DisplayDataProcessor(ProcessorBase):
     def __init__(self, *,
@@ -816,6 +836,10 @@ class DisplayValues:
     @property
     def data_metadata(self) -> DataAndMetadata.DataMetadata | None:
         return self.__data_and_metadata.data_metadata if self.__data_and_metadata else None
+
+    @property
+    def element_data_metadata(self) -> DataAndMetadata.DataMetadata | None:
+        return self.__element_data_processor.get_data_metadata()
 
     @property
     def element_data_and_metadata(self) -> typing.Optional[DataAndMetadata.DataAndMetadata]:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2113,9 +2113,6 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
                 self.__display_properties = copy.deepcopy(new_display_properties)
                 self.__send_delta()
 
-    # def __get_xdata_list(self) -> typing.Sequence[typing.Optional[DataAndMetadata.DataAndMetadata]]:
-    #     return [display_values.data_and_metadata if display_values else None for display_values in list(self.__display_values_list)]
-
     def __update(self) -> None:
         display_values_list = self.__display_values_list
         dimensional_calibrations: typing.Optional[DataAndMetadata.CalibrationListType] = None

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -640,8 +640,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
@@ -658,8 +658,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         # notice: dragging increasing y drags down.
         line_plot_canvas_item = self.setup_line_plot(data_min=0.1, data_max=980)
         self.display_item.set_display_property("y_style", "log")
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
@@ -668,8 +668,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
-        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
-        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
 
     def test_mouse_tracking_moves_log_vertical_scale_with_calibrated_data_with_offset(self):
         # notice: dragging increasing y drags down.
@@ -679,8 +679,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
@@ -689,8 +689,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
-        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
-        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
 
     def test_mouse_tracking_moves_log_vertical_scale_with_calibrated_data_with_offset_and_scale(self):
         # notice: dragging increasing y drags down.
@@ -701,8 +701,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration.offset = 0.2
         intensity_calibration.scale = 1.6
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.mapped_calibrated_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
@@ -711,8 +711,8 @@ class TestDisplayPanelClass(unittest.TestCase):
         axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
-        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
-        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_mapped_calibrated_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
+        self.assertAlmostEqual(self.display_item.get_display_property("y_max"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_max + calibrated_offset))
 
     def test_mouse_tracking_shrink_scale_by_10_around_center(self):
         line_plot_canvas_item = self.setup_line_plot()

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -113,7 +113,6 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.display_canvas_item.layout_immediate(canvas_shape)
         self.display_panel_drawing_context = DrawingContext.DrawingContext()
         self.display_item = display_item_1d
-        self.display_panel.display_canvas_item._update_canvas_items_for_testing()
         self.display_panel.refresh_layout_immediate()
         return self.display_panel.display_canvas_item
 
@@ -641,7 +640,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
         calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
@@ -859,7 +858,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -880,7 +879,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.2)
         self.display_item.set_display_property("y_max", 0.8)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -903,7 +902,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = -0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -924,7 +923,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         # now stretch way past top
         pos = Geometry.IntPoint(x=30, y=20)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -944,7 +943,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
-        line_plot_canvas_item._update_canvas_items_for_testing()
+        line_plot_canvas_item._update_canvas_items()
         # now stretch way past top
         pos = Geometry.IntPoint(x=30, y=plot_height-20)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -964,7 +963,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         v = line_plot_canvas_item.line_graph_horizontal_axis_group_canvas_item.map_to_canvas_item(Geometry.IntPoint(), line_plot_canvas_item)[0] + 8
         line_plot_canvas_item.mouse_pressed(plot_left, v, CanvasItem.KeyboardModifiers(control=True))
         line_plot_canvas_item.mouse_position_changed(plot_left+96, v, CanvasItem.KeyboardModifiers(control=True))
-        line_plot_canvas_item._update_canvas_items_for_testing()  # update after the expansion, but before the move.
+        line_plot_canvas_item._update_canvas_items()  # update after the expansion, but before the move.
         # continue
         line_plot_canvas_item.mouse_position_changed(plot_left+96, v, CanvasItem.KeyboardModifiers())
         line_plot_canvas_item.mouse_position_changed(plot_left+196, v, CanvasItem.KeyboardModifiers())
@@ -1814,7 +1813,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 640))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(0, len(display_item.graphics))
@@ -1852,7 +1850,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.graphic_selection.set(0)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(1, len(display_item.graphics))
@@ -1927,7 +1924,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(0, len(display_item.graphics))
@@ -2027,7 +2023,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(100, 100))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             document_controller.tool_mode = "rectangle"
@@ -2067,7 +2062,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2095,7 +2089,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(line_plot_display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2130,7 +2123,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(line_plot_display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2166,7 +2158,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.append_display_data_channel(DisplayItem.DisplayDataChannel(data_item=data_item2))
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             line_plot_canvas_item = display_panel.display_canvas_item
@@ -2202,7 +2193,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(document_model.get_display_item_for_data_item(fft_data_item))
             document_model.recompute_all()
             display_panel.layout_immediate(Geometry.IntSize(200, 200))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # everything should be updated; the display values should not be dirty
@@ -2221,7 +2211,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(document_model.get_display_item_for_data_item(line_profile_data_item))
             document_model.recompute_all()
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # everything should be updated; the display values should not be dirty
@@ -2238,7 +2227,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             command = document_controller.create_remove_display_items_command([display_item])
@@ -2248,7 +2236,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             document_controller.handle_undo()
             # everything should be updated; the display values should not be dirty
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             self.assertTrue(display_panel.display_canvas_item._has_valid_drawn_graph_data)
 
@@ -2285,7 +2272,6 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_panel = document_controller.selected_display_panel
                 display_panel.set_display_panel_display_item(display_item)
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
-                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
             profile_context.project_properties["display_items"][2]["display_data_channels"][0]["data_item_reference"] = str(uuid.uuid4())
             document_controller = profile_context.create_document_controller(auto_close=False)
@@ -2293,7 +2279,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             with contextlib.closing(document_controller):
                 display_panel = document_controller.selected_display_panel
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
-                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
 
     def test_image_display_item_with_missing_data_item_fails_gracefully(self):
@@ -2312,7 +2297,6 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_panel = document_controller.selected_display_panel
                 display_panel.set_display_panel_display_item(display_item)
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
-                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
             profile_context.project_properties["display_items"][2]["display_data_channels"][0]["data_item_reference"] = str(uuid.uuid4())
             document_controller = profile_context.create_document_controller(auto_close=False)
@@ -2320,7 +2304,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             with contextlib.closing(document_controller):
                 display_panel = document_controller.selected_display_panel
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
-                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
 
     def test_append_display_data_channel_undo_redo_cycle(self):
@@ -2860,7 +2843,6 @@ class TestDisplayPanelClass(unittest.TestCase):
                 canvas_shape = (480, 640)
                 document_controller.show_display_item(display_item)
                 display_panel.display_canvas_item.layout_immediate(canvas_shape)
-                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
                 line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
                 interval_graphic = Graphics.IntervalGraphic()
@@ -2898,7 +2880,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -2937,7 +2918,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -2970,7 +2950,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -3009,7 +2988,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -3048,7 +3026,6 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -113,6 +113,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         self.display_panel.display_canvas_item.layout_immediate(canvas_shape)
         self.display_panel_drawing_context = DrawingContext.DrawingContext()
         self.display_item = display_item_1d
+        self.display_panel.display_canvas_item._update_canvas_items_for_testing()
         self.display_panel.refresh_layout_immediate()
         return self.display_panel.display_canvas_item
 
@@ -640,6 +641,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
         calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
@@ -857,6 +859,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -877,6 +880,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.2)
         self.display_item.set_display_property("y_max", 0.8)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -899,6 +903,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = -0.2
         data_item.set_intensity_calibration(intensity_calibration)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         # now stretch 1/2 + 100 to 1/2 + 150
         pos = Geometry.IntPoint(x=30, y=plot_bottom-320)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -919,6 +924,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         # now stretch way past top
         pos = Geometry.IntPoint(x=30, y=20)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -938,6 +944,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         # adjust image panel display and trigger layout
         self.display_item.set_display_property("y_min", -0.5)
         self.display_item.set_display_property("y_max", 0.5)
+        line_plot_canvas_item._update_canvas_items_for_testing()
         # now stretch way past top
         pos = Geometry.IntPoint(x=30, y=plot_height-20)
         modifiers = CanvasItem.KeyboardModifiers()
@@ -957,6 +964,7 @@ class TestDisplayPanelClass(unittest.TestCase):
         v = line_plot_canvas_item.line_graph_horizontal_axis_group_canvas_item.map_to_canvas_item(Geometry.IntPoint(), line_plot_canvas_item)[0] + 8
         line_plot_canvas_item.mouse_pressed(plot_left, v, CanvasItem.KeyboardModifiers(control=True))
         line_plot_canvas_item.mouse_position_changed(plot_left+96, v, CanvasItem.KeyboardModifiers(control=True))
+        line_plot_canvas_item._update_canvas_items_for_testing()  # update after the expansion, but before the move.
         # continue
         line_plot_canvas_item.mouse_position_changed(plot_left+96, v, CanvasItem.KeyboardModifiers())
         line_plot_canvas_item.mouse_position_changed(plot_left+196, v, CanvasItem.KeyboardModifiers())
@@ -1806,6 +1814,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 640))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(0, len(display_item.graphics))
@@ -1843,6 +1852,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.graphic_selection.set(0)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(1, len(display_item.graphics))
@@ -1917,6 +1927,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             self.assertEqual(0, len(display_item.graphics))
@@ -2016,6 +2027,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(100, 100))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             document_controller.tool_mode = "rectangle"
@@ -2055,6 +2067,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2082,6 +2095,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(line_plot_display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2116,6 +2130,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(line_plot_display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # verify setup
@@ -2151,6 +2166,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.append_display_data_channel(DisplayItem.DisplayDataChannel(data_item=data_item2))
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(240, 1000))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             line_plot_canvas_item = display_panel.display_canvas_item
@@ -2186,6 +2202,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(document_model.get_display_item_for_data_item(fft_data_item))
             document_model.recompute_all()
             display_panel.layout_immediate(Geometry.IntSize(200, 200))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # everything should be updated; the display values should not be dirty
@@ -2204,6 +2221,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(document_model.get_display_item_for_data_item(line_profile_data_item))
             document_model.recompute_all()
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             # everything should be updated; the display values should not be dirty
@@ -2220,6 +2238,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             document_controller.periodic()
             command = document_controller.create_remove_display_items_command([display_item])
@@ -2229,6 +2248,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             document_controller.handle_undo()
             # everything should be updated; the display values should not be dirty
             display_panel.layout_immediate(Geometry.IntSize(1000, 200))
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             self.assertTrue(display_panel.display_canvas_item._has_valid_drawn_graph_data)
 
@@ -2265,6 +2285,7 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_panel = document_controller.selected_display_panel
                 display_panel.set_display_panel_display_item(display_item)
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
+                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
             profile_context.project_properties["display_items"][2]["display_data_channels"][0]["data_item_reference"] = str(uuid.uuid4())
             document_controller = profile_context.create_document_controller(auto_close=False)
@@ -2272,6 +2293,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             with contextlib.closing(document_controller):
                 display_panel = document_controller.selected_display_panel
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
+                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
 
     def test_image_display_item_with_missing_data_item_fails_gracefully(self):
@@ -2290,6 +2312,7 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_panel = document_controller.selected_display_panel
                 display_panel.set_display_panel_display_item(display_item)
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
+                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
             profile_context.project_properties["display_items"][2]["display_data_channels"][0]["data_item_reference"] = str(uuid.uuid4())
             document_controller = profile_context.create_document_controller(auto_close=False)
@@ -2297,6 +2320,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             with contextlib.closing(document_controller):
                 display_panel = document_controller.selected_display_panel
                 display_panel.layout_immediate(Geometry.IntSize(200, 200))
+                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
 
     def test_append_display_data_channel_undo_redo_cycle(self):
@@ -2836,6 +2860,7 @@ class TestDisplayPanelClass(unittest.TestCase):
                 canvas_shape = (480, 640)
                 document_controller.show_display_item(display_item)
                 display_panel.display_canvas_item.layout_immediate(canvas_shape)
+                display_panel.display_canvas_item._update_canvas_items_for_testing()
                 display_panel.display_canvas_item.refresh_layout_immediate()
                 line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
                 interval_graphic = Graphics.IntervalGraphic()
@@ -2847,7 +2872,7 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 display_item.graphic_selection.set(0)
                 line_plot_canvas_item.handle_auto_display()
-                axes = line_plot_canvas_item._axes
+                axes = line_plot_canvas_item._axes_for_testing
                 self.assertAlmostEqual(axes.drawn_left_channel, (min(interval) - padding) * 1024)
                 self.assertAlmostEqual(axes.drawn_right_channel, (max(interval) + padding) * 1024)
 
@@ -2873,6 +2898,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -2883,7 +2909,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.add_graphic(interval_graphic)
             display_item.graphic_selection.set(0)
             line_plot_canvas_item.handle_auto_display()
-            axes = line_plot_canvas_item._axes
+            axes = line_plot_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.drawn_left_channel, 0)
             self.assertAlmostEqual(axes.drawn_right_channel, 12)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(48.0) * 1.2, axes.uncalibrated_data_max)
@@ -2911,11 +2937,12 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
             line_plot_canvas_item.handle_auto_display()
-            axes = line_plot_canvas_item._axes
+            axes = line_plot_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.drawn_left_channel, 0.0)  # no interval selected, so no padding
             self.assertAlmostEqual(axes.drawn_right_channel, 12.0)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(96.0) * 1.2, axes.uncalibrated_data_max)
@@ -2943,6 +2970,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -2953,7 +2981,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.add_graphic(interval_graphic)
             display_item.graphic_selection.set(0)
             line_plot_canvas_item.handle_auto_display()
-            axes = line_plot_canvas_item._axes
+            axes = line_plot_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.drawn_left_channel, 0)
             self.assertAlmostEqual(axes.drawn_right_channel, 12)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(3.0) * 1.2, axes.uncalibrated_data_max)
@@ -2981,6 +3009,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -2991,7 +3020,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             display_item.add_graphic(interval_graphic)
             display_item.graphic_selection.set(0)
             line_plot_canvas_item.handle_auto_display()
-            axes = line_plot_canvas_item._axes
+            axes = line_plot_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.drawn_left_channel, 0)
             self.assertAlmostEqual(axes.drawn_right_channel, 12)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(10.0) * 1.2, axes.uncalibrated_data_max)
@@ -3019,6 +3048,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             canvas_shape = (480, 640)
             document_controller.show_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate(canvas_shape)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.display_canvas_item.refresh_layout_immediate()
             line_plot_canvas_item = typing.cast(LinePlotCanvasItem.LinePlotCanvasItem, display_panel.display_canvas_item)
 
@@ -3032,7 +3062,7 @@ class TestDisplayPanelClass(unittest.TestCase):
                 display_item.add_graphic(interval_graphic)
                 display_item.graphic_selection.add(display_item.graphics.index(interval_graphic))
             line_plot_canvas_item.handle_auto_display()
-            axes = line_plot_canvas_item._axes
+            axes = line_plot_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.drawn_left_channel, 1)
             self.assertAlmostEqual(axes.drawn_right_channel, 17)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(26.0) * 1.2, axes.uncalibrated_data_max)

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -602,13 +602,13 @@ class TestDisplayPanelClass(unittest.TestCase):
 
     def test_line_plot_initially_displays_entire_data_in_horizontal_direction(self):
         line_plot_canvas_item = self.setup_line_plot()
-        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes.drawn_left_channel, 0)
-        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes.drawn_right_channel, 1024)
+        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.drawn_left_channel, 0)
+        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.drawn_right_channel, 1024)
 
     def test_line_plot_initially_displays_entire_data_in_vertical_direction(self):
         line_plot_canvas_item = self.setup_line_plot()
-        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes.uncalibrated_data_min, 0.0)
-        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes.uncalibrated_data_max, 1.0)
+        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.uncalibrated_data_min, 0.0)
+        self.assertEqual(line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.uncalibrated_data_max, 1.0)
 
     def test_mouse_tracking_moves_horizontal_scale(self):
         line_plot_canvas_item = self.setup_line_plot()
@@ -640,15 +640,15 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
         line_plot_canvas_item.continue_tracking(Geometry.IntPoint(x=30, y=240), modifiers)
         line_plot_canvas_item.end_tracking(modifiers)
-        uncalibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.uncalibrated_data_min
-        uncalibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.uncalibrated_data_max
+        uncalibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.uncalibrated_data_min
+        uncalibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.uncalibrated_data_max
         uncalibrated_data_range = uncalibrated_data_max - uncalibrated_data_min
         offset = -uncalibrated_data_range * 30.0 / plot_height
         self.assertAlmostEqual(self.display_item.get_display_property("y_min"), calibrated_data_min + offset - intensity_calibration.offset)
@@ -658,14 +658,14 @@ class TestDisplayPanelClass(unittest.TestCase):
         # notice: dragging increasing y drags down.
         line_plot_canvas_item = self.setup_line_plot(data_min=0.1, data_max=980)
         self.display_item.set_display_property("y_style", "log")
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
         line_plot_canvas_item.continue_tracking(Geometry.IntPoint(x=30, y=240), modifiers)
         line_plot_canvas_item.end_tracking(modifiers)
-        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
+        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
         self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
@@ -679,14 +679,14 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration = data_item.intensity_calibration
         intensity_calibration.offset = 0.2
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
         line_plot_canvas_item.continue_tracking(Geometry.IntPoint(x=30, y=240), modifiers)
         line_plot_canvas_item.end_tracking(modifiers)
-        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
+        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
         self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))
@@ -701,14 +701,14 @@ class TestDisplayPanelClass(unittest.TestCase):
         intensity_calibration.offset = 0.2
         intensity_calibration.scale = 1.6
         data_item.set_intensity_calibration(intensity_calibration)
-        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_min
-        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes.scaled_data_max
+        calibrated_data_min = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_min
+        calibrated_data_max = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing.scaled_data_max
         plot_height = line_plot_canvas_item.line_graph_layers_canvas_item.canvas_rect.height - 1
         modifiers = CanvasItem.KeyboardModifiers()
         line_plot_canvas_item.begin_tracking_vertical(Geometry.IntPoint(x=30, y=270), rescale=False)
         line_plot_canvas_item.continue_tracking(Geometry.IntPoint(x=30, y=240), modifiers)
         line_plot_canvas_item.end_tracking(modifiers)
-        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes
+        axes = line_plot_canvas_item.line_graph_layers_canvas_item._axes_for_testing
         calibrated_data_range = calibrated_data_max - calibrated_data_min
         calibrated_offset = -calibrated_data_range * 30.0 / plot_height
         self.assertAlmostEqual(self.display_item.get_display_property("y_min"), axes.convert_scaled_y_value_to_uncalibrated_value(calibrated_data_min + calibrated_offset))

--- a/nion/swift/test/InfoPanel_test.py
+++ b/nion/swift/test/InfoPanel_test.py
@@ -127,6 +127,7 @@ class TestInfoPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             header_height = display_panel.header_canvas_item.header_height
             info_panel = document_controller.find_dock_panel("info-panel")
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((1000 + header_height, 1000))
             line_graph_layer_canvas_item = next(i for i in display_panel.canvas_items_at_point(500, 500) if isinstance(i, LineGraphCanvasItem.LineGraphLayerCanvasItem))
             p1 = line_graph_layer_canvas_item.map_to_canvas_item(Geometry.IntPoint(500, 20), display_panel.display_canvas_item)

--- a/nion/swift/test/InfoPanel_test.py
+++ b/nion/swift/test/InfoPanel_test.py
@@ -127,9 +127,8 @@ class TestInfoPanelClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             header_height = display_panel.header_canvas_item.header_height
             info_panel = document_controller.find_dock_panel("info-panel")
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((1000 + header_height, 1000))
-            line_graph_layer_canvas_item = next(i for i in display_panel.canvas_items_at_point(500, 500) if isinstance(i, LineGraphCanvasItem.LineGraphLayerCanvasItem))
+            line_graph_layer_canvas_item = display_panel.display_canvas_item.line_graph_layers_canvas_item
             p1 = line_graph_layer_canvas_item.map_to_canvas_item(Geometry.IntPoint(500, 20), display_panel.display_canvas_item)
             p2 = line_graph_layer_canvas_item.map_to_canvas_item(Geometry.IntPoint(500, 70), display_panel.display_canvas_item)
             p3 = line_graph_layer_canvas_item.map_to_canvas_item(Geometry.IntPoint(500, 140), display_panel.display_canvas_item)

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -11,7 +11,6 @@ import numpy
 # local libraries
 from nion.data import Calibration
 from nion.data import DataAndMetadata
-from nion.swift import Application
 from nion.swift import LineGraphCanvasItem
 from nion.swift import LinePlotCanvasItem
 from nion.swift.model import DataItem
@@ -193,6 +192,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # run test
             self.assertEqual(document_controller.tool_mode, "pointer")
@@ -215,6 +215,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -236,6 +237,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             region.end = 0.95
             display_item.add_graphic(region)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -257,6 +259,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             region.end = 0.9
             display_item.add_graphic(region)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -278,8 +281,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
-            axes = display_panel.display_canvas_item._axes
+            axes = display_panel.display_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.scaled_data_min, 0.0)
             self.assertAlmostEqual(axes.scaled_data_max, 80.0)
             self.assertAlmostEqual(axes.uncalibrated_data_min, 0.0)
@@ -297,8 +301,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
-            axes = display_panel.display_canvas_item._axes
+            axes = display_panel.display_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.scaled_data_min, 0.0)
             self.assertAlmostEqual(axes.scaled_data_max, 40.0)
             self.assertAlmostEqual(axes.uncalibrated_data_min, 0.0)
@@ -315,8 +320,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
-            axes = display_panel.display_canvas_item._axes
+            axes = display_panel.display_canvas_item._axes_for_testing
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
@@ -338,8 +344,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_item.set_display_property("y_style", "log")
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
-            axes = display_panel.display_canvas_item._axes
+            axes = display_panel.display_canvas_item._axes_for_testing
             self.assertEqual(axes.axis_scale.axis_scale_id, "log")
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
@@ -361,6 +368,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_calculates_calibrated_vs_uncalibrated_display_y_values(self):
@@ -373,9 +381,11 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.full((8, ), 10)))
             display_item.intensity_calibration_style_id = "uncalibrated"
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.ones((8, ))))
 
@@ -389,9 +399,11 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units, "nm")
             display_item.calibration_style_id = "pixels-top-left"
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units)
 
@@ -404,6 +416,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             display_panel.display_canvas_item.simulate_click((240, 16))
 
@@ -419,8 +432,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
-            axes = display_panel.display_canvas_item._axes
+            axes = display_panel.display_canvas_item._axes_for_testing
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
@@ -440,6 +454,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_with_too_few_layers_displays_gracefully(self):
@@ -458,6 +473,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             self.assertEqual(4, len(display_item.display_layers))
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_displays_gracefully_when_switching_layers(self):
@@ -471,6 +487,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
             display_item.display_type = "line_plot"
+            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             display_item.display_type = None
             display_panel.layout_immediate((640, 480))

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -374,10 +374,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
-            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.data, numpy.full((8, ), 10)))
+            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.full((8, ), 10)))
             display_item.intensity_calibration_style_id = "uncalibrated"
             display_panel.layout_immediate((640, 480))
-            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.data, numpy.ones((8, ))))
+            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.ones((8, ))))
 
     def test_line_plot_handles_calibrated_vs_uncalibrated_display(self):
         with TestContext.create_memory_context() as test_context:
@@ -390,10 +390,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
-            self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.dimensional_calibrations[-1].units, "nm")
+            self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units, "nm")
             display_item.calibration_style_id = "pixels-top-left"
             display_panel.layout_immediate((640, 480))
-            self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.dimensional_calibrations[-1].units)
+            self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units)
 
     def test_line_plot_with_no_data_handles_clicks(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -84,8 +84,8 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             data[:] = data_min + (data_max - data_min) * (irow / 15.0)
             # auto on min/max
             xdata = DataAndMetadata.new_data_and_metadata(data)
-            mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, None)
-            axes = LineGraphCanvasItem.LineGraphAxes(1.0, mapped_calibrated_data_min, mapped_calibrated_data_max, 0, 100, None, None, None, y_ticker)
+            scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, None)
+            axes = LineGraphCanvasItem.LineGraphAxes(1.0, scaled_data_min, scaled_data_max, 0, 100, None, None, None, y_ticker)
             self.assertEqual(axes.uncalibrated_data_min, expected_uncalibrated_data_min)
             self.assertEqual(axes.uncalibrated_data_max, expected_uncalibrated_data_max)
 
@@ -103,17 +103,17 @@ class TestLineGraphCanvasItem(unittest.TestCase):
         for data_in, data_out in test_ranges:
             with self.subTest(data_in=data_in, data_out=data_out):
                 data = numpy.linspace(data_in[0], data_in[1], 100, endpoint=False)
-                data_style = "log"
+                axis_scale_id = "log"
                 xdata = DataAndMetadata.new_data_and_metadata(data)
-                mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, data_style)
-                axes = LineGraphCanvasItem.LineGraphAxes(1.0, mapped_calibrated_data_min, mapped_calibrated_data_max, 0, 100, None, None, data_style, y_ticker)
+                scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, axis_scale_id)
+                axes = LineGraphCanvasItem.LineGraphAxes(1.0, scaled_data_min, scaled_data_max, 0, 100, None, None, axis_scale_id, y_ticker)
                 self.assertAlmostEqual(axes.uncalibrated_data_min, data_out[0], places=1)
                 self.assertAlmostEqual(axes.uncalibrated_data_max, data_out[1], places=1)
-                mapped_calibrated_data = axes.convert_uncalibrated_array_to_mapped_calibrated_values(DataAndMetadata.new_data_and_metadata(data)).data
-                assert mapped_calibrated_data is not None
+                scaled_data = axes.convert_calibrated_array_to_scaled_array(DataAndMetadata.new_data_and_metadata(data)).data
+                assert scaled_data is not None
                 data[data <= 0] = numpy.nan
-                self.assertAlmostEqual(numpy.nanmin(mapped_calibrated_data), math.log10(numpy.nanmin(data)))
-                self.assertAlmostEqual(numpy.nanmax(mapped_calibrated_data), math.log10(numpy.nanmax(data)))
+                self.assertAlmostEqual(numpy.nanmin(scaled_data), math.log10(numpy.nanmin(data)))
+                self.assertAlmostEqual(numpy.nanmax(scaled_data), math.log10(numpy.nanmax(data)))
 
     def test_display_limits_are_reasonable_when_using_calibrated_log_scale(self):
 
@@ -130,42 +130,42 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             with self.subTest(data_in=data_in, data_out=data_out):
                 data = numpy.linspace(data_in[0], data_in[1], 100, endpoint=False)
                 intensity_calibration = Calibration.Calibration(-5, 2)
-                data_style = "log"
+                axis_scale_id = "log"
                 xdata = DataAndMetadata.new_data_and_metadata(data, intensity_calibration=intensity_calibration)
-                mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, data_style)
-                axes = LineGraphCanvasItem.LineGraphAxes(1.0, mapped_calibrated_data_min, mapped_calibrated_data_max, 0, 100, None, intensity_calibration, data_style, y_ticker)
+                scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, axis_scale_id)
+                axes = LineGraphCanvasItem.LineGraphAxes(1.0, scaled_data_min, scaled_data_max, 0, 100, None, intensity_calibration, axis_scale_id, y_ticker)
                 self.assertAlmostEqual(axes.uncalibrated_data_min, data_out[0], places=1)
                 self.assertAlmostEqual(axes.uncalibrated_data_max, data_out[1], places=1)
-                mapped_calibrated_data = axes.convert_uncalibrated_array_to_mapped_calibrated_values(DataAndMetadata.new_data_and_metadata(data)).data
-                assert mapped_calibrated_data is not None
+                scaled_data = axes.convert_calibrated_array_to_scaled_array(DataAndMetadata.new_data_and_metadata(data)).data
+                assert scaled_data is not None
                 data[data <= 0] = numpy.nan
-                self.assertAlmostEqual(numpy.nanmin(mapped_calibrated_data), math.log10(numpy.nanmin(data)))
-                self.assertAlmostEqual(numpy.nanmax(mapped_calibrated_data), math.log10(numpy.nanmax(data)))
+                self.assertAlmostEqual(numpy.nanmin(scaled_data), math.log10(numpy.nanmin(data)))
+                self.assertAlmostEqual(numpy.nanmax(scaled_data), math.log10(numpy.nanmax(data)))
 
     def test_line_plot_with_negative_lower_display_limit_in_log_scale_displays_reasonable_limits(self):
         # tests that entering a invalid lower display limit (negative) still results in a mapped calibrated data limits.
         data = numpy.linspace(0, 10, 100, endpoint=False)
         intensity_calibration = Calibration.Calibration()
         xdata = DataAndMetadata.new_data_and_metadata(data, intensity_calibration=intensity_calibration)
-        mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], -2, 12, "log")
+        scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], -2, 12, "log")
         # the mapped calibrated data min should be 0.0 (a reasonable value for negative data)
         # the unmapped mapped calibrated data max should match the upper display limit (12).
-        self.assertAlmostEqual(0.0, mapped_calibrated_data_min)
-        self.assertAlmostEqual(12.0, math.pow(10, mapped_calibrated_data_max))
+        self.assertAlmostEqual(0.0, scaled_data_min)
+        self.assertAlmostEqual(12.0, math.pow(10, scaled_data_max))
 
     def test_line_plot_with_log_scale_displays_integers(self):
         data = numpy.array([1,2,3], dtype=int)
-        data_style = "log"
+        axis_scale_id = "log"
         xdata = DataAndMetadata.new_data_and_metadata(data)
         # at some point, calculate_y_axis failed to return without exception when the data type was int.
         # so the main point of this test is to ensure that the function returns without exception.
-        mapped_calibrated_data_min, mapped_calibrated_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, data_style)
+        scaled_data_min, scaled_data_max, y_ticker = LineGraphCanvasItem.calculate_y_axis([xdata], None, None, axis_scale_id)
         # the asserts below are a sanity check to ensure that the function is returning reasonable values.
         # note: these are calibrated values for the AXES not the original data. furthermore they will be log10.
         # so checking that the first value is negative (original axes value is less than 1), and the second value
         # is positive (original axes value is greater than 1) is a reasonable check.
-        self.assertLess(mapped_calibrated_data_min, 0.0)
-        self.assertGreater(mapped_calibrated_data_max, 0.0)
+        self.assertLess(scaled_data_min, 0.0)
+        self.assertGreater(scaled_data_max, 0.0)
 
     def test_graph_segments_are_calculated_correctly_with_nans(self):
         # this was a bug in the original implementation
@@ -176,7 +176,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
         data[3:] = range(3,16,1)
         segments, baseline = LineGraphCanvasItem.calculate_line_graph(
             100, 32, 0, 0, DataAndMetadata.new_data_and_metadata(data),
-            0, 16, 0, 16, Calibration.Calibration(), None, LineGraphCanvasItem._get_data_style("linear")
+            0, 16, 0, 16, Calibration.Calibration(), None, LineGraphCanvasItem._get_axis_scale("linear")
         )
         self.assertEqual(2, len(segments))
         # make a rough check to ensure that the first segment is minimal; and the second one has some content.
@@ -280,8 +280,8 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes
-            self.assertAlmostEqual(axes.mapped_calibrated_data_min, 0.0)
-            self.assertAlmostEqual(axes.mapped_calibrated_data_max, 80.0)
+            self.assertAlmostEqual(axes.scaled_data_min, 0.0)
+            self.assertAlmostEqual(axes.scaled_data_max, 80.0)
             self.assertAlmostEqual(axes.uncalibrated_data_min, 0.0)
             self.assertAlmostEqual(axes.uncalibrated_data_max, 80.0)
 
@@ -299,8 +299,8 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes
-            self.assertAlmostEqual(axes.mapped_calibrated_data_min, 0.0)
-            self.assertAlmostEqual(axes.mapped_calibrated_data_max, 40.0)
+            self.assertAlmostEqual(axes.scaled_data_min, 0.0)
+            self.assertAlmostEqual(axes.scaled_data_max, 40.0)
             self.assertAlmostEqual(axes.uncalibrated_data_min, 0.0)
             self.assertAlmostEqual(axes.uncalibrated_data_max, 80.0)
 
@@ -340,7 +340,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes
-            self.assertEqual(axes.data_style.style_id, "log")
+            self.assertEqual(axes.axis_scale.axis_scale_id, "log")
             drawing_context = DrawingContext.DrawingContext()
             line_graph_layer = LineGraphCanvasItem.LineGraphLayer(data_item.xdata, axes, Color.Color("black"), Color.Color("black"), None)
             canvas_bounds = Geometry.IntRect.from_tlbr(0, 0, 480, 640)
@@ -374,10 +374,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
-            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.mapped_calibrated_xdata.data, numpy.full((8, ), 10)))
+            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.data, numpy.full((8, ), 10)))
             display_item.intensity_calibration_style_id = "uncalibrated"
             display_panel.layout_immediate((640, 480))
-            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.mapped_calibrated_xdata.data, numpy.ones((8, ))))
+            self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.data, numpy.ones((8, ))))
 
     def test_line_plot_handles_calibrated_vs_uncalibrated_display(self):
         with TestContext.create_memory_context() as test_context:
@@ -390,10 +390,10 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
-            self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item.mapped_calibrated_xdata.dimensional_calibrations[-1].units, "nm")
+            self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.dimensional_calibrations[-1].units, "nm")
             display_item.calibration_style_id = "pixels-top-left"
             display_panel.layout_immediate((640, 480))
-            self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item.mapped_calibrated_xdata.dimensional_calibrations[-1].units)
+            self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item.scaled_xdata.dimensional_calibrations[-1].units)
 
     def test_line_plot_with_no_data_handles_clicks(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -192,7 +192,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # run test
             self.assertEqual(document_controller.tool_mode, "pointer")
@@ -215,7 +214,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -237,7 +235,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             region.end = 0.95
             display_item.add_graphic(region)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -259,7 +256,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             region.end = 0.9
             display_item.add_graphic(region)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             # test
             document_controller.tool_mode = "pointer"
@@ -281,7 +277,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.scaled_data_min, 0.0)
@@ -301,7 +296,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes_for_testing
             self.assertAlmostEqual(axes.scaled_data_min, 0.0)
@@ -320,7 +314,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes_for_testing
             drawing_context = DrawingContext.DrawingContext()
@@ -344,7 +337,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_item.set_display_property("y_style", "log")
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes_for_testing
             self.assertEqual(axes.axis_scale.axis_scale_id, "log")
@@ -368,7 +360,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_calculates_calibrated_vs_uncalibrated_display_y_values(self):
@@ -381,11 +372,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.full((8, ), 10)))
             display_item.intensity_calibration_style_id = "uncalibrated"
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertTrue(numpy.array_equal(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.data, numpy.ones((8, ))))
 
@@ -399,11 +388,9 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertEqual(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units, "nm")
             display_item.calibration_style_id = "pixels-top-left"
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             self.assertFalse(display_panel.display_canvas_item.line_graph_layers_canvas_item._scaled_xdata_for_testing.dimensional_calibrations[-1].units)
 
@@ -416,7 +403,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             display_panel.display_canvas_item.simulate_click((240, 16))
 
@@ -432,7 +418,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             document_model.append_data_item(data_item)
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             axes = display_panel.display_canvas_item._axes_for_testing
             drawing_context = DrawingContext.DrawingContext()
@@ -454,7 +439,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item.display_type = "line_plot"
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_with_too_few_layers_displays_gracefully(self):
@@ -473,7 +457,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             self.assertEqual(4, len(display_item.display_layers))
             display_panel = document_controller.selected_display_panel
             display_panel.set_display_panel_display_item(display_item)
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
 
     def test_line_plot_displays_gracefully_when_switching_layers(self):
@@ -487,7 +470,6 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.layout_immediate((640, 480))
             display_item.display_type = "line_plot"
-            display_panel.display_canvas_item._update_canvas_items_for_testing()
             display_panel.layout_immediate((640, 480))
             display_item.display_type = None
             display_panel.layout_immediate((640, 480))
@@ -522,18 +504,17 @@ class TestLineGraphCanvasItem(unittest.TestCase):
             display_item = document_model.get_display_item_for_data_item(data_item)
             display_panel.set_display_panel_display_item(display_item)
 
-            lp_ci = _find_first_descendant_of_type_postorder(
-                display_panel,
-                LinePlotCanvasItem.LinePlotCanvasItem)
+            display_panel.layout_immediate((960, 1200))
+
+            lp_ci = display_panel.display_canvas_item
             lp_graph_frame_ci = _find_first_descendant_of_type_postorder(
-                display_panel,
+                display_panel.display_canvas_item,
                 LineGraphCanvasItem.LineGraphFrameCanvasItem
             )
             lp_vert_axis_scale_ci = _find_first_descendant_of_type_postorder(
-                display_panel,
+                display_panel.display_canvas_item,
                 LineGraphCanvasItem.LineGraphVerticalAxisScaleCanvasItem
             )
-            display_panel.layout_immediate((960, 1200))
 
             # _print_canvas_item_tree_preorder(display_panel)
 


### PR DESCRIPTION
**IMPORTANT: REQUIRES THE PR BELOW**
- https://github.com/nion-software/nionui/pull/131

---

- **Remove unused line plot field (__last_xdata_list).**
- **Simplify the metadata visible optimization.**
- **Remove unused method (DisplayValues.display_rgba_timestamp).**
- **Remove unused commented-out code.**
- **Rename 'mapped_calibrated' to 'scaled' and 'data style' to 'axis scale' in line plot display.**
- **Eliminate main thread use of DisplayValues.display_data_and_metadata. Use only metadata instead.**
- **Denote methods directly accessing data as testing only.**
- **Restructure line plot canvas item state tracking.**
- **Change display panel to wrap display canvas items in threaded canvas item.**

This changes prepares for display computations (e.g. y x^2).

This change should not have any behavior changes.

Each commit has been audited by copilot.