### PR TITLE
Consolidate data calibration handling, particularly in inspector and histogram

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -1027,90 +1027,6 @@ class MissingDisplayCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         return False
 
 
-class DisplayTracker:
-    """Tracks messages from a display and passes them to associated display canvas item."""
-
-    def __init__(self, display_item: DisplayItem.DisplayItem, ui_settings: UISettings.UISettings,
-                 delegate: DisplayCanvasItem.DisplayCanvasItemDelegate, event_loop: asyncio.AbstractEventLoop,
-                 draw_background: bool) -> None:
-        self.__display_item = display_item
-        self.__ui_settings = ui_settings
-        self.__delegate = delegate
-        self.__event_loop = event_loop
-        self.__draw_background = draw_background
-        self.__closing_lock = threading.RLock()
-
-        # callbacks
-        self.on_clear_display: typing.Optional[typing.Callable[[], None]] = None
-        self.on_title_changed: typing.Optional[typing.Callable[[str], None]] = None
-        self.on_replace_display_canvas_item: typing.Optional[typing.Callable[[DisplayCanvasItem.DisplayCanvasItem], None]] = None
-
-        def clear_display() -> None:
-            if callable(self.on_clear_display):
-                self.on_clear_display()
-
-        def display_item_property_changed(key: str) -> None:
-            if key == "displayed_title":
-                if callable(self.on_title_changed):
-                    self.on_title_changed(display_item.displayed_title)
-
-        self.__display_about_to_be_removed_event_listener = display_item.about_to_be_removed_event.listen(clear_display)
-        self.__display_property_changed_event_listener = display_item.property_changed_event.listen(display_item_property_changed)
-
-        # ensure data stays in memory while displayed
-        display_item.increment_display_ref_count()
-
-        # create a canvas item and add it to the container canvas item.
-
-        self.__display_canvas_item = create_display_canvas_item(display_item, ui_settings, delegate, event_loop, draw_background=self.__draw_background)
-
-        def handle_display_data_delta(display_data_delta: DisplayItem.DisplayDataDelta | None) -> None:
-            # This is called when the display data delta stream produces a new value. The value is passed on to the
-            # display canvas item.
-            with self.__closing_lock:
-                assert display_data_delta
-                self.__display_canvas_item.update_display_data_delta(display_data_delta)
-
-        self.__display_data_delta_stream = display_item.display_data_delta_stream
-        self.__display_data_delta_stream_action = Stream.ValueStreamAction(self.__display_data_delta_stream, handle_display_data_delta)
-        self.__display_type: str | None = None
-
-        def handle_display_changed(display_item: DisplayItem.DisplayItem) -> None:
-            # This is called in response to a display change event, which may indicate a change in the display type.
-            # If the display type changes, update the display canvas item and the display data delta stream listener.
-            display_type = display_item.used_display_type
-            if self.__display_type != display_type:
-                self.__display_type = display_type
-                new_display_canvas_item = create_display_canvas_item(display_item, ui_settings, self.__delegate, self.__event_loop, draw_background=self.__draw_background)
-                if callable(self.on_replace_display_canvas_item):
-                    self.on_replace_display_canvas_item(new_display_canvas_item)
-                self.__display_canvas_item = new_display_canvas_item
-                # force an update of the display canvas item with the current display data delta by marking it changed.
-                display_data_delta = self.__display_data_delta_stream.value
-                assert display_data_delta
-                display_data_delta.mark_changed()
-                handle_display_data_delta(display_data_delta)
-
-        # set up a listener to handle display type changes.
-        self.__display_changed_event_listener = display_item.display_changed_event.listen(functools.partial(handle_display_changed, display_item))
-
-        # initial update
-        handle_display_changed(display_item)
-
-    def close(self) -> None:
-        with self.__closing_lock:  # ensures that display pipeline finishes
-            # decrement the ref count on the old item to release it from memory if no longer used.
-            self.__display_item.decrement_display_ref_count()
-            self.__display_about_to_be_removed_event_listener = typing.cast(typing.Any, None)
-            self.__display_property_changed_event_listener = typing.cast(typing.Any, None)
-            self.__display_canvas_item = typing.cast(typing.Any, None)
-            self.__display_data_delta_stream_action = typing.cast(typing.Any, None)
-
-    @property
-    def display_canvas_item(self) -> DisplayCanvasItem.DisplayCanvasItem:
-        return self.__display_canvas_item
-
-
 class InsertGraphicsCommand(Undo.UndoableCommand):
 
     def __init__(self, document_controller: DocumentController.DocumentController,
@@ -2001,8 +1917,14 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
         ui = document_controller.ui
 
+        self.__display_canvas_item: DisplayCanvasItem.DisplayCanvasItem | None = None
         self.__display_item: typing.Optional[DisplayItem.DisplayItem] = None
-        self.__display_tracker: typing.Optional[DisplayTracker] = None
+        self.__display_data_delta_stream: DisplayItem.DisplayDataDeltaStream | None = None
+        self.__display_data_delta_stream_action: Stream.ValueStreamAction[DisplayItem.DisplayDataDelta] | None = None
+        self.__display_type: str | None = None
+        self.__display_changed_event_listener: Event.EventListener | None = None
+        self.__display_about_to_be_removed_event_listener: Event.EventListener | None = None
+        self.__display_property_changed_event_listener: Event.EventListener | None = None
         self.__data_item_reference_changed_event_listener: typing.Optional[Event.EventListener] = None
         self.__data_item_reference_changed_task: typing.Optional[asyncio.Task[None]] = None
 
@@ -2012,7 +1934,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         # used for the (optional) display canvas item
         self.__closing_lock = threading.RLock()
 
-        self.__display_item_value_stream = Stream.ValueStream[DisplayItem.DisplayItem]().add_ref()
+        self.__display_item_value_stream = Stream.ValueStream[DisplayItem.DisplayItem]()
 
         self.__related_icons_canvas_item: typing.Optional[RelatedIconsCanvasItem] = None
 
@@ -2185,11 +2107,10 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             self.__data_item_reference_changed_event_listener.close()
             self.__data_item_reference_changed_event_listener = None
 
-        self.__display_item_value_stream.remove_ref()
-        self.__display_item_value_stream = typing.cast(typing.Any, None)
-
         with self.__closing_lock:  # ensures that display pipeline finishes
             self.set_display_item(None)  # required before destructing display thread
+
+        self.__display_item_value_stream = typing.cast(typing.Any, None)
 
         # NOTE: the enclosing canvas item should be closed AFTER this close is called.
         self.__set_display_panel_controller(None)
@@ -2254,8 +2175,8 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         return self.__identifier
 
     @property
-    def display_canvas_item(self) -> typing.Optional[DisplayCanvasItem.DisplayCanvasItem]:
-        return self.__display_tracker.display_canvas_item if self.__display_tracker else None
+    def display_canvas_item(self) -> DisplayCanvasItem.DisplayCanvasItem | None:
+        return self.__display_canvas_item
 
     @property
     def display_panel_type(self) -> str:
@@ -2490,73 +2411,107 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
         old_display_items = copy.copy(self.__display_items)
 
-        did_display_change = self.__display_item != display_item
+        if display_item != self.__display_item:
+            document_controller = self.__document_controller
+            document_model = document_controller.document_model
 
-        if did_display_change:
+            def add_display_controls(display_canvas_item: DisplayCanvasItem.DisplayCanvasItem) -> None:
+                related_icons_canvas_item = RelatedIconsCanvasItem(self.ui, document_model,
+                                                                   self.__display_item_value_stream,
+                                                                   self.document_controller.drag)
+                sequence_slider_row = IndexValueSliderCanvasItem(_("S"),
+                                                                 self.__display_item_value_stream,
+                                                                 SequenceIndexAdapter(self.document_controller),
+                                                                 self.ui.get_font_metrics,
+                                                                 self.__document_controller.event_loop,
+                                                                 self.__playback_controller.handle_play_button,
+                                                                 self.__playback_controller.is_movie_playing)
+                c0_slider_row = IndexValueSliderCanvasItem(_("C0"),
+                                                           self.__display_item_value_stream,
+                                                           CollectionIndexAdapter(self.document_controller, 0),
+                                                           self.ui.get_font_metrics,
+                                                           self.__document_controller.event_loop)
+                c1_slider_row = IndexValueSliderCanvasItem(_("C1"),
+                                                           self.__display_item_value_stream,
+                                                           CollectionIndexAdapter(self.document_controller, 1),
+                                                           self.ui.get_font_metrics,
+                                                           self.__document_controller.event_loop)
+                display_canvas_item.add_display_control(related_icons_canvas_item, "related_icons")
+                display_canvas_item.add_display_control(sequence_slider_row)
+                display_canvas_item.add_display_control(c0_slider_row)
+                display_canvas_item.add_display_control(c1_slider_row)
+                self.__related_icons_canvas_item = related_icons_canvas_item
 
-            # remove any existing display canvas item
-            self.__display_composition_canvas_item.remove_all_canvas_items()
+            def clear_display() -> None:
+                self.set_display_panel_display_item(None, True)
 
-            old_display_tracker = self.__display_tracker
-            self.__display_tracker = None
-
-            if display_item:
-                def clear_display() -> None:
-                    self.set_display_panel_display_item(None, True)
-
-                def handle_title_changed(title: str) -> None:
+            def display_item_property_changed(key: str) -> None:
+                if key == "displayed_title":
                     self.__update_title()
 
-                def add_display_controls(display_canvas_item: DisplayCanvasItem.DisplayCanvasItem) -> None:
-                    related_icons_canvas_item = RelatedIconsCanvasItem(self.ui, self.get_document_model(),
-                                                                       self.__display_item_value_stream,
-                                                                       self.document_controller.drag)
-                    sequence_slider_row = IndexValueSliderCanvasItem(_("S"),
-                                                                     self.__display_item_value_stream,
-                                                                     SequenceIndexAdapter(self.document_controller),
-                                                                     self.ui.get_font_metrics,
-                                                                     self.__document_controller.event_loop,
-                                                                     self.__playback_controller.handle_play_button,
-                                                                     self.__playback_controller.is_movie_playing)
-                    c0_slider_row = IndexValueSliderCanvasItem(_("C0"),
-                                                               self.__display_item_value_stream,
-                                                               CollectionIndexAdapter(self.document_controller, 0),
-                                                               self.ui.get_font_metrics,
-                                                               self.__document_controller.event_loop)
-                    c1_slider_row = IndexValueSliderCanvasItem(_("C1"),
-                                                               self.__display_item_value_stream,
-                                                               CollectionIndexAdapter(self.document_controller, 1),
-                                                               self.ui.get_font_metrics,
-                                                               self.__document_controller.event_loop)
-                    display_canvas_item.add_display_control(related_icons_canvas_item, "related_icons")
-                    display_canvas_item.add_display_control(sequence_slider_row)
-                    display_canvas_item.add_display_control(c0_slider_row)
-                    display_canvas_item.add_display_control(c1_slider_row)
-                    self.__related_icons_canvas_item = related_icons_canvas_item
+            def handle_display_data_delta(display_data_delta: DisplayItem.DisplayDataDelta | None) -> None:
+                # This is called when the display data delta stream produces a new value. The value is passed on to the
+                # display canvas item.
+                if display_data_delta is not None and self.__display_canvas_item is not None:
+                    self.__display_canvas_item.update_display_data_delta(display_data_delta)
 
-                def replace_display_canvas_item(new_display_canvas_item: DisplayCanvasItem.DisplayCanvasItem) -> None:
-                    self.__display_composition_canvas_item.remove_all_canvas_items()
+            def handle_display_changed(display_item: DisplayItem.DisplayItem) -> None:
+                # This is called in response to a display change event, which may indicate a change in the display type.
+                # If the display type changes, update the display canvas item and the display data delta stream listener.
+                display_type = display_item.used_display_type
+                if self.__display_type != display_type:
+                    configure_display_canvas_item(display_item)
+
+            def configure_display_canvas_item(display_item: DisplayItem.DisplayItem | None) -> None:
+                # Clear the existing display canvas item and display item listeners.
+                self.__display_canvas_item = None
+                self.__display_type = None
+                self.__display_data_delta_stream = None
+                self.__display_data_delta_stream_action = None
+                self.__display_changed_event_listener = None
+                self.__display_about_to_be_removed_event_listener = None
+                self.__display_property_changed_event_listener = None
+                self.__display_composition_canvas_item.remove_all_canvas_items()
+
+                if display_item:
+                    # update the display type so we can know when it changes.
+                    self.__display_type = display_item.used_display_type
+                    ui_settings = DisplayPanelUISettings(self.ui)
+                    self.__display_about_to_be_removed_event_listener = display_item.about_to_be_removed_event.listen(clear_display)
+                    self.__display_property_changed_event_listener = display_item.property_changed_event.listen(display_item_property_changed)
+                    new_display_canvas_item = create_display_canvas_item(display_item, ui_settings, self, document_controller.event_loop, True)
                     threaded_canvas_item = CanvasItem.ThreadedCanvasItem(new_display_canvas_item)
                     threaded_canvas_item.on_will_repaint = new_display_canvas_item._update_canvas_items
                     self.__display_composition_canvas_item.add_canvas_item(threaded_canvas_item)
                     add_display_controls(new_display_canvas_item)
                     # whenever focus or the display canvas item changes, update the focused status
                     new_display_canvas_item.set_focused(self.__content_canvas_item.focused)
+                    self.__display_canvas_item = new_display_canvas_item
+                    # configure the display data stream and listener to update the display canvas item when the display data changes.
+                    display_data_delta_stream = display_item.display_data_delta_stream
+                    display_data_delta_stream_action = Stream.ValueStreamAction(display_data_delta_stream, handle_display_data_delta)
+                    self.__display_data_delta_stream = display_data_delta_stream
+                    self.__display_data_delta_stream_action = display_data_delta_stream_action
+                    # set up a listener to handle display type changes.
+                    self.__display_changed_event_listener = display_item.display_changed_event.listen(functools.partial(handle_display_changed, display_item))
+                    # force an update of the display canvas item with the current display data delta by marking it changed.
+                    display_data_delta = display_data_delta_stream.value
+                    assert display_data_delta
+                    display_data_delta.mark_changed()
+                    handle_display_data_delta(display_data_delta)
 
-                self.__display_tracker = DisplayTracker(display_item, DisplayPanelUISettings(self.ui), self, self.__document_controller.event_loop, True)
-                self.__display_tracker.on_clear_display = clear_display
-                self.__display_tracker.on_title_changed = handle_title_changed
-                self.__display_tracker.on_replace_display_canvas_item = replace_display_canvas_item
+            configure_display_canvas_item(display_item)
 
-                new_display_canvas_item = self.__display_tracker.display_canvas_item
-                threaded_canvas_item = CanvasItem.ThreadedCanvasItem(new_display_canvas_item)
-                threaded_canvas_item.on_will_repaint = new_display_canvas_item._update_canvas_items
-                self.__display_composition_canvas_item.add_canvas_item(threaded_canvas_item)
-                add_display_controls(new_display_canvas_item)
+            # Ensure data stays in memory while displayed. Do this before decrementing the old display item's ref
+            # count in case the new display item is the same as the old display item.
+            if display_item:
+                display_item.increment_display_ref_count()
 
-            if old_display_tracker:
-                old_display_tracker.close()
+            # Decrement the ref count on the old item to release it from memory if no longer used.
+            if self.__display_item:
+                self.__display_item.decrement_display_ref_count()
 
+            # Store the new display.
             self.__display_item = display_item
 
             self.__playback_controller.display_data_channel = self.display_item.display_data_channel if self.display_item else None
@@ -2576,8 +2531,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         # setting the related icons canvas item is costly and can cause stuttering in operations
         # as simple as dragging a background selection in a background subtracted line plot as it
         # recalculates thumbnails on the main thread.
-        if did_display_change and self.__display_item_value_stream:
-            self.__display_item_value_stream.value = display_item
+        self.__display_item_value_stream.value = display_item
 
         self.__update_title()
 
@@ -2840,9 +2794,8 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
     def _context_menu_event_for_testing(self, x: int, y: int) -> bool:
         canvas_items = list[CanvasItem.AbstractCanvasItem]()
-        if self.__display_tracker:
-            display_canvas_item = self.__display_tracker.display_canvas_item
-            canvas_items = display_canvas_item.canvas_items_at_point(x, y)
+        if self.__display_canvas_item:
+            canvas_items = self.__display_canvas_item.canvas_items_at_point(x, y)
         canvas_items.extend(self.canvas_items_at_point(x, y))
         for canvas_item in canvas_items:
             canvas_item_point = self.map_to_canvas_item(Geometry.IntPoint(y=y, x=x), canvas_item)

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -543,36 +543,6 @@ def is_valid_display_type(display_type: str) -> bool:
     return display_type in ("image", "line_plot")
 
 
-class DisplayTypeMonitor:
-    """Monitor a display for changes to the display type.
-
-    Provides the display_type_changed(display_type) event.
-
-    Provides the display_type r/o property.
-    """
-
-    def __init__(self, display_item: DisplayItem.DisplayItem) -> None:
-        self.display_type_changed_event = Event.Event()
-        self.__display_changed_event_listener: typing.Optional[Event.EventListener] = None
-        self.__display_type: typing.Optional[str] = None
-        self.__first = True  # handle case where there is no data, so display_type is always None and doesn't change
-        if display_item:
-            self.__display_changed_event_listener = display_item.display_changed_event.listen(functools.partial(self.__update_display_type, display_item))
-        self.__update_display_type(display_item)
-
-    def close(self) -> None:
-        if self.__display_changed_event_listener:
-            self.__display_changed_event_listener.close()
-            self.__display_changed_event_listener = None
-
-    def __update_display_type(self, display_item: DisplayItem.DisplayItem) -> None:
-        display_type = display_item.used_display_type if display_item else None
-        if self.__display_type != display_type or self.__first:
-            self.__display_type = display_type
-            self.display_type_changed_event.fire(display_type)
-            self.__first = False
-
-
 class DisplayDataChannelValueStream(Stream.ValueStream[DisplayItem.DisplayDataChannel]):
     def __init__(self, display_item_value_stream: Stream.ValueStream[DisplayItem.DisplayItem]) -> None:
         super().__init__()
@@ -1094,45 +1064,44 @@ class DisplayTracker:
 
         self.__display_canvas_item = create_display_canvas_item(display_item, ui_settings, delegate, event_loop, draw_background=self.__draw_background)
 
-        def handle_display_data_delta(display_data_delta: typing.Optional[DisplayItem.DisplayDataDelta]) -> None:
+        def handle_display_data_delta(display_data_delta: DisplayItem.DisplayDataDelta | None) -> None:
+            # This is called when the display data delta stream produces a new value. The value is passed on to the
+            # display canvas item.
             with self.__closing_lock:
                 assert display_data_delta
                 self.__display_canvas_item.update_display_data_delta(display_data_delta)
 
-        self.__display_data_delta_stream_action = Stream.ValueStreamAction[DisplayItem.DisplayDataDelta](display_item.display_data_delta_stream, handle_display_data_delta)
+        self.__display_data_delta_stream = display_item.display_data_delta_stream
+        self.__display_data_delta_stream_action = Stream.ValueStreamAction(self.__display_data_delta_stream, handle_display_data_delta)
+        self.__display_type: str | None = None
 
-        def display_type_changed(display_type: typing.Optional[str]) -> None:
-            # called when the display type of the data item changes.
-            self.__display_data_delta_stream_action = typing.cast(typing.Any, None)
-            new_display_canvas_item = create_display_canvas_item(display_item, ui_settings, self.__delegate, self.__event_loop, draw_background=self.__draw_background)
-            if callable(self.on_replace_display_canvas_item):
-                self.on_replace_display_canvas_item(new_display_canvas_item)
-            self.__display_canvas_item = new_display_canvas_item
-            self.__display_data_delta_stream_action = Stream.ValueStreamAction[DisplayItem.DisplayDataDelta](display_item.display_data_delta_stream, handle_display_data_delta)
-            display_data_delta = display_item.display_data_delta_stream.value
-            assert display_data_delta
-            display_data_delta.mark_changed()
-            handle_display_data_delta(display_data_delta)
+        def handle_display_changed(display_item: DisplayItem.DisplayItem) -> None:
+            # This is called in response to a display change event, which may indicate a change in the display type.
+            # If the display type changes, update the display canvas item and the display data delta stream listener.
+            display_type = display_item.used_display_type
+            if self.__display_type != display_type:
+                self.__display_type = display_type
+                new_display_canvas_item = create_display_canvas_item(display_item, ui_settings, self.__delegate, self.__event_loop, draw_background=self.__draw_background)
+                if callable(self.on_replace_display_canvas_item):
+                    self.on_replace_display_canvas_item(new_display_canvas_item)
+                self.__display_canvas_item = new_display_canvas_item
+                # force an update of the display canvas item with the current display data delta by marking it changed.
+                display_data_delta = self.__display_data_delta_stream.value
+                assert display_data_delta
+                display_data_delta.mark_changed()
+                handle_display_data_delta(display_data_delta)
 
-        self.__display_type_monitor = DisplayTypeMonitor(display_item)
-        self.__display_type_changed_event_listener =  self.__display_type_monitor.display_type_changed_event.listen(display_type_changed)
+        # set up a listener to handle display type changes.
+        self.__display_changed_event_listener = display_item.display_changed_event.listen(functools.partial(handle_display_changed, display_item))
 
-        display_data_delta = display_item.display_data_delta_stream.value
-        assert display_data_delta
-        display_data_delta.mark_changed()
-        handle_display_data_delta(display_data_delta)
+        # initial update
+        handle_display_changed(display_item)
 
     def close(self) -> None:
         with self.__closing_lock:  # ensures that display pipeline finishes
-            self.__display_type_changed_event_listener.close()
-            self.__display_type_changed_event_listener = typing.cast(typing.Any, None)
-            self.__display_type_monitor.close()
-            self.__display_type_monitor = typing.cast(typing.Any, None)
             # decrement the ref count on the old item to release it from memory if no longer used.
             self.__display_item.decrement_display_ref_count()
-            self.__display_about_to_be_removed_event_listener.close()
             self.__display_about_to_be_removed_event_listener = typing.cast(typing.Any, None)
-            self.__display_property_changed_event_listener.close()
             self.__display_property_changed_event_listener = typing.cast(typing.Any, None)
             self.__display_canvas_item = typing.cast(typing.Any, None)
             self.__display_data_delta_stream_action = typing.cast(typing.Any, None)

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -1818,9 +1818,11 @@ class DocumentController(Window.Window):
         if display_item:
             mime_data = self.ui.create_mime_data()
 
-            # copy the data item as an svg
+            # copy the data item as SVG
 
-            if display_item.display_data_shape and len(display_item.display_data_shape) == 2:
+            display_calibration_info = display_item.display_calibration_info
+            display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+            if display_data_shape and len(display_data_shape) == 2:
                 display_shape = Geometry.IntSize(height=800, width=800)
             else:
                 display_shape = Geometry.IntSize(height=600, width=800)

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -322,8 +322,10 @@ def calculate_display_size_in_pixels(display_item: DisplayItem.DisplayItem) -> G
 
     If the display item is a line plot, use the hardcoded value of 5x3 inches.
     """
-    if display_item.display_data_shape and display_item.used_display_type != "line_plot":
-        return Geometry.IntSize(height=display_item.display_data_shape[-2], width=display_item.display_data_shape[-1])
+    display_calibration_info = display_item.display_calibration_info
+    display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+    if display_data_shape and display_item.used_display_type != "line_plot":
+        return Geometry.IntSize(height=display_data_shape[-2], width=display_data_shape[-1])
     return Geometry.IntSize(
         height=round(inch_unit_description.convert_value_to_pixels(3.0)),
         width=round(inch_unit_description.convert_value_to_pixels(5.0))

--- a/nion/swift/Facade.py
+++ b/nion/swift/Facade.py
@@ -1341,9 +1341,10 @@ class DataItem(metaclass=SharedInstance):
         display_data_channel = self.__display_item.display_data_channel
         if display_data_channel:
             shape = display_data_channel.display_data_shape
-            if shape is not None:
-                calibrated_origin = Geometry.FloatPoint(y=self.__display_item.datum_calibrations[0].convert_from_calibrated_value(0.0),
-                                                        x=self.__display_item.datum_calibrations[1].convert_from_calibrated_value(0.0))
+            display_calibration_info = self.__display_item.display_calibration_info
+            if shape is not None and display_calibration_info is not None:
+                calibrated_origin = Geometry.FloatPoint(y=display_calibration_info.datum_calibrations[0].convert_from_calibrated_value(0.0),
+                                                        x=display_calibration_info.datum_calibrations[1].convert_from_calibrated_value(0.0))
                 mask = Graphics.create_mask_data(self.__display_item.graphics, shape, calibrated_origin)
                 return DataAndMetadata.new_data_and_metadata(data=mask)
         return None

--- a/nion/swift/HistogramPanel.py
+++ b/nion/swift/HistogramPanel.py
@@ -832,7 +832,7 @@ class HistogramPanel(Panel.Panel):
         display_data_and_metadata_stream = DisplayValuesValueStream[DataAndMetadata.DataAndMetadata](display_values_stream, "display_data_and_metadata", cmp=compare_data)
         display_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "display_range")
         display_data_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "data_range")
-        displayed_intensity_calibration_stream = Stream.MapStream[DisplayItem.DisplayCalibrationInfo, Calibration.Calibration](DisplayCalibrationInfoStream(display_item_stream), extract_displayed_intensity_calibration)
+        displayed_intensity_calibration_stream = Stream.MapStream[DisplayItem.DisplayCalibrationInfo, Calibration.Calibration](DisplayItem.DisplayCalibrationInfoStream(display_item_stream), extract_displayed_intensity_calibration)
 
         self._histogram_processor = HistogramProcessor(document_controller.event_loop)
 
@@ -922,29 +922,6 @@ class TargetDisplayItemStream(Stream.AbstractStream[DisplayItem.DisplayItem]):
         if display_item != self.__value:
             self.__value = display_item
             self.value_stream.fire(display_item)
-
-
-class DisplayCalibrationInfoStream(Stream.ValueStream[DisplayItem.DisplayCalibrationInfo]):
-    def __init__(self, display_item_stream: TargetDisplayItemStream) -> None:
-        super().__init__()
-        self.__display_item_stream = display_item_stream.add_ref()
-        self.__display_stream_listener = display_item_stream.value_stream.listen(ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__display_item_changed, self))
-        self.__display_data_delta_stream_action: typing.Optional[Stream.ValueStreamAction[DisplayItem.DisplayDataDelta]] = None
-        self.__display_item_changed(display_item_stream.value)
-
-    def __display_item_changed(self, display_item: typing.Optional[DisplayItem.DisplayItem]) -> None:
-        if display_item:
-            self.__display_data_delta_stream_action = Stream.ValueStreamAction(display_item.display_data_delta_stream, ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__handle_display_data_delta_stream, self))
-            self.__handle_display_data_delta_stream(display_item.display_data_delta_stream.value)
-        else:
-            self.__display_data_delta_stream_action = None
-            self.__handle_display_data_delta_stream(None)
-
-    def __handle_display_data_delta_stream(self, value: typing.Optional[DisplayItem.DisplayDataDelta]) -> None:
-        if value:
-            self.value_stream.fire(value.display_calibration_info)
-        else:
-            self.value_stream.fire(None)
 
 
 class TargetRegionStream(Stream.AbstractStream[Graphics.Graphic]):

--- a/nion/swift/HistogramPanel.py
+++ b/nion/swift/HistogramPanel.py
@@ -827,13 +827,20 @@ class HistogramPanel(Panel.Panel):
             return display_calibration_info.displayed_intensity_calibration if display_calibration_info else None
 
         display_item_stream = TargetDisplayItemStream(document_controller)
+        display_item = display_item_stream.value
         display_data_channel_stream = StreamPropertyStream[DisplayItem.DisplayDataChannel](typing.cast(Stream.AbstractStream[Observable.Observable], display_item_stream), "display_data_channel")
         display_values_stream = DisplayDataChannelDisplayValuesStream(display_data_channel_stream)
         display_data_and_metadata_stream = DisplayValuesValueStream[DataAndMetadata.DataAndMetadata](display_values_stream, "display_data_and_metadata", cmp=compare_data)
         display_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "display_range")
         display_data_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "data_range")
-        display_calibration_info_stream = DisplayItem.DisplayCalibrationInfoStream(display_item_stream)
+        display_calibration_info_stream = Stream.FollowStream[DisplayItem.DisplayCalibrationInfo](display_item.display_calibration_info_stream if display_item else None)
         displayed_intensity_calibration_stream = Stream.MapStream[DisplayItem.DisplayCalibrationInfo, Calibration.Calibration](display_calibration_info_stream, extract_displayed_intensity_calibration)
+
+        # configure the display_calibration_info_stream to update when the display item changes, since the calibration info stream is based on the display item stream.
+        def handle_display_item_changed(display_item: DisplayItem.DisplayItem | None) -> None:
+            display_calibration_info_stream.stream = display_item.display_calibration_info_stream if display_item else None
+
+        self.__display_item_stream_action = Stream.ValueStreamAction(display_item_stream, handle_display_item_changed)
 
         self._histogram_processor = HistogramProcessor(document_controller.event_loop)
 

--- a/nion/swift/HistogramPanel.py
+++ b/nion/swift/HistogramPanel.py
@@ -832,7 +832,8 @@ class HistogramPanel(Panel.Panel):
         display_data_and_metadata_stream = DisplayValuesValueStream[DataAndMetadata.DataAndMetadata](display_values_stream, "display_data_and_metadata", cmp=compare_data)
         display_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "display_range")
         display_data_range_stream = DisplayValuesValueStream[typing.Tuple[float, float]](display_values_stream, "data_range")
-        displayed_intensity_calibration_stream = Stream.MapStream[DisplayItem.DisplayCalibrationInfo, Calibration.Calibration](DisplayItem.DisplayCalibrationInfoStream(display_item_stream), extract_displayed_intensity_calibration)
+        display_calibration_info_stream = DisplayItem.DisplayCalibrationInfoStream(display_item_stream)
+        displayed_intensity_calibration_stream = Stream.MapStream[DisplayItem.DisplayCalibrationInfo, Calibration.Calibration](display_calibration_info_stream, extract_displayed_intensity_calibration)
 
         self._histogram_processor = HistogramProcessor(document_controller.event_loop)
 
@@ -854,8 +855,9 @@ class HistogramPanel(Panel.Panel):
             if not canvas_x:
                 document_controller.cursor_changed(None)
             if display_item_stream and display_item_stream.value and canvas_x:
-                if display_range is not None:  # can be None with empty data
-                    displayed_intensity_calibration = display_item_stream.value.displayed_intensity_calibration
+                display_calibration_info = display_calibration_info_stream.value
+                if display_range is not None and display_calibration_info is not None:  # can be None with empty data
+                    displayed_intensity_calibration = display_calibration_info.displayed_intensity_calibration
                     adjusted_x = display_range[0] + canvas_x * (display_range[1] - display_range[0])
                     adjusted_x_str = displayed_intensity_calibration.convert_to_calibrated_value_str(adjusted_x)
                     document_controller.cursor_changed([_('Intensity: ') + adjusted_x_str])

--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -150,8 +150,8 @@ class ImageCanvasItemMapping(Graphics.CoordinateMappingLike):
 
 class GraphicsCanvasItemComposer(CanvasItem.BaseComposer):
     def __init__(self, canvas_item: CanvasItem.AbstractCanvasItem, layout_sizing: CanvasItem.Sizing, cache: CanvasItem.ComposerCache,
-                 ui_settings: UISettings.UISettings, graphics: typing.List[Graphics.Graphic], graphic_selection: DisplayItem.GraphicSelection,
-                 displayed_shape: typing.Optional[DataAndMetadata.ShapeType], coordinate_system: typing.List[Calibration.Calibration],
+                 ui_settings: UISettings.UISettings, graphics: typing.Sequence[Graphics.Graphic], graphic_selection: DisplayItem.GraphicSelection,
+                 displayed_shape: typing.Optional[DataAndMetadata.ShapeType], coordinate_system: typing.Sequence[Calibration.Calibration],
                  is_focused: bool) -> None:
         super().__init__(canvas_item, layout_sizing, cache)
         self.__ui_settings = ui_settings
@@ -193,10 +193,10 @@ class GraphicsCanvasItem(CanvasItem.AbstractCanvasItem):
         super().__init__()
         self.__ui_settings = ui_settings
         self.__displayed_shape: typing.Optional[DataAndMetadata.ShapeType] = None
-        self.__graphics: typing.List[Graphics.Graphic] = list()
-        self.__graphics_for_compare: list[tuple[uuid.UUID, int]] = list()
+        self.__graphics: typing.Sequence[Graphics.Graphic] = tuple()
+        self.__graphics_for_compare: typing.Sequence[tuple[uuid.UUID, int]] = tuple()
         self.__graphic_selection = DisplayItem.GraphicSelection()
-        self.__coordinate_system: typing.List[Calibration.Calibration] = list()
+        self.__coordinate_system: typing.Sequence[Calibration.Calibration] = tuple()
         self.__is_focused = False
 
     @property
@@ -211,11 +211,11 @@ class GraphicsCanvasItem(CanvasItem.AbstractCanvasItem):
     def update_coordinate_system(self, displayed_shape: typing.Optional[DataAndMetadata.ShapeType], coordinate_system: typing.Sequence[Calibration.Calibration], graphics: typing.Sequence[Graphics.Graphic], graphic_selection: DisplayItem.GraphicSelection) -> None:
         needs_update = False
         if coordinate_system != self.__coordinate_system:
-            self.__coordinate_system = list(coordinate_system)
+            self.__coordinate_system = tuple(coordinate_system)
             needs_update = True
         if displayed_shape is None or len(displayed_shape) != 2:
             displayed_shape = None
-            graphics = list()
+            graphics = tuple()
             graphic_selection = DisplayItem.GraphicSelection()
         assert displayed_shape is None or len(displayed_shape) == 2
         if ((self.__displayed_shape is None) != (displayed_shape is None)) or (self.__displayed_shape != displayed_shape):
@@ -223,7 +223,7 @@ class GraphicsCanvasItem(CanvasItem.AbstractCanvasItem):
             needs_update = True
         graphics_for_compare = [(graphic.uuid, graphic.modified_count) for graphic in graphics]
         if graphics_for_compare != self.__graphics_for_compare:
-            self.__graphics = list(graphics)
+            self.__graphics = tuple(graphics)
             self.__graphics_for_compare = graphics_for_compare
             needs_update = True
         if self.__graphic_selection != graphic_selection:
@@ -1243,7 +1243,7 @@ class ImageCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__pending_display_values_lock = threading.RLock()
         self.__pending_display_values = list[DisplayItem.DisplayValues]()
         self.__data_shape: typing.Optional[DataAndMetadata.Shape2dType] = None
-        self.__coordinate_system: typing.List[Calibration.Calibration] = list()
+        self.__coordinate_system: typing.Sequence[Calibration.Calibration] = tuple()
         self.__graphics: typing.List[Graphics.Graphic] = list()
         self.__graphic_selection: DisplayItem.GraphicSelection = DisplayItem.GraphicSelection()
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2489,156 +2489,6 @@ class RadianToDegreeStringConverter(Converter.ConverterLike[float, str]):
         return None
 
 
-class CalibratedValueFloatToStringConverter(Converter.ConverterLike[float, str]):
-    """Converter object to convert from calibrated value to string and back.
-
-    If uniform is true, the converter will fall back to uncalibrated value if the calibrations have
-    different units.
-
-    This class does the conversion based on the display item, which may change (i.e. calibration style).
-    No attempt is made to keep this class up to date, and it must be recreated or updated when the display item changes.
-    """
-    def __init__(self, display_item: DisplayItem.DisplayItem, index: int, uniform: bool = False) -> None:
-        self.__display_item = display_item
-        self.__index = index
-        self.__uniform = uniform
-
-    def __get_calibration(self) -> Calibration.Calibration:
-        index = self.__index
-        display_calibration_info = self.__display_item.display_calibration_info
-        calibrations = display_calibration_info.displayed_display_data_calibrations if display_calibration_info else None
-        if not calibrations:
-            return Calibration.Calibration()
-        if self.__uniform:
-            unit_set = set(calibration.units if calibration.units else '' for calibration in calibrations)
-            if len(unit_set) > 1:
-                return Calibration.Calibration()
-        dimension_count = len(calibrations)
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count:
-            return calibrations[index]
-        else:
-            return Calibration.Calibration()
-
-    def get_units(self) -> str:
-        return self.__get_calibration().units
-
-    def __get_data_size(self) -> int:
-        index = self.__index
-        display_calibration_info = self.__display_item.display_calibration_info
-        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count and display_data_shape is not None:
-            return display_data_shape[index]
-        else:
-            return 1
-
-    def convert_calibrated_value_to_str(self, calibrated_value: float) -> str:
-        calibration = self.__get_calibration()
-        return calibration.convert_calibrated_value_to_str(calibrated_value)
-
-    def convert_to_calibrated_value(self, value: float) -> float:
-        calibration = self.__get_calibration()
-        data_size = self.__get_data_size()
-        return calibration.convert_to_calibrated_value(data_size * value)
-
-    def convert_from_calibrated_value(self, calibrated_value: float) -> float:
-        calibration = self.__get_calibration()
-        data_size = self.__get_data_size()
-        return calibration.convert_from_calibrated_value(calibrated_value) / data_size
-
-    def convert(self, value: typing.Optional[float]) -> typing.Optional[str]:
-        if value is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
-            return calibration.convert_to_calibrated_value_str(data_size * value, value_range=(0, data_size), samples=data_size)
-        return None
-
-    def convert_back(self, value_str: typing.Optional[str]) -> typing.Optional[float]:
-        if value_str is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
-            value = Converter.FloatToStringConverter().convert_back(value_str)
-            if value is not None:
-                return calibration.convert_from_calibrated_value(value) / data_size
-        return None
-
-
-class CalibratedSizeFloatToStringConverter(Converter.ConverterLike[float, str]):
-    """Converter object to convert from calibrated size to string and back.
-
-    If uniform is true, the converter will fall back to uncalibrated value if the calibrations have
-    different units.
-
-    This class does the conversion based on the display item, which may change (i.e. calibration style).
-    No attempt is made to keep this class up to date, and it must be recreated or updated when the display item changes.
-    """
-
-    def __init__(self, display_item: DisplayItem.DisplayItem, index: int, factor: float = 1.0, uniform: bool = False) -> None:
-        self.__display_item = display_item
-        self.__index = index
-        self.__factor = factor
-        self.__uniform = uniform
-
-    def __get_calibration(self) -> Calibration.Calibration:
-        index = self.__index
-        display_calibration_info = self.__display_item.display_calibration_info
-        calibrations = display_calibration_info.displayed_display_data_calibrations if display_calibration_info else None
-        if not calibrations:
-            return Calibration.Calibration()
-        if self.__uniform:
-            unit_set = set(calibration.units if calibration.units else '' for calibration in calibrations)
-            if len(unit_set) > 1:
-                return Calibration.Calibration()
-        dimension_count = len(calibrations)
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count:
-            return calibrations[index]
-        else:
-            return Calibration.Calibration()
-
-    def __get_data_size(self) -> int:
-        index = self.__index
-        display_calibration_info = self.__display_item.display_calibration_info
-        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count and display_data_shape is not None:
-            return display_data_shape[index]
-        else:
-            return 1
-
-    def convert_calibrated_value_to_str(self, calibrated_value: float) -> str:
-        calibration = self.__get_calibration()
-        return calibration.convert_calibrated_size_to_str(calibrated_value)
-
-    def convert_to_calibrated_value(self, size: float) -> float:
-        calibration = self.__get_calibration()
-        data_size = self.__get_data_size()
-        return calibration.convert_to_calibrated_size(data_size * size * self.__factor)
-
-    def convert(self, value: typing.Optional[float]) -> typing.Optional[str]:
-        if value is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
-            return calibration.convert_to_calibrated_size_str(data_size * value * self.__factor, value_range=(0, data_size), samples=data_size)
-        return None
-
-    def convert_back(self, value_str: typing.Optional[str]) -> typing.Optional[float]:
-        if value_str is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
-            value = Converter.FloatToStringConverter().convert_back(value_str)
-            if value is not None:
-                return calibration.convert_from_calibrated_size(value) / data_size / self.__factor
-        return None
-
-
 class CalibratedBinding(Binding.Binding):
     """A abstract calibrated dimension value binding.
 
@@ -2794,15 +2644,15 @@ class CalibratedLengthBinding(Binding.Binding):
         end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
         y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
         x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
-        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y),
-                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x))
-        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y),
-                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x))
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
         delta = calibrated_end - calibrated_start
         angle = -math.atan2(delta.y, delta.x)
         new_calibrated_end = calibrated_start + target_value * Geometry.FloatSize(height=-math.sin(angle), width=math.cos(angle))
-        end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.y),
-                                  x=x_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.x))
+        end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.y) / y_calibration_and_data_size.data_size,
+                                  x=x_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.x) / x_calibration_and_data_size.data_size)
         self.__end_binding.update_source(end)
 
     # get the value from the model and return it as a string suitable for the target ui element.
@@ -2812,10 +2662,10 @@ class CalibratedLengthBinding(Binding.Binding):
         end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
         y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
         x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
-        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y),
-                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x))
-        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y),
-                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x))
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
         calibrated_distance = Geometry.distance(calibrated_end, calibrated_start)
         return y_calibration_and_data_size.calibration.convert_calibrated_size_to_str(calibrated_distance)
 
@@ -2829,7 +2679,7 @@ class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):
         self.__is_size = is_size
         self.__uniform = uniform
         self.__factor = factor
-        self.__display_calibration_info: DisplayItem.DisplayCalibrationInfo | None = self.__display_item.display_calibration_info
+        self.__display_calibration_info = self.__display_item.display_calibration_info
         self.__display_item_listener = Stream.ValueStreamAction(self.__display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
         self.__property_listener = self.__property_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__on_value_changed, self))
         self.__value_str: str | None = None
@@ -2949,42 +2799,52 @@ class LineLengthModel(Model.PropertyModel[float]):
         super().__init__()
         self.__start_model = start_model
         self.__end_model = end_model
+        self.__display_calibration_info = display_item.display_calibration_info
+        self.__display_item_listener = Stream.ValueStreamAction(display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
+        self.__start_listener = self.__start_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__handle_model_changed, self))
+        self.__end_listener = self.__end_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__handle_model_changed, self))
 
-        self.__x_converter = CalibratedValueFloatToStringConverter(display_item, 1, uniform=True)
-        self.__y_converter = CalibratedValueFloatToStringConverter(display_item, 0, uniform=True)
-        self.__size_converter = CalibratedSizeFloatToStringConverter(display_item, 0, uniform=True)
+    def __get_calibration_and_data_size(self, dimension_index: int) -> DisplayItem.CalibrationAndDataSize:
+        if self.__display_calibration_info:
+            return self.__display_calibration_info.get_dimension_calibration_and_data_size(dimension_index, uniform=True)
+        else:
+            return DisplayItem.CalibrationAndDataSize(Calibration.Calibration(), 1)
 
-        self.__start_listener = self.__start_model.property_changed_event.listen(
-            ReferenceCounting.weak_partial(LineLengthModel.__on_line_changed, self))
-        self.__end_listener = self.__end_model.property_changed_event.listen(
-            ReferenceCounting.weak_partial(LineLengthModel.__on_line_changed, self))
+    def __handle_model_changed(self, property: str) -> None:
+        self.notify_property_changed("value")
 
-    def __on_line_changed(self, property: str) -> None:
+    def __on_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        self.__display_calibration_info = display_calibration_info
         self.notify_property_changed("value")
 
     @property
     def value(self) -> typing.Any:
         start = self.__start_model.value or Geometry.FloatPoint()
         end = self.__end_model.value or Geometry.FloatPoint()
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        calibrated_value = math.sqrt(calibrated_dx * calibrated_dx + calibrated_dy * calibrated_dy)
-        return self.__size_converter.convert_calibrated_value_to_str(calibrated_value)
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
+        calibrated_distance = Geometry.distance(calibrated_end, calibrated_start)
+        return y_calibration_and_data_size.calibration.convert_calibrated_size_to_str(calibrated_distance)
 
     @value.setter
     def value(self, target_value: typing.Any) -> None:
         start = self.__start_model.value or Geometry.FloatPoint()
         end = self.__end_model.value or Geometry.FloatPoint()
-        calibrated_start = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(start[0]),
-                                               x=self.__x_converter.convert_to_calibrated_value(start[1]))
-        calibrated_end = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(end[0]),
-                                             x=self.__x_converter.convert_to_calibrated_value(end[1]))
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
         delta = calibrated_end - calibrated_start
         angle = -math.atan2(delta.y, delta.x)
-        new_calibrated_end = calibrated_start + target_value * Geometry.FloatSize(height=-math.sin(angle),
-                                                                                  width=math.cos(angle))
-        end = Geometry.FloatPoint(y=self.__y_converter.convert_from_calibrated_value(new_calibrated_end.y),
-                                  x=self.__x_converter.convert_from_calibrated_value(new_calibrated_end.x))
+        new_calibrated_end = calibrated_start + target_value * Geometry.FloatSize(height=-math.sin(angle), width=math.cos(angle))
+        end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.y) / y_calibration_and_data_size.data_size,
+                                  x=x_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.x) / x_calibration_and_data_size.data_size)
         self.__end_model.value = end
 
 
@@ -2994,43 +2854,52 @@ class LineAngleModel(Model.PropertyModel[float]):
         super().__init__()
         self.__start_model = start_model
         self.__end_model = end_model
+        self.__display_calibration_info = display_item.display_calibration_info
+        self.__display_item_listener = Stream.ValueStreamAction(display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
+        self.__start_listener = self.__start_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__handle_model_changed, self))
+        self.__end_listener = self.__end_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__handle_model_changed, self))
 
-        self.__x_converter = CalibratedValueFloatToStringConverter(display_item, 1, uniform=True)
-        self.__y_converter = CalibratedValueFloatToStringConverter(display_item, 0, uniform=True)
-        self.__size_converter = CalibratedSizeFloatToStringConverter(display_item, 0, uniform=True)
+    def __get_calibration_and_data_size(self, dimension_index: int) -> DisplayItem.CalibrationAndDataSize:
+        if self.__display_calibration_info:
+            return self.__display_calibration_info.get_dimension_calibration_and_data_size(dimension_index, uniform=True)
+        else:
+            return DisplayItem.CalibrationAndDataSize(Calibration.Calibration(), 1)
 
-        self.__start_listener = self.__start_model.property_changed_event.listen(
-            ReferenceCounting.weak_partial(LineAngleModel.__on_line_changed, self))
-        self.__end_listener = self.__end_model.property_changed_event.listen(
-            ReferenceCounting.weak_partial(LineAngleModel.__on_line_changed, self))
+    def __handle_model_changed(self, property: str) -> None:
+        self.notify_property_changed("value")
 
-    def __on_line_changed(self, property_name: str) -> None:
+    def __on_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        self.__display_calibration_info = display_calibration_info
         self.notify_property_changed("value")
 
     @property
     def value(self) -> typing.Any:
         start = self.__start_model.value or Geometry.FloatPoint()
         end = self.__end_model.value or Geometry.FloatPoint()
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        return RadianToDegreeStringConverter().convert(-math.atan2(calibrated_dy, calibrated_dx))
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
+        calibrated_delta = calibrated_end - calibrated_start
+        return RadianToDegreeStringConverter().convert(-math.atan2(calibrated_delta.y, calibrated_delta.x))
 
     @value.setter
     def value(self, target_value: typing.Any) -> None:
         start = self.__start_model.value or Geometry.FloatPoint()
         end = self.__end_model.value or Geometry.FloatPoint()
-        calibrated_start = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(start[0]),
-                                               x=self.__x_converter.convert_to_calibrated_value(start[1]))
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(
-            end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(
-            end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        length = math.sqrt(calibrated_dy * calibrated_dy + calibrated_dx * calibrated_dx)
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y * y_calibration_and_data_size.data_size),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x * x_calibration_and_data_size.data_size))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y * y_calibration_and_data_size.data_size),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x * x_calibration_and_data_size.data_size))
+        calibrated_distance = Geometry.distance(calibrated_end, calibrated_start)
         angle = RadianToDegreeStringConverter().convert_back(target_value) or 0.0
-        new_calibrated_end = calibrated_start + length * Geometry.FloatSize(height=-math.sin(angle),
-                                                                            width=math.cos(angle))
-        end = Geometry.FloatPoint(y=self.__y_converter.convert_from_calibrated_value(new_calibrated_end.y),
-                                  x=self.__x_converter.convert_from_calibrated_value(new_calibrated_end.x))
+        new_calibrated_end = calibrated_start + calibrated_distance * Geometry.FloatSize(height=-math.sin(angle), width=math.cos(angle))
+        end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.y) / y_calibration_and_data_size.data_size,
+                                  x=x_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.x) / x_calibration_and_data_size.data_size)
         self.__end_model.value = end
 
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2640,55 +2640,141 @@ class CalibratedSizeFloatToStringConverter(Converter.ConverterLike[float, str]):
 
 
 class CalibratedBinding(Binding.Binding):
-    def __init__(self, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding, converter: Converter.ConverterLike[float, str]) -> None:
-        super().__init__(None, converter=converter)
-        self.__display_item = display_item
+    """A abstract calibrated dimension value binding.
+
+    Takes a value binding and a display item, and combines them to convert between the binding value and the calibrated string for a UI element.
+
+    The display item is monitored for changes to the calibration info, and the target value is updated when the calibration info changes.
+
+    Subclasses must override the two conversion methods.
+    """
+    def __init__(self, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding, dimension_index: int) -> None:
+        super().__init__(None)
+        self.__display_calibration_info = display_item.display_calibration_info
+        self.__dimension_index = dimension_index
+        self.__display_item_listener = Stream.ValueStreamAction(display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
         self.__value_binding = value_binding
-        self.__converter_x = converter  # mypy bug (it uses base self.__converter type if named the same)
-
-        self.__value_binding.target_setter = ReferenceCounting.weak_partial(CalibratedBinding.__update_target, self)
-
-        self.__calibrations_changed_event_listener = display_item.display_property_changed_event.listen(ReferenceCounting.weak_partial(CalibratedBinding.__calibrations_changed, self))
+        self.__value_binding.target_setter = ReferenceCounting.weak_partial(self.__class__.__update_target, self)
 
     def __update_target(self, value: typing.Any) -> None:
         self.update_target_direct(self.get_target_value())
 
-    def __calibrations_changed(self, key: str) -> None:
-        display_calibration_info = self.__display_item.display_calibration_info
-        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
+    def __on_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        self.__display_calibration_info = display_calibration_info
+        if display_calibration_info:
             self.__update_target(display_calibration_info.displayed_display_data_calibrations)
+
+    def __get_calibration(self) -> Calibration.Calibration:
+        dimension_index = self.__dimension_index
+        calibrations = self.__display_calibration_info.displayed_display_data_calibrations if self.__display_calibration_info else None
+        if not calibrations:
+            return Calibration.Calibration()
+        dimension_count = len(calibrations)
+        if dimension_index < 0:
+            dimension_index = dimension_count + dimension_index
+        if dimension_index >= 0 and dimension_index < dimension_count:
+            return calibrations[dimension_index]
+        else:
+            return Calibration.Calibration()
+
+    def __get_data_size(self) -> int:
+        index = self.__dimension_index
+        display_calibration_info = self.__display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
+        if index < 0:
+            index = dimension_count + index
+        if index >= 0 and index < dimension_count and display_data_shape is not None:
+            return display_data_shape[index]
+        else:
+            return 1
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
-        converted_value = self.__converter_x.convert_back(target_value)
+        converted_value = self._convert_str_to_value(self.__get_calibration(), self.__display_calibration_info, self.__get_data_size(), target_value)
         self.__value_binding.update_source(converted_value)
 
     # get the value from the model and return it as a string suitable for the target ui element.
     # in this binding, it combines the two source bindings into one.
     def get_target_value(self) -> typing.Optional[str]:
         value = self.__value_binding.get_target_value()
-        return self.__converter_x.convert(value) if value is not None else None
+        return self._convert_value_to_str(self.__get_calibration(), self.__display_calibration_info, self.__get_data_size(), value) if value is not None else None
+
+    def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
+        """Subclasses must override this method to convert from the string to the model value, using the calibration and data size as needed."""
+        raise NotImplementedError()
+
+    def _convert_value_to_str(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value: float | None) -> str | None:
+        """Subclasses must override this method to convert from the model value to the string, using the calibration and data size as needed."""
+        raise NotImplementedError()
 
 
 class CalibratedValueBinding(CalibratedBinding):
     def __init__(self, index: int, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding) -> None:
-        converter = CalibratedValueFloatToStringConverter(display_item, index)
-        super().__init__(display_item, value_binding, converter)
+        super().__init__(display_item, value_binding, index)
+
+    def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
+        if value_str is not None:
+            value = Converter.FloatToStringConverter().convert_back(value_str)
+            if value is not None:
+                return calibration.convert_from_calibrated_value(value) / data_size
+        return None
+
+    def _convert_value_to_str(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value: float | None) -> str | None:
+        if value is not None:
+            return calibration.convert_to_calibrated_value_str(data_size * value, value_range=(0, data_size), samples=data_size)
+        return None
 
 
 class CalibratedSizeBinding(CalibratedBinding):
     def __init__(self, index: int, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding) -> None:
-        converter = CalibratedSizeFloatToStringConverter(display_item, index)
-        super().__init__(display_item, value_binding, converter)
+        super().__init__(display_item, value_binding, index)
+
+    def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
+        if value_str is not None:
+            value = Converter.FloatToStringConverter().convert_back(value_str)
+            if value is not None:
+                return calibration.convert_from_calibrated_size(value) / data_size
+        return None
+
+    def _convert_value_to_str(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value: float | None) -> str | None:
+        if value is not None:
+            return calibration.convert_to_calibrated_size_str(data_size * value, value_range=(0, data_size), samples=data_size)
+        return None
 
 
 class CalibratedWidthBinding(CalibratedBinding):
     def __init__(self, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding) -> None:
-        display_calibration_info = display_item.display_calibration_info
-        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
-        converter = CalibratedSizeFloatToStringConverter(display_item, 0, factor)  # width is stored in pixels. argh.
-        super().__init__(display_item, value_binding, converter)
+        super().__init__(display_item, value_binding, 0)
+
+    def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
+        if value_str is not None:
+            value = Converter.FloatToStringConverter().convert_back(value_str)
+            if value is not None:
+                display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+                factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
+                return calibration.convert_from_calibrated_size(value) / data_size / factor
+        return None
+
+    def _convert_value_to_str(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value: float | None) -> str | None:
+        if value is not None:
+            display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+            factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
+            return calibration.convert_to_calibrated_size_str(data_size * value * factor, value_range=(0, data_size), samples=data_size)
+        return None
+
+
+class CalibratedAngleBinding(CalibratedBinding):
+    # NOTE: the angle can change depending on the calibrations
+
+    def __init__(self, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding) -> None:
+        super().__init__(display_item, value_binding, 0)
+
+    def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
+        return RadianToDegreeStringConverter().convert_back(value_str) if value_str is not None else None
+
+    def _convert_value_to_str(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value: float | None) -> str | None:
+        return RadianToDegreeStringConverter().convert(value) if value is not None else None
 
 
 class CalibratedLengthBinding(Binding.Binding):
@@ -3949,7 +4035,7 @@ class GraphicHandler(Declarative.Handler):
                 display_item = graphic.display_item
                 graphic_name = "line_profile"
                 property_model_f = GraphicPropertyCommandModel[float](self.document_controller, display_item, graphic, "angle", title=_("Change {} Angle").format(graphic_name), command_id="change_" + graphic_name + "_angle")
-                return CalibratedBinding(display_item, ClosingPropertyBinding(property_model_f, "value"), RadianToDegreeStringConverter())
+                return CalibratedAngleBinding(display_item, ClosingPropertyBinding(property_model_f, "value"))
         if isinstance(source, Graphics.LineProfileGraphic):
             if property == "width":
                 graphic = source

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -576,7 +576,10 @@ class DisplayItemDisplayPropertyCommandModel(Model.PropertyModel[typing.Any]):
         return self.__display_item.get_display_property(self.__property_name)
 
 
-class GraphicPropertyCommandModel(Model.PropertyModel[typing.Any]):
+_GraphicPropertyCommandModelValueType = typing.TypeVar("_GraphicPropertyCommandModelValueType")
+
+
+class GraphicPropertyCommandModel(Model.PropertyModel[_GraphicPropertyCommandModelValueType]):
     def __init__(self, document_controller: DocumentController.DocumentController, display_item: DisplayItem.DisplayItem, graphic: Graphics.Graphic,
                  property_name: str, title: str,  command_id: str, read_property_name: str | None = None) -> None:
         read_name = read_property_name if read_property_name else property_name
@@ -585,11 +588,11 @@ class GraphicPropertyCommandModel(Model.PropertyModel[typing.Any]):
         self.__read_property_name = read_name
         self.__graphic = graphic
 
-        def property_changed_from_user(value: typing.Any) -> None:
+        def property_changed_from_user(value: _GraphicPropertyCommandModelValueType | None) -> None:
             if value != getattr(graphic, self.__read_property_name):
                 command = DisplayPanel.ChangeGraphicsCommand(document_controller.document_model, display_item, [graphic],
                                                             title=title, command_id=command_id, is_mergeable=True,
-                                                            **{self.__property_name: value})
+                                                            **{self.__property_name: typing.cast(typing.Any, value)})
                 command.perform()
                 document_controller.push_undo_command(command)
                 self.value = getattr(graphic, self.__read_property_name)
@@ -2602,7 +2605,7 @@ class CalibratedSizeFloatToStringConverter(Converter.ConverterLike[float, str]):
         index = self.__index
         display_calibration_info = self.__display_item.display_calibration_info
         display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        dimension_count = len(display_data_shape) if display_data_shape else 0
+        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
         if index < 0:
             index = dimension_count + index
         if index >= 0 and index < dimension_count and display_data_shape is not None:
@@ -2732,105 +2735,146 @@ class CalibratedLengthBinding(Binding.Binding):
         return self.__size_converter.convert_calibrated_value_to_str(calibrated_value)
 
 
-class CalibratedAngleBinding(Binding.Binding):
-    def __init__(self, display_item: DisplayItem.DisplayItem, start_binding: Binding.Binding, end_binding: Binding.Binding) -> None:
-        super().__init__(None)
-        self.__display_item = display_item
-        self.__x_converter = CalibratedValueFloatToStringConverter(display_item, 1, uniform=True)
-        self.__y_converter = CalibratedValueFloatToStringConverter(display_item, 0, uniform=True)
-        self.__size_converter = CalibratedSizeFloatToStringConverter(display_item, 0, uniform=True)
-        self.__start_binding = start_binding
-        self.__end_binding = end_binding
-        self.__start_binding.target_setter = ReferenceCounting.weak_partial(CalibratedAngleBinding.__update_target, self)
-        self.__end_binding.target_setter = ReferenceCounting.weak_partial(CalibratedAngleBinding.__update_target, self)
-        self.__calibrations_changed_event_listener = display_item.display_property_changed_event.listen(ReferenceCounting.weak_partial(CalibratedAngleBinding.__calibrations_changed, self))
-
-    def __update_target(self, value: typing.Any) -> None:
-        self.update_target_direct(self.get_target_value())
-
-    def __calibrations_changed(self, key: str) -> None:
-        display_calibration_info = self.__display_item.display_calibration_info
-        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
-            self.__update_target(display_calibration_info.displayed_display_data_calibrations)
-
-    # set the model value from the target ui element text.
-    def update_source(self, target_value: typing.Any) -> None:
-        start = self.__start_binding.get_target_value() or Geometry.FloatPoint()
-        end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
-        calibrated_start = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(start[0]),
-                                               x=self.__x_converter.convert_to_calibrated_value(start[1]))
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        length = math.sqrt(calibrated_dy * calibrated_dy + calibrated_dx * calibrated_dx)
-        angle = RadianToDegreeStringConverter().convert_back(target_value) or 0.0
-        new_calibrated_end = calibrated_start + length * Geometry.FloatSize(height=-math.sin(angle), width=math.cos(angle))
-        end = Geometry.FloatPoint(y=self.__y_converter.convert_from_calibrated_value(new_calibrated_end.y),
-                                  x=self.__x_converter.convert_from_calibrated_value(new_calibrated_end.x))
-        self.__end_binding.update_source(end)
-
-    # get the value from the model and return it as a string suitable for the target ui element.
-    # in this binding, it combines the two source bindings into one.
-    def get_target_value(self) -> typing.Optional[str]:
-        start = self.__start_binding.get_target_value() or Geometry.FloatPoint()
-        end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        return RadianToDegreeStringConverter().convert(-math.atan2(calibrated_dy, calibrated_dx))
-
-
-class DisplayItemCalibratedValueModel(Model.PropertyModel[typing.Any]):
-    """ Model to catch the property changed event for the calibration changing that can trigger a UI update """
-    def __init__(self, property_model: Model.PropertyModel[typing.Any],
-                 converter: Converter.ConverterLike[typing.Any, typing.Any],
-                 display_item: DisplayItem.DisplayItem):
+class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):
+    def __init__(self, property_model: Model.ValueModel[tuple[float, ...]], display_item: DisplayItem.DisplayItem, *, dimension_index: int, is_size: bool, uniform: bool = False, factor: float = 1.0) -> None:
         super().__init__()
         self.__property_model = property_model
-        self.__converter = converter
         self.__display_item = display_item
+        self.__dimension_index = dimension_index
+        self.__is_size = is_size
+        self.__uniform = uniform
+        self.__factor = factor
+        self.__display_calibration_info: DisplayItem.DisplayCalibrationInfo | None = self.__display_item.display_calibration_info
+        self.__display_item_listener = Stream.ValueStreamAction(self.__display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
+        self.__property_listener = self.__property_model.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__on_value_changed, self))
+        self.__value_str: str | None = None
+        self.__update()
 
-        self.__display_item_listener = self.__display_item.display_property_changed_event.listen(
-            ReferenceCounting.weak_partial(DisplayItemCalibratedValueModel.__on_calibration_changed, self))
-        self.__property_listener = self.__property_model.property_changed_event.listen(
-            ReferenceCounting.weak_partial(DisplayItemCalibratedValueModel.__on_value_changed, self))
+    def __get_calibration(self) -> Calibration.Calibration:
+        dimension_index = self.__dimension_index
+        calibrations = self.__display_calibration_info.displayed_display_data_calibrations if self.__display_calibration_info else None
+        if not calibrations:
+            return Calibration.Calibration()
+        if self.__uniform:
+            unit_set = set(calibration.units if calibration.units else '' for calibration in calibrations)
+            if len(unit_set) > 1:
+                return Calibration.Calibration()
+        dimension_count = len(calibrations)
+        if dimension_index < 0:
+            dimension_index = dimension_count + dimension_index
+        if dimension_index >= 0 and dimension_index < dimension_count:
+            return calibrations[dimension_index]
+        else:
+            return Calibration.Calibration()
 
-    def __on_calibration_changed(self, property: str) -> None:
-        if property == "displayed_display_data_calibrations":
+    def __get_data_size(self) -> int:
+        index = self.__dimension_index
+        display_calibration_info = self.__display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
+        if index < 0:
+            index = dimension_count + index
+        if index >= 0 and index < dimension_count and display_data_shape is not None:
+            return display_data_shape[index]
+        else:
+            return 1
+
+    def __get_value_str(self) -> str | None:
+        value_tuple = self.__property_model.value
+        if value_tuple is not None:
+            calibration = self.__get_calibration()
+            data_size = self.__get_data_size()
+            if self.__is_size:
+                return calibration.convert_to_calibrated_size_str(data_size * value_tuple[self.__dimension_index] * self.__factor, value_range=(0, data_size), samples=data_size)
+            else:
+                return calibration.convert_to_calibrated_value_str(data_size * value_tuple[self.__dimension_index] * self.__factor, value_range=(0, data_size), samples=data_size)
+        return None
+
+    def __update(self) -> None:
+        new_value = self.__get_value_str()
+        if new_value != self.__value_str:
+            self.__value_str = new_value
             self.notify_property_changed("value")
 
+    def __on_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        self.__display_calibration_info = display_calibration_info
+        self.__update()
+
     def __on_value_changed(self, property: str) -> None:
-        self.notify_property_changed("value")
+        self.__update()
 
     @property
-    def value(self) -> typing.Any:
-        return self.__converter.convert(self.__property_model.value)
+    def value(self) -> str | None:
+        return self.__value_str
 
     @value.setter
-    def value(self, value: typing.Any) -> None:
-        self.__property_model.value = self.__converter.convert_back(value)
+    def value(self, value_str: str | None) -> None:
+        new_value: float | None = None
+        if value_str is not None:
+            calibration = self.__get_calibration()
+            data_size = self.__get_data_size()
+            value = Converter.FloatToStringConverter().convert_back(value_str)
+            if value is not None:
+                if self.__is_size:
+                    new_value = calibration.convert_from_calibrated_size(value) / data_size / self.__factor
+                else:
+                    new_value = calibration.convert_from_calibrated_value(value) / data_size / self.__factor
+        value_tuple = self.__property_model.value
+        new_value_tuple = value_tuple
+        if value_tuple is not None and new_value is not None:
+            value_list = list(value_tuple)
+            value_list[self.__dimension_index] = new_value
+            new_value_tuple = tuple(value_list)
+        if new_value_tuple != value_tuple:
+            self.__property_model.value = new_value_tuple
 
 
-class TuplePropertyElementModel(Model.PropertyModel[typing.Any]):
-    def __init__(self, source: Model.PropertyModel[tuple[typing.Any]], index: int):
+class TupleToFloatPropertyElementModel(Model.ValueModel[float]):
+    """Model to represent an indexed element of a tuple model."""
+
+    def __init__(self, source: Model.ValueModel[tuple[float, ...]], index: int):
         super().__init__()
         self.__source = source
         self.__index = index
-        self.__listener = self.__source.property_changed_event.listen(
-            ReferenceCounting.weak_partial(TuplePropertyElementModel.__on_tuple_changed, self))
+        self.__listener = self.__source.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__on_source_changed, self))
 
     @property
-    def value(self) -> typing.Any:
+    def value(self) -> float | None:
         tuple_value = self.__source.value
         return tuple_value[self.__index] if tuple_value else None
 
     @value.setter
-    def value(self, new_value: typing.Any) -> None:
+    def value(self, new_value: float | None) -> None:
         if self.value != new_value:
             tuple_value = self.__source.value
-            tuple_as_list = list(tuple_value) if tuple_value else []
-            tuple_as_list[self.__index] = new_value
+            tuple_as_list: list[float] = list(tuple_value) if tuple_value else []
+            tuple_as_list[self.__index] = new_value or 0.0
             self.__source.value = tuple(tuple_as_list)
 
-    def __on_tuple_changed(self, property_name: str) -> None:
+    def __on_source_changed(self, property_name: str) -> None:
+        if property_name == "value":
+            self.notify_property_changed("value")
+
+
+class FloatToTuplePropertyElementModel(Model.ValueModel[tuple[float, ...]]):
+    """Model to represent an indexed element of a tuple model."""
+
+    def __init__(self, source: Model.ValueModel[float]):
+        super().__init__()
+        self.__source = source
+        self.__listener = self.__source.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__on_source_changed, self))
+
+    @property
+    def value(self) -> tuple[float, ...] | None:
+        source_value = self.__source.value
+        return (source_value,) if isinstance(source_value, float) else None
+
+    @value.setter
+    def value(self, new_value: tuple[float, ...] | None) -> None:
+        if self.value != new_value:
+            self.__source.value = new_value[0] if new_value is not None and len(new_value) > 0 else None
+
+    def __on_source_changed(self, property_name: str) -> None:
         if property_name == "value":
             self.notify_property_changed("value")
 
@@ -2937,15 +2981,15 @@ class GraphicsInspectorHandler(Declarative.Handler):
         self._stroke_float_str_converter = Converter.FloatToStringConverter(pass_none=True)
         self._graphic_type_model = Model.PropertyModel[str]()
         self.__set_type_specifics()
-        self._graphic_label_model = GraphicPropertyCommandModel(document_controller, display_item, graphic, "label", title=_("Change Label"), command_id="change_label")
-        self._lock_position_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, graphic, "is_position_locked", title=_(f"Change {self._graphic_type_model.value} Position Locked"), command_id=f"change_{self._graphic_type_model.value}_position_locked")
-        self._lock_rotation_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, graphic, "is_rotation_locked", title=_(f"Change {self._graphic_type_model.value} Rotation Locked"), command_id=f"change_{self._graphic_type_model.value}_rotation_locked")
-        self._stroke_color_model = GraphicPropertyCommandModel(document_controller, display_item, graphic,"stroke_color", title=_("Change Stroke Color"), command_id="change_stroke_color")
-        self._used_stroke_color_model = GraphicPropertyCommandModel(document_controller, display_item, graphic,"stroke_color", title=_("Change Stroke Color"), command_id="change_stroke_color", read_property_name="used_stroke_style")
-        self._stroke_width_model = GraphicPropertyCommandModel(document_controller, display_item, graphic, "stroke_width", title=_("Change Stroke Width"), command_id="change_stroke_width")
-        self._fill_color_model = GraphicPropertyCommandModel(document_controller, display_item, graphic, "fill_color", title=_("Change Fill Color"), command_id="change_fill_color")
-        self._used_fill_color_model = GraphicPropertyCommandModel(document_controller, display_item, graphic,"fill_color", title=_("Change Fill Color"), command_id="change_fill_color", read_property_name="used_fill_style")
-        self._lock_shape_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, graphic,"is_shape_locked", title=_(f"Change {self._graphic_type_model.value} Shape Locked"), command_id=f"change_{self._graphic_type_model.value}_shape_locked")
+        self._graphic_label_model = GraphicPropertyCommandModel[str](document_controller, display_item, graphic, "label", title=_("Change Label"), command_id="change_label")
+        self._lock_position_model = GraphicPropertyCommandModel[bool](self.__document_controller, self.__display_item, graphic, "is_position_locked", title=_(f"Change {self._graphic_type_model.value} Position Locked"), command_id=f"change_{self._graphic_type_model.value}_position_locked")
+        self._lock_rotation_model = GraphicPropertyCommandModel[bool](self.__document_controller, self.__display_item, graphic, "is_rotation_locked", title=_(f"Change {self._graphic_type_model.value} Rotation Locked"), command_id=f"change_{self._graphic_type_model.value}_rotation_locked")
+        self._stroke_color_model = GraphicPropertyCommandModel[str](document_controller, display_item, graphic,"stroke_color", title=_("Change Stroke Color"), command_id="change_stroke_color")
+        self._used_stroke_color_model = GraphicPropertyCommandModel[str](document_controller, display_item, graphic,"stroke_color", title=_("Change Stroke Color"), command_id="change_stroke_color", read_property_name="used_stroke_style")
+        self._stroke_width_model = GraphicPropertyCommandModel[float](document_controller, display_item, graphic, "stroke_width", title=_("Change Stroke Width"), command_id="change_stroke_width")
+        self._fill_color_model = GraphicPropertyCommandModel[str](document_controller, display_item, graphic, "fill_color", title=_("Change Fill Color"), command_id="change_fill_color")
+        self._used_fill_color_model = GraphicPropertyCommandModel[str](document_controller, display_item, graphic,"fill_color", title=_("Change Fill Color"), command_id="change_fill_color", read_property_name="used_fill_style")
+        self._lock_shape_model = GraphicPropertyCommandModel[bool](self.__document_controller, self.__display_item, graphic,"is_shape_locked", title=_(f"Change {self._graphic_type_model.value} Shape Locked"), command_id=f"change_{self._graphic_type_model.value}_shape_locked")
 
         u = Declarative.DeclarativeUI()
 
@@ -3047,15 +3091,9 @@ class GraphicsInspectorHandler(Declarative.Handler):
 
     def __create_point_shape_and_pos(self) -> Declarative.UIDescriptionResult:
         u = Declarative.DeclarativeUI()
-        position_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "position", title=_("Change Position"), command_id="change_point_position")
-        self._point_position_x_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(position_model, 1),
-                                                                       CalibratedValueFloatToStringConverter(self.__display_item, 1),
-                                                                       self.__display_item)
-        self._point_position_y_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(position_model, 0),
-                                                                       CalibratedValueFloatToStringConverter(
-                                                                           self.__display_item, 0),
-                                                                       self.__display_item)
-
+        position_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "position", title=_("Change Position"), command_id="change_point_position")
+        self._point_position_x_model = DisplayItemCalibratedDimensionValueModel(position_model, self.__display_item, dimension_index=1, is_size=False)
+        self._point_position_y_model = DisplayItemCalibratedDimensionValueModel(position_model, self.__display_item, dimension_index=0, is_size=False)
         return u.create_row(
             u.create_spacing(20),
             u.create_label(text=_("X"), width=26),
@@ -3071,9 +3109,8 @@ class GraphicsInspectorHandler(Declarative.Handler):
         display_calibration_info = self.__display_item.display_calibration_info
         display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
         factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
-        self._line_profile_width_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "width", title=_("Change Width"), command_id="change_line_profile_width"),
-            CalibratedSizeFloatToStringConverter(self.__display_item, 0, factor), self.__display_item)
+        line_profile_width_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "width", title=_("Change Width"), command_id="change_line_profile_width")
+        self._line_profile_width_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(line_profile_width_model), self.__display_item, dimension_index=0, is_size=True, factor=factor)
         return u.create_column(
             self.__create_line_shape_and_pos(),
             u.create_spacing(4),
@@ -3087,20 +3124,12 @@ class GraphicsInspectorHandler(Declarative.Handler):
 
     def __create_line_shape_and_pos(self) -> Declarative.UIDescriptionResult:
         u = Declarative.DeclarativeUI()
-        start_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "start", title=_("Change Line Start"), command_id="change_line_start")
-        end_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "end", title=_("Change Line End"), command_id="change_line_end")
-        self._x0_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(start_model, 1),
-                                                         CalibratedValueFloatToStringConverter(self.__display_item, 1),
-                                                         self.__display_item)
-        self._y0_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(start_model, 0),
-                                                         CalibratedValueFloatToStringConverter(self.__display_item, 0),
-                                                         self.__display_item)
-        self._x1_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(end_model, 1),
-                                                         CalibratedValueFloatToStringConverter(self.__display_item, 1),
-                                                         self.__display_item)
-        self._y1_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(end_model, 0),
-                                                         CalibratedValueFloatToStringConverter(self.__display_item, 0),
-                                                         self.__display_item)
+        start_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "start", title=_("Change Line Start"), command_id="change_line_start")
+        end_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "end", title=_("Change Line End"), command_id="change_line_end")
+        self._x0_model = DisplayItemCalibratedDimensionValueModel(start_model, self.__display_item, dimension_index=1, is_size=False)
+        self._y0_model = DisplayItemCalibratedDimensionValueModel(start_model, self.__display_item, dimension_index=0, is_size=False)
+        self._x1_model = DisplayItemCalibratedDimensionValueModel(end_model, self.__display_item, dimension_index=1, is_size=False)
+        self._y1_model = DisplayItemCalibratedDimensionValueModel(end_model, self.__display_item, dimension_index=0, is_size=False)
         self._length_model = LineLengthModel(start_model, end_model, self.__display_item)
         self._angle_model = LineAngleModel(start_model, end_model, self.__display_item)
 
@@ -3138,19 +3167,15 @@ class GraphicsInspectorHandler(Declarative.Handler):
 
     def __create_rectangle_shape_and_pos(self) -> Declarative.UIDescriptionResult:
         u = Declarative.DeclarativeUI()
-        center_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "center", title=_(f"Change {self._graphic_type_model.value} Center"), command_id=f"change_{self._graphic_type_model.value}_center")
-        size_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "size", title=_(f"Change {self._graphic_type_model.value} Size"), command_id=f"change_{self._graphic_type_model.value}_size")
+        center_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "center", title=_(f"Change {self._graphic_type_model.value} Center"), command_id=f"change_{self._graphic_type_model.value}_center")
+        size_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "size", title=_(f"Change {self._graphic_type_model.value} Size"), command_id=f"change_{self._graphic_type_model.value}_size")
 
-        x_value_converter = CalibratedValueFloatToStringConverter(self.__display_item, 1)
-        y_value_converter = CalibratedValueFloatToStringConverter(self.__display_item, 0)
-        x_size_converter = CalibratedSizeFloatToStringConverter(self.__display_item, 1)
-        y_size_converter = CalibratedSizeFloatToStringConverter(self.__display_item, 0)
+        self._center_x_model = DisplayItemCalibratedDimensionValueModel(center_model, self.__display_item, dimension_index=1, is_size=False)
+        self._center_y_model = DisplayItemCalibratedDimensionValueModel(center_model, self.__display_item, dimension_index=0, is_size=False)
+        self._width_model = DisplayItemCalibratedDimensionValueModel(size_model, self.__display_item, dimension_index=1, is_size=True)
+        self._height_model = DisplayItemCalibratedDimensionValueModel(size_model, self.__display_item, dimension_index=0, is_size=True)
 
-        self._center_x_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(center_model, 1), x_value_converter, self.__display_item)
-        self._center_y_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(center_model, 0), y_value_converter, self.__display_item)
-        self._width_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(size_model, 1), x_size_converter, self.__display_item)
-        self._height_model = DisplayItemCalibratedValueModel(TuplePropertyElementModel(size_model, 0), y_size_converter, self.__display_item)
-        self._rotation_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "rotation", title=_(f"Change {self._graphic_type_model.value} Rotation"), command_id=f"change_{self._graphic_type_model.value}_size")
+        self._rotation_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "rotation", title=_(f"Change {self._graphic_type_model.value} Rotation"), command_id=f"change_{self._graphic_type_model.value}_size")
 
         self._radian_to_degrees_string_converter = RadianToDegreeStringConverter()
 
@@ -3188,17 +3213,11 @@ class GraphicsInspectorHandler(Declarative.Handler):
         return self.__create_rectangle_shape_and_pos()
 
     def __create_interval_shape_and_pos(self) -> Declarative.UIDescriptionResult:
-        converter = CalibratedValueFloatToStringConverter(self.__display_item, -1)
-        self._start_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "start",
-                                        title=_(f"Change {self._graphic_type_model.value} Start"),
-                                        command_id=f"change_{self._graphic_type_model.value}_start"),
-            converter, self.__display_item)
-        self._end_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "end",
-                                        title=_(f"Change {self._graphic_type_model.value} End"),
-                                        command_id=f"change_{self._graphic_type_model.value}_end"),
-            converter, self.__display_item)
+        start_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "start", title=_(f"Change {self._graphic_type_model.value} Start"), command_id=f"change_{self._graphic_type_model.value}_start")
+        end_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "end", title=_(f"Change {self._graphic_type_model.value} End"), command_id=f"change_{self._graphic_type_model.value}_end")
+
+        self._start_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(start_model), self.__display_item, dimension_index=-1, is_size=False)
+        self._end_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(end_model), self.__display_item, dimension_index=-1, is_size=False)
 
         u = Declarative.DeclarativeUI()
 
@@ -3219,12 +3238,9 @@ class GraphicsInspectorHandler(Declarative.Handler):
         )
 
     def __create_channel_pos(self) -> Declarative.UIDescriptionResult:
-        converter = CalibratedValueFloatToStringConverter(self.__display_item, -1)
-        self._position_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "position",
-                                        title=_(f"Change {self._graphic_type_model.value} Position"),
-                                        command_id=f"change_{self._graphic_type_model.value}_position"),
-            converter, self.__display_item)
+        position_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "position", title=_(f"Change {self._graphic_type_model.value} Position"), command_id=f"change_{self._graphic_type_model.value}_position")
+
+        self._position_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(position_model), self.__display_item, dimension_index=-1, is_size=False)
 
         u = Declarative.DeclarativeUI()
 
@@ -3243,14 +3259,11 @@ class GraphicsInspectorHandler(Declarative.Handler):
         return self.__create_rectangle_shape_and_pos()
 
     def __create_wedge_shape_and_pos(self) -> Declarative.UIDescriptionResult:
-        angle_interval_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item,
-                                                           self.__graphic, "angle_interval",
-                                                           title=_("Change Angle Interval"),
-                                                           command_id="change_angle_interval")
+        angle_interval_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "angle_interval", title=_("Change Angle Interval"), command_id="change_angle_interval")
 
         self._radian_to_degrees_string_converter = RadianToDegreeStringConverter()
-        self._start_angle_model = TuplePropertyElementModel(angle_interval_model, 0)
-        self._end_angle_model = TuplePropertyElementModel(angle_interval_model, 1)
+        self._start_angle_model = TupleToFloatPropertyElementModel(angle_interval_model, 0)
+        self._end_angle_model = TupleToFloatPropertyElementModel(angle_interval_model, 1)
 
         u = Declarative.DeclarativeUI()
 
@@ -3282,27 +3295,17 @@ class GraphicsInspectorHandler(Declarative.Handler):
         self.__annular_ring_mode_model.value = self.__annular_ring_mode_ids[current_index]
 
     def __create_ring_shape_and_pos(self) -> Declarative.UIDescriptionResult:
-        self._radius_1_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item,
-                                        self.__graphic, "radius_1",
-                                        title=_("Change Radius 1"),
-                                        command_id="change_radius_1"),
-            CalibratedSizeFloatToStringConverter(self.__display_item, 0), self.__display_item)
-        self._radius_2_model = DisplayItemCalibratedValueModel(
-            GraphicPropertyCommandModel(self.__document_controller, self.__display_item,
-                                        self.__graphic, "radius_2",
-                                        title=_("Change Radius 2"),
-                                        command_id="change_radius_2"),
-            CalibratedSizeFloatToStringConverter(self.__display_item, 0), self.__display_item)
+        radius_1_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "radius_1", title=_("Change Radius 1"), command_id="change_radius_1")
+        radius_2_model = GraphicPropertyCommandModel[float](self.__document_controller, self.__display_item, self.__graphic, "radius_2", title=_("Change Radius 2"), command_id="change_radius_2")
+
+        self._radius_1_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(radius_1_model), self.__display_item, dimension_index=0, is_size=True)
+        self._radius_2_model = DisplayItemCalibratedDimensionValueModel(FloatToTuplePropertyElementModel(radius_2_model), self.__display_item, dimension_index=0, is_size=True)
 
         self.__annular_ring_mode_options = [_("Band-Pass"), _("Low-Pass"), _("High-Pass")]
         self.__annular_ring_mode_ids = ["band-pass", "low-pass", "high-pass"]
         self.__annular_ring_mode_reverse_map = {p: i for i, p in enumerate(self.__annular_ring_mode_ids)}
 
-        self.__annular_ring_mode_model = GraphicPropertyCommandModel(self.__document_controller, self.__display_item,
-                                                                     self.__graphic, "mode",
-                                                                     title=_("Change Mode"),
-                                                                     command_id="change_mode")
+        self.__annular_ring_mode_model = GraphicPropertyCommandModel[str](self.__document_controller, self.__display_item, self.__graphic, "mode", title=_("Change Mode"), command_id="change_mode")
 
         self._current_annular_ring_mode_index = Model.PropertyModel(
             self.__annular_ring_mode_reverse_map.get(str(self.__annular_ring_mode_model.value), 0))
@@ -3904,20 +3907,20 @@ class GraphicHandler(Declarative.Handler):
                 display_item = graphic.display_item
                 index = 1 if property == "center_x" else 0
                 graphic_name = "rectangle"
-                property_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "center", title=_("Change {} Center").format(graphic_name), command_id="change_" + graphic_name + "_center")
+                property_model = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "center", title=_("Change {} Center").format(graphic_name), command_id="change_" + graphic_name + "_center")
                 return CalibratedValueBinding(index, display_item, ClosingTuplePropertyBinding(property_model, "value", index))
             elif property in ("width", "height"):
                 graphic = source
                 display_item = graphic.display_item
                 index = 1 if property == "width" else 0
                 graphic_name = "rectangle"
-                size_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "size", title=_("Change {} Size").format(graphic_name), command_id="change_" + graphic_name + "_size")
+                size_model = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "size", title=_("Change {} Size").format(graphic_name), command_id="change_" + graphic_name + "_size")
                 return CalibratedSizeBinding(index, display_item, ClosingTuplePropertyBinding(size_model, "value", index))
             elif property in ("rotation_deg", ):
                 graphic = source
                 display_item = graphic.display_item
                 graphic_name = "rectangle"
-                rotation_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "rotation", title=_("Change {} Rotation").format(graphic_name), command_id="change_" + graphic_name + "_size")
+                rotation_model = GraphicPropertyCommandModel[float](self.document_controller, display_item, graphic, "rotation", title=_("Change {} Rotation").format(graphic_name), command_id="change_" + graphic_name + "_size")
                 return ClosingPropertyBinding(rotation_model, "value", converter=RadianToDegreeStringConverter())
         if isinstance(source, Graphics.LineTypeGraphic):
             if property in ("start_x", "start_y"):
@@ -3925,35 +3928,35 @@ class GraphicHandler(Declarative.Handler):
                 display_item = graphic.display_item
                 index = 1 if property == "start_x" else 0
                 graphic_name = "line_profile"
-                property_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "start", title=_("Change {} Start").format(graphic_name), command_id="change_" + graphic_name + "_start")
+                property_model = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "start", title=_("Change {} Start").format(graphic_name), command_id="change_" + graphic_name + "_start")
                 return CalibratedValueBinding(index, display_item, ClosingTuplePropertyBinding(property_model, "value", index))
             if property in ("end_x", "end_y"):
                 graphic = source
                 display_item = graphic.display_item
                 index = 1 if property == "end_x" else 0
                 graphic_name = "line_profile"
-                property_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "end", title=_("Change {} End").format(graphic_name), command_id="change_" + graphic_name + "_end")
+                property_model = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "end", title=_("Change {} End").format(graphic_name), command_id="change_" + graphic_name + "_end")
                 return CalibratedValueBinding(index, display_item, ClosingTuplePropertyBinding(property_model, "value", index))
             if property == "length":
                 graphic = source
                 display_item = graphic.display_item
                 graphic_name = "line_profile"
-                property_model1 = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "start", title=_("Change {} Length").format(graphic_name), command_id="change_" + graphic_name + "_length_start")
-                property_model2 = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "end", title=_("Change {} Length").format(graphic_name), command_id="change_" + graphic_name + "_length_end")
+                property_model1 = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "start", title=_("Change {} Length").format(graphic_name), command_id="change_" + graphic_name + "_length_start")
+                property_model2 = GraphicPropertyCommandModel[tuple[float, ...]](self.document_controller, display_item, graphic, "end", title=_("Change {} Length").format(graphic_name), command_id="change_" + graphic_name + "_length_end")
                 return CalibratedLengthBinding(display_item, ClosingPropertyBinding(property_model1, "value"), ClosingPropertyBinding(property_model2, "value"))
             if property == "angle":
                 graphic = source
                 display_item = graphic.display_item
                 graphic_name = "line_profile"
-                property_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "angle", title=_("Change {} Angle").format(graphic_name), command_id="change_" + graphic_name + "_angle")
-                return CalibratedBinding(display_item, ClosingPropertyBinding(property_model, "value"), RadianToDegreeStringConverter())
+                property_model_f = GraphicPropertyCommandModel[float](self.document_controller, display_item, graphic, "angle", title=_("Change {} Angle").format(graphic_name), command_id="change_" + graphic_name + "_angle")
+                return CalibratedBinding(display_item, ClosingPropertyBinding(property_model_f, "value"), RadianToDegreeStringConverter())
         if isinstance(source, Graphics.LineProfileGraphic):
             if property == "width":
                 graphic = source
                 display_item = graphic.display_item
                 graphic_name = "line_profile"
-                property_model = GraphicPropertyCommandModel(self.document_controller, display_item, graphic, "width", title=_("Change {} Line Width").format(graphic_name), command_id="change_" + graphic_name + "_line_width")
-                return CalibratedWidthBinding(display_item, ClosingPropertyBinding(property_model, "value"))
+                property_model_f = GraphicPropertyCommandModel[float](self.document_controller, display_item, graphic, "width", title=_("Change {} Line Width").format(graphic_name), command_id="change_" + graphic_name + "_line_width")
+                return CalibratedWidthBinding(display_item, ClosingPropertyBinding(property_model_f, "value"))
         return None
 
     def __make_component_content(self, graphic: Graphics.Graphic) -> Declarative.UIDescription:

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -1692,12 +1692,7 @@ class CalibrationStyleModelAdapter(typing.Protocol):
 
 class DimensionalCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
     def get_calibrations(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
-        dimensional_shape = display_calibration_info.dimensional_shape
-        dimensional_calibrations = display_calibration_info.dimensional_calibrations
-        if dimensional_calibrations and dimensional_shape:
-            metadata = display_calibration_info.display_data_metadata
-            return calibration_style.get_dimensional_calibrations(dimensional_shape, dimensional_calibrations, metadata)
-        return [Calibration.Calibration() for _ in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()]
+        return display_calibration_info.get_dimensional_calibrations_for_calibration_style(calibration_style)
 
     def get_calibration_style(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> DisplayItem.CalibrationStyle:
         return display_calibration_info.calibration_style
@@ -1711,10 +1706,7 @@ class DimensionalCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
 
 class IntensityCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
     def get_calibrations(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
-        intensity_calibration = display_calibration_info.intensity_calibration
-        if intensity_calibration:
-            return [calibration_style.get_intensity_calibration(intensity_calibration)]
-        return [Calibration.Calibration()]
+        return display_calibration_info.get_intensity_calibrations_for_calibration_style(calibration_style)
 
     def get_calibration_style(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> DisplayItem.CalibrationStyle:
         return display_calibration_info.intensity_calibration_style
@@ -2510,7 +2502,8 @@ class CalibratedValueFloatToStringConverter(Converter.ConverterLike[float, str])
 
     def __get_calibration(self) -> Calibration.Calibration:
         index = self.__index
-        calibrations = self.__display_item.displayed_display_data_calibrations
+        display_calibration_info = self.__display_item.display_calibration_info
+        calibrations = display_calibration_info.displayed_display_data_calibrations if display_calibration_info else None
         if not calibrations:
             return Calibration.Calibration()
         if self.__uniform:
@@ -2530,7 +2523,8 @@ class CalibratedValueFloatToStringConverter(Converter.ConverterLike[float, str])
 
     def __get_data_size(self) -> int:
         index = self.__index
-        display_data_shape = self.__display_item.display_data_shape
+        display_calibration_info = self.__display_item.display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
         dimension_count = len(display_data_shape) if display_data_shape is not None else 0
         if index < 0:
             index = dimension_count + index
@@ -2588,7 +2582,8 @@ class CalibratedSizeFloatToStringConverter(Converter.ConverterLike[float, str]):
 
     def __get_calibration(self) -> Calibration.Calibration:
         index = self.__index
-        calibrations = self.__display_item.displayed_display_data_calibrations
+        display_calibration_info = self.__display_item.display_calibration_info
+        calibrations = display_calibration_info.displayed_display_data_calibrations if display_calibration_info else None
         if not calibrations:
             return Calibration.Calibration()
         if self.__uniform:
@@ -2605,7 +2600,8 @@ class CalibratedSizeFloatToStringConverter(Converter.ConverterLike[float, str]):
 
     def __get_data_size(self) -> int:
         index = self.__index
-        display_data_shape = self.__display_item.display_data_shape
+        display_calibration_info = self.__display_item.display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
         dimension_count = len(display_data_shape) if display_data_shape else 0
         if index < 0:
             index = dimension_count + index
@@ -2655,8 +2651,9 @@ class CalibratedBinding(Binding.Binding):
         self.update_target_direct(self.get_target_value())
 
     def __calibrations_changed(self, key: str) -> None:
-        if key == "displayed_display_data_calibrations":
-            self.__update_target(self.__display_item.displayed_display_data_calibrations)
+        display_calibration_info = self.__display_item.display_calibration_info
+        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
+            self.__update_target(display_calibration_info.displayed_display_data_calibrations)
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
@@ -2684,7 +2681,8 @@ class CalibratedSizeBinding(CalibratedBinding):
 
 class CalibratedWidthBinding(CalibratedBinding):
     def __init__(self, display_item: DisplayItem.DisplayItem, value_binding: Binding.Binding) -> None:
-        display_data_shape = display_item.display_data_shape
+        display_calibration_info = display_item.display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
         factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
         converter = CalibratedSizeFloatToStringConverter(display_item, 0, factor)  # width is stored in pixels. argh.
         super().__init__(display_item, value_binding, converter)
@@ -2707,8 +2705,9 @@ class CalibratedLengthBinding(Binding.Binding):
         self.update_target_direct(self.get_target_value())
 
     def __calibrations_changed(self, key: str) -> None:
-        if key == "displayed_display_data_calibrations":
-            self.__update_target(self.__display_item.displayed_display_data_calibrations)
+        display_calibration_info = self.__display_item.display_calibration_info
+        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
+            self.__update_target(display_calibration_info.displayed_display_data_calibrations)
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
@@ -2750,8 +2749,9 @@ class CalibratedAngleBinding(Binding.Binding):
         self.update_target_direct(self.get_target_value())
 
     def __calibrations_changed(self, key: str) -> None:
-        if key == "displayed_display_data_calibrations":
-            self.__update_target(self.__display_item.displayed_display_data_calibrations)
+        display_calibration_info = self.__display_item.display_calibration_info
+        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
+            self.__update_target(display_calibration_info.displayed_display_data_calibrations)
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
@@ -3068,7 +3068,8 @@ class GraphicsInspectorHandler(Declarative.Handler):
 
     def __create_line_profile_shape_and_pos(self) -> Declarative.UIDescriptionResult:
         u = Declarative.DeclarativeUI()
-        display_data_shape = self.__display_item.display_data_shape
+        display_calibration_info = self.__display_item.display_calibration_info
+        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
         factor = 1.0 / (display_data_shape[0] if display_data_shape is not None else 1)
         self._line_profile_width_model = DisplayItemCalibratedValueModel(
             GraphicPropertyCommandModel(self.__document_controller, self.__display_item, self.__graphic, "width", title=_("Change Width"), command_id="change_line_profile_width"),

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2767,34 +2767,42 @@ class CalibratedAngleBinding(CalibratedBinding):
 class CalibratedLengthBinding(Binding.Binding):
     def __init__(self, display_item: DisplayItem.DisplayItem, start_binding: Binding.Binding, end_binding: Binding.Binding) -> None:
         super().__init__(None)
-        self.__display_item = display_item
-        self.__x_converter = CalibratedValueFloatToStringConverter(display_item, 1, uniform=True)
-        self.__y_converter = CalibratedValueFloatToStringConverter(display_item, 0, uniform=True)
-        self.__size_converter = CalibratedSizeFloatToStringConverter(display_item, 0, uniform=True)
+        self.__display_calibration_info = display_item.display_calibration_info
+        self.__display_item_listener = Stream.ValueStreamAction(display_item.display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__on_display_calibration_info_changed, self))
         self.__start_binding = start_binding
         self.__end_binding = end_binding
-        self.__start_binding.target_setter = ReferenceCounting.weak_partial(CalibratedLengthBinding.__update_target, self)
-        self.__end_binding.target_setter = ReferenceCounting.weak_partial(CalibratedLengthBinding.__update_target, self)
-        self.__calibrations_changed_event_listener = display_item.display_property_changed_event.listen(ReferenceCounting.weak_partial(CalibratedLengthBinding.__calibrations_changed, self))
+        self.__start_binding.target_setter = ReferenceCounting.weak_partial(self.__class__.__update_target, self)
+        self.__end_binding.target_setter = ReferenceCounting.weak_partial(self.__class__.__update_target, self)
 
     def __update_target(self, value: typing.Any) -> None:
         self.update_target_direct(self.get_target_value())
 
-    def __calibrations_changed(self, key: str) -> None:
-        display_calibration_info = self.__display_item.display_calibration_info
-        if key == "displayed_display_data_calibrations" and display_calibration_info is not None:
+    def __on_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        self.__display_calibration_info = display_calibration_info
+        if display_calibration_info:
             self.__update_target(display_calibration_info.displayed_display_data_calibrations)
+
+    def __get_calibration_and_data_size(self, dimension_index: int) -> DisplayItem.CalibrationAndDataSize:
+        if self.__display_calibration_info:
+            return self.__display_calibration_info.get_dimension_calibration_and_data_size(dimension_index, uniform=True)
+        else:
+            return DisplayItem.CalibrationAndDataSize(Calibration.Calibration(), 1)
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
         start = self.__start_binding.get_target_value() or Geometry.FloatPoint()
         end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
-        calibrated_start = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(start[0]), x=self.__x_converter.convert_to_calibrated_value(start[1]))
-        calibrated_end = Geometry.FloatPoint(y=self.__y_converter.convert_to_calibrated_value(end[0]), x=self.__x_converter.convert_to_calibrated_value(end[1]))
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x))
         delta = calibrated_end - calibrated_start
         angle = -math.atan2(delta.y, delta.x)
         new_calibrated_end = calibrated_start + target_value * Geometry.FloatSize(height=-math.sin(angle), width=math.cos(angle))
-        end = Geometry.FloatPoint(y=self.__y_converter.convert_from_calibrated_value(new_calibrated_end.y), x=self.__x_converter.convert_from_calibrated_value(new_calibrated_end.x))
+        end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.y),
+                                  x=x_calibration_and_data_size.calibration.convert_from_calibrated_value(new_calibrated_end.x))
         self.__end_binding.update_source(end)
 
     # get the value from the model and return it as a string suitable for the target ui element.
@@ -2802,10 +2810,14 @@ class CalibratedLengthBinding(Binding.Binding):
     def get_target_value(self) -> typing.Optional[str]:
         start = self.__start_binding.get_target_value() or Geometry.FloatPoint()
         end = self.__end_binding.get_target_value() or Geometry.FloatPoint()
-        calibrated_dy = self.__y_converter.convert_to_calibrated_value(end[0]) - self.__y_converter.convert_to_calibrated_value(start[0])
-        calibrated_dx = self.__x_converter.convert_to_calibrated_value(end[1]) - self.__x_converter.convert_to_calibrated_value(start[1])
-        calibrated_value = math.sqrt(calibrated_dx * calibrated_dx + calibrated_dy * calibrated_dy)
-        return self.__size_converter.convert_calibrated_value_to_str(calibrated_value)
+        y_calibration_and_data_size = self.__get_calibration_and_data_size(0)
+        x_calibration_and_data_size = self.__get_calibration_and_data_size(1)
+        calibrated_start = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(start.y),
+                                               x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(start.x))
+        calibrated_end = Geometry.FloatPoint(y=y_calibration_and_data_size.calibration.convert_to_calibrated_value(end.y),
+                                             x=x_calibration_and_data_size.calibration.convert_to_calibrated_value(end.x))
+        calibrated_distance = Geometry.distance(calibrated_end, calibrated_start)
+        return y_calibration_and_data_size.calibration.convert_calibrated_size_to_str(calibrated_distance)
 
 
 class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2664,41 +2664,28 @@ class CalibratedBinding(Binding.Binding):
         if display_calibration_info:
             self.__update_target(display_calibration_info.displayed_display_data_calibrations)
 
-    def __get_calibration(self) -> Calibration.Calibration:
-        dimension_index = self.__dimension_index
-        calibrations = self.__display_calibration_info.displayed_display_data_calibrations if self.__display_calibration_info else None
-        if not calibrations:
-            return Calibration.Calibration()
-        dimension_count = len(calibrations)
-        if dimension_index < 0:
-            dimension_index = dimension_count + dimension_index
-        if dimension_index >= 0 and dimension_index < dimension_count:
-            return calibrations[dimension_index]
+    def __get_calibration_and_data_size(self) -> DisplayItem.CalibrationAndDataSize:
+        if self.__display_calibration_info:
+            return self.__display_calibration_info.get_dimension_calibration_and_data_size(self.__dimension_index)
         else:
-            return Calibration.Calibration()
-
-    def __get_data_size(self) -> int:
-        index = self.__dimension_index
-        display_calibration_info = self.__display_calibration_info
-        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count and display_data_shape is not None:
-            return display_data_shape[index]
-        else:
-            return 1
+            return DisplayItem.CalibrationAndDataSize(Calibration.Calibration(), 1)
 
     # set the model value from the target ui element text.
     def update_source(self, target_value: typing.Any) -> None:
-        converted_value = self._convert_str_to_value(self.__get_calibration(), self.__display_calibration_info, self.__get_data_size(), target_value)
+        calibration_and_data_size = self.__get_calibration_and_data_size()
+        calibration = calibration_and_data_size.calibration
+        data_size = calibration_and_data_size.data_size
+        converted_value = self._convert_str_to_value(calibration, self.__display_calibration_info, data_size, target_value)
         self.__value_binding.update_source(converted_value)
 
     # get the value from the model and return it as a string suitable for the target ui element.
     # in this binding, it combines the two source bindings into one.
     def get_target_value(self) -> typing.Optional[str]:
         value = self.__value_binding.get_target_value()
-        return self._convert_value_to_str(self.__get_calibration(), self.__display_calibration_info, self.__get_data_size(), value) if value is not None else None
+        calibration_and_data_size = self.__get_calibration_and_data_size()
+        calibration = calibration_and_data_size.calibration
+        data_size = calibration_and_data_size.data_size
+        return self._convert_value_to_str(calibration, self.__display_calibration_info, data_size, value) if value is not None else None
 
     def _convert_str_to_value(self, calibration: Calibration.Calibration, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None, data_size: int, value_str: str | None) -> float | None:
         """Subclasses must override this method to convert from the string to the model value, using the calibration and data size as needed."""
@@ -2836,40 +2823,18 @@ class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):
         self.__value_str: str | None = None
         self.__update()
 
-    def __get_calibration(self) -> Calibration.Calibration:
-        dimension_index = self.__dimension_index
-        calibrations = self.__display_calibration_info.displayed_display_data_calibrations if self.__display_calibration_info else None
-        if not calibrations:
-            return Calibration.Calibration()
-        if self.__uniform:
-            unit_set = set(calibration.units if calibration.units else '' for calibration in calibrations)
-            if len(unit_set) > 1:
-                return Calibration.Calibration()
-        dimension_count = len(calibrations)
-        if dimension_index < 0:
-            dimension_index = dimension_count + dimension_index
-        if dimension_index >= 0 and dimension_index < dimension_count:
-            return calibrations[dimension_index]
+    def __get_calibration_and_data_size(self) -> DisplayItem.CalibrationAndDataSize:
+        if self.__display_calibration_info:
+            return self.__display_calibration_info.get_dimension_calibration_and_data_size(self.__dimension_index, uniform=self.__uniform)
         else:
-            return Calibration.Calibration()
-
-    def __get_data_size(self) -> int:
-        index = self.__dimension_index
-        display_calibration_info = self.__display_calibration_info
-        display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
-        dimension_count = len(display_data_shape) if display_data_shape is not None else 0
-        if index < 0:
-            index = dimension_count + index
-        if index >= 0 and index < dimension_count and display_data_shape is not None:
-            return display_data_shape[index]
-        else:
-            return 1
+            return DisplayItem.CalibrationAndDataSize(Calibration.Calibration(), 1)
 
     def __get_value_str(self) -> str | None:
         value_tuple = self.__property_model.value
         if value_tuple is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
+            calibration_and_data_size = self.__get_calibration_and_data_size()
+            calibration = calibration_and_data_size.calibration
+            data_size = calibration_and_data_size.data_size
             if self.__is_size:
                 return calibration.convert_to_calibrated_size_str(data_size * value_tuple[self.__dimension_index] * self.__factor, value_range=(0, data_size), samples=data_size)
             else:
@@ -2897,8 +2862,9 @@ class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):
     def value(self, value_str: str | None) -> None:
         new_value: float | None = None
         if value_str is not None:
-            calibration = self.__get_calibration()
-            data_size = self.__get_data_size()
+            calibration_and_data_size = self.__get_calibration_and_data_size()
+            calibration = calibration_and_data_size.calibration
+            data_size = calibration_and_data_size.data_size
             value = Converter.FloatToStringConverter().convert_back(value_str)
             if value is not None:
                 if self.__is_size:

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -1684,125 +1684,116 @@ class CalibrationHandler(Declarative.Handler):
 
 
 class CalibrationStyleModelAdapter(typing.Protocol):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]: ...
-    def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str: ...
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]: ...
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]: ...
+    def get_calibrations(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]: ...
+    def get_calibration_style(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> DisplayItem.CalibrationStyle: ...
+    def get_calibration_styles(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> typing.Sequence[DisplayItem.CalibrationStyle]: ...
     def get_calibration_style_id_property_name(self) -> str: ...
-    def get_calibration_styles_property_name(self) -> str: ...
-    def get_display_calibrations_property_name(self) -> str: ...
 
 
 class DimensionalCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
-        return display_item.calibration_styles
+    def get_calibrations(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        dimensional_shape = display_calibration_info.dimensional_shape
+        dimensional_calibrations = display_calibration_info.dimensional_calibrations
+        if dimensional_calibrations and dimensional_shape:
+            metadata = display_calibration_info.display_data_metadata
+            return calibration_style.get_dimensional_calibrations(dimensional_shape, dimensional_calibrations, metadata)
+        return [Calibration.Calibration() for _ in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()]
 
-    def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str:
-        return display_item.calibration_style_id
+    def get_calibration_style(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> DisplayItem.CalibrationStyle:
+        return display_calibration_info.calibration_style
 
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
-        return display_item.calibration_styles
-
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
-        return display_item.get_displayed_dimensional_calibrations_with_calibration_style(calibration_style)
+    def get_calibration_styles(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> typing.Sequence[DisplayItem.CalibrationStyle]:
+        return display_calibration_info.calibration_styles
 
     def get_calibration_style_id_property_name(self) -> str:
         return "calibration_style_id"
 
-    def get_calibration_styles_property_name(self) -> str:
-        return "calibration_styles"
-
-    def get_display_calibrations_property_name(self) -> str:
-        return "displayed_dimensional_calibrations"
-
 
 class IntensityCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
-        return display_item.intensity_calibration_styles
+    def get_calibrations(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        intensity_calibration = display_calibration_info.intensity_calibration
+        if intensity_calibration:
+            return [calibration_style.get_intensity_calibration(intensity_calibration)]
+        return [Calibration.Calibration()]
 
-    def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str:
-        return display_item.intensity_calibration_style_id
+    def get_calibration_style(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> DisplayItem.CalibrationStyle:
+        return display_calibration_info.intensity_calibration_style
 
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
-        return display_item.intensity_calibration_styles
-
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
-        return [display_item.get_displayed_intensity_calibration_with_calibration_style(calibration_style)]
+    def get_calibration_styles(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo) -> typing.Sequence[DisplayItem.CalibrationStyle]:
+        return display_calibration_info.intensity_calibration_styles
 
     def get_calibration_style_id_property_name(self) -> str:
         return "intensity_calibration_style_id"
 
-    def get_calibration_styles_property_name(self) -> str:
-        return "intensity_calibration_styles"
-
-    def get_display_calibrations_property_name(self) -> str:
-        return "displayed_intensity_calibration"
-
 
 class CalibrationStyleModel(Observable.Observable):
-    """"""
+    """A model represents the calibration styles available and chosen calibration style for a display item.
+
+    The items property is a read-only sequence of strings representing the available calibration styles for the display item.
+
+    The index property is a read/write integer and will update the display item to use the selected calibration style when set.
+
+    The adapter is used to adapt this model to either dimensional or intensity calibrations.
+    """
     def __init__(self, document_controller: DocumentController.DocumentController, display_item: DisplayItem.DisplayItem, adapter: CalibrationStyleModelAdapter) -> None:
         super().__init__()
         self.__document_controller = document_controller
         self.__display_item = display_item
         self.__adapter = adapter
-        self.__display_item_property_changed_listener = display_item.property_changed_event.listen(ReferenceCounting.weak_partial(CalibrationStyleModel.__handle_display_item_property_changed, self))
-        self.__display_item_display_property_changed_listener = display_item.display_property_changed_event.listen(ReferenceCounting.weak_partial(CalibrationStyleModel.__handle_display_item_property_changed, self))
-        self.__calibration_styles = self.__adapter.get_calibration_style(self.__display_item)
+        self.__last_display_calibration_info: DisplayItem.DisplayCalibrationInfo | None = None
+        self.__index: int | None = None
+        self.__items: tuple[str, ...] = tuple()
+        self.__calibration_styles: tuple[DisplayItem.CalibrationStyle, ...] = tuple()
+        display_calibration_info_stream = DisplayItem.DisplayCalibrationInfoStream(Stream.ValueStream(display_item))
+        self.__display_calibration_info_stream_action = Stream.ValueStreamAction(display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__handle_display_calibration_info_changed, self))
+        self.__update_items_and_index(display_calibration_info_stream.value)
 
-    def __handle_display_item_property_changed(self, name: str) -> None:
-        if name == self.__adapter.get_calibration_style_id_property_name():
-            self.notify_property_changed("calibration_style_id")
-            self.notify_property_changed("index")
-        if name == self.__adapter.get_calibration_styles_property_name():
-            self.__calibration_styles = self.__adapter.get_calibration_style(self.__display_item)
-            self.notify_property_changed("items")
-            self.notify_property_changed("index")
-        if name == self.__adapter.get_display_calibrations_property_name():
-            self.notify_property_changed("items")
-
-    @property
-    def items(self) -> typing.List[str]:
+    def __update_items_and_index(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        calibration_style = self.__adapter.get_calibration_style(display_calibration_info) if display_calibration_info else None
+        calibration_styles = self.__adapter.get_calibration_styles(display_calibration_info) if display_calibration_info else tuple()
+        index = calibration_styles.index(calibration_style) if calibration_style in calibration_styles else None
         items = list[str]()
-        for calibration_style in self.__calibration_styles:
-            calibration_style_label = calibration_style.label
-            if calibration_style.is_calibrated:
-                calibrations = self.__adapter.get_calibrations(self.__display_item, calibration_style)
+        for calibration_style_ in calibration_styles:
+            calibration_style_label = calibration_style_.label
+            if calibration_style_.is_calibrated:
+                calibrations = self.__adapter.get_calibrations(display_calibration_info, calibration_style_) if display_calibration_info else tuple()
                 units = [c.units or "-" for c in calibrations]
                 if units and all(unit == units[0] for unit in units):
                     calibration_style_label += " (" + units[0] + ")"
                 else:
                     calibration_style_label += " (" + "/".join(units) + ")"
             items.append(calibration_style_label)
-        return items
+        items_tuple = tuple(items)
+        if items_tuple != self.__items:
+            self.__items = items_tuple
+            self.notify_property_changed("items")
+        if index != self.__index:
+            self.__index = index
+            self.notify_property_changed("index")
+        self.__calibration_styles = tuple(calibration_styles)
+
+    def __handle_display_calibration_info_changed(self, display_calibration_info: DisplayItem.DisplayCalibrationInfo | None) -> None:
+        if self.__last_display_calibration_info != display_calibration_info:
+            self.__update_items_and_index(display_calibration_info)
+            self.__last_display_calibration_info = display_calibration_info
 
     @property
-    def index(self) -> typing.Optional[int]:
-        calibration_style_id = self.calibration_style_id
-        for i, calibration_style in enumerate(self.__calibration_styles):
-            if calibration_style.calibration_style_id == calibration_style_id:
-                return i
-        return 0
+    def items(self) -> typing.Sequence[str]:
+        return self.__items
+
+    @property
+    def index(self) -> int | None:
+        return self.__index
 
     @index.setter
-    def index(self, value: typing.Optional[int]) -> None:
+    def index(self, value: int | None) -> None:
         value = value or 0  # startup case
         if value != self.index:
             value = max(0, min(value, len(self.__calibration_styles) - 1))
-            self.calibration_style_id = self.__calibration_styles[value].calibration_style_id
-
-    @property
-    def calibration_style_id(self) -> str:
-        return self.__adapter.get_calibrated_style_id(self.__display_item)
-
-    @calibration_style_id.setter
-    def calibration_style_id(self, value: str) -> None:
-        if value != self.calibration_style_id:
-            command = ChangeDisplayItemPropertyCommand(self.__document_controller.document_model, self.__display_item, self.__adapter.get_calibration_style_id_property_name(), value)
+            calibration_style_id = self.__calibration_styles[value].calibration_style_id
+            command = ChangeDisplayItemPropertyCommand(self.__document_controller.document_model, self.__display_item, self.__adapter.get_calibration_style_id_property_name(), calibration_style_id)
             command.perform()
             self.__document_controller.push_undo_command(command)
-            self.notify_property_changed("calibration_style_id")
-            self.notify_property_changed("index")
 
 
 class CalibrationSectionHandler(Declarative.Handler):

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -1739,7 +1739,7 @@ class CalibrationStyleModel(Observable.Observable):
         self.__index: int | None = None
         self.__items: tuple[str, ...] = tuple()
         self.__calibration_styles: tuple[DisplayItem.CalibrationStyle, ...] = tuple()
-        display_calibration_info_stream = DisplayItem.DisplayCalibrationInfoStream(Stream.ValueStream(display_item))
+        display_calibration_info_stream = display_item.display_calibration_info_stream
         self.__display_calibration_info_stream_action = Stream.ValueStreamAction(display_calibration_info_stream, ReferenceCounting.weak_partial(self.__class__.__handle_display_calibration_info_changed, self))
         self.__update_items_and_index(display_calibration_info_stream.value)
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -1684,27 +1684,27 @@ class CalibrationHandler(Declarative.Handler):
 
 
 class CalibrationStyleModelAdapter(typing.Protocol):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]: ...
+    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]: ...
     def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str: ...
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]: ...
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyleLike) -> typing.Sequence[Calibration.Calibration]: ...
+    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]: ...
+    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]: ...
     def get_calibration_style_id_property_name(self) -> str: ...
     def get_calibration_styles_property_name(self) -> str: ...
     def get_display_calibrations_property_name(self) -> str: ...
 
 
 class DimensionalCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]:
+    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
         return display_item.calibration_styles
 
     def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str:
         return display_item.calibration_style_id
 
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]:
+    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
         return display_item.calibration_styles
 
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyleLike) -> typing.Sequence[Calibration.Calibration]:
-        return display_item.get_displayed_dimensional_calibrations_with_calibration_style(typing.cast(DisplayItem.CalibrationStyle, calibration_style))
+    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        return display_item.get_displayed_dimensional_calibrations_with_calibration_style(calibration_style)
 
     def get_calibration_style_id_property_name(self) -> str:
         return "calibration_style_id"
@@ -1717,17 +1717,17 @@ class DimensionalCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
 
 
 class IntensityCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
-    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]:
+    def get_calibration_style(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
         return display_item.intensity_calibration_styles
 
     def get_calibrated_style_id(self, display_item: DisplayItem.DisplayItem) -> str:
         return display_item.intensity_calibration_style_id
 
-    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyleLike]:
+    def get_calibration_styles(self, display_item: DisplayItem.DisplayItem) -> typing.Sequence[DisplayItem.CalibrationStyle]:
         return display_item.intensity_calibration_styles
 
-    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyleLike) -> typing.Sequence[Calibration.Calibration]:
-        return [display_item.get_displayed_intensity_calibration_with_calibration_style(typing.cast(DisplayItem.CalibrationStyle, calibration_style))]
+    def get_calibrations(self, display_item: DisplayItem.DisplayItem, calibration_style: DisplayItem.CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        return [display_item.get_displayed_intensity_calibration_with_calibration_style(calibration_style)]
 
     def get_calibration_style_id_property_name(self) -> str:
         return "intensity_calibration_style_id"
@@ -1740,6 +1740,7 @@ class IntensityCalibrationStyleModelAdapter(CalibrationStyleModelAdapter):
 
 
 class CalibrationStyleModel(Observable.Observable):
+    """"""
     def __init__(self, document_controller: DocumentController.DocumentController, display_item: DisplayItem.DisplayItem, adapter: CalibrationStyleModelAdapter) -> None:
         super().__init__()
         self.__document_controller = document_controller
@@ -1927,14 +1928,6 @@ class CalibrationsInspectorSection(InspectorSection):
     @property
     def _intensity_calibration_model(self) -> CalibrationModel:
         return self.__intensity_calibration_model
-
-    @property
-    def _calibration_style_model(self) -> CalibrationStyleModel:
-        return self.__calibration_style_model
-
-    @property
-    def _intensity_calibration_style_model(self) -> CalibrationStyleModel:
-        return self.__intensity_calibration_style_model
 
 
 class ChangeDisplayTypeCommand(Undo.UndoableCommand):

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -3380,29 +3380,12 @@ class GraphicsSectionHandler(Declarative.Handler):
         self.__display_item = display_item
         self._graphics_model = graphics_model
         self._graphic_handlers: list[GraphicsInspectorHandler] = []
-
-        calibration_styles = display_item.calibration_styles
-        self.__display_calibration_style_options = [calibration_style.label for calibration_style in calibration_styles]
-        self.__display_calibration_style_ids = [calibration_style.calibration_style_id for calibration_style in
-                                                calibration_styles]
-        self.__display_calibration_style_reverse_map = {p: i for i, p in
-                                                        enumerate(self.__display_calibration_style_ids)}
-
-        self._current_calibration_index_model = Model.PropertyModel(
-            self.__display_calibration_style_reverse_map.get(self.__display_item.calibration_style_id))
-        self.__calibration_style_listener = self.__display_item.display_property_changed_event.listen(
-            ReferenceCounting.weak_partial(GraphicsSectionHandler.__update_calibration_id, self))
+        self._calibration_style_model = CalibrationStyleModel(document_controller, display_item, DimensionalCalibrationStyleModelAdapter())
 
         u = Declarative.DeclarativeUI()
         self.ui_view = u.create_column(
             u.create_column(items="_graphics_model.items", item_component_id="graphic", spacing=4),
-            u.create_row(
-                u.create_label(text=_("Display"), width=60, text_alignment_vertical="center"),
-                u.create_combo_box(items=self.__display_calibration_style_options,
-                                   current_index="@binding(_current_calibration_index_model.value)",
-                                   on_current_index_changed="_change_calibration_style_option"),
-                u.create_stretch()
-            ),
+            u.create_row(u.create_label(text=_("Display"), width=60), u.create_combo_box(items_ref="@binding(_calibration_style_model.items)", current_index="@binding(_calibration_style_model.index)"), u.create_stretch()),
             u.create_stretch()
         )
 
@@ -3413,13 +3396,6 @@ class GraphicsSectionHandler(Declarative.Handler):
             self._graphic_handlers.append(handler)
             return handler
         return None
-
-    def _change_calibration_style_option(self, widget: Declarative.UIWidget, current_index: int) -> None:
-        self.__display_item.calibration_style_id = self.__display_calibration_style_ids[current_index]
-
-    def __update_calibration_id(self, property_name: typing.Any) -> None:
-        if property_name == "calibration_style_id":
-            self._current_calibration_index_model.value = self.__display_calibration_style_reverse_map[self.__display_item.calibration_style_id]
 
 
 class GraphicsInspectorSection(InspectorSection):

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2791,9 +2791,31 @@ class FloatToTuplePropertyElementModel(Model.ValueModel[tuple[float, ...]]):
             self.notify_property_changed("value")
 
 
+class FloatPointToTuplePropertyModel(Model.ValueModel[tuple[float, ...]]):
+    """Model to represent a FloatPoint as a tuple model."""
+
+    def __init__(self, source: Model.ValueModel[Geometry.FloatPoint]):
+        super().__init__()
+        self.__source = source
+        self.__listener = self.__source.property_changed_event.listen(ReferenceCounting.weak_partial(self.__class__.__handle_source_changed, self))
+
+    @property
+    def value(self) -> tuple[float, ...] | None:
+        source_value = self.__source.value
+        return (source_value.y, source_value.x) if isinstance(source_value, Geometry.FloatPoint) else None
+
+    @value.setter
+    def value(self, new_value: tuple[float, ...] | None) -> None:
+        if self.value != new_value:
+            self.__source.value = Geometry.FloatPoint(y=new_value[0], x=new_value[1]) if new_value is not None and len(new_value) == 2 else None
+
+    def __handle_source_changed(self, property_name: str) -> None:
+        if property_name == "value":
+            self.notify_property_changed("value")
+
+
 class LineLengthModel(Model.PropertyModel[float]):
-    def __init__(self, start_model: Model.PropertyModel[typing.Any], end_model: Model.PropertyModel[typing.Any],
-                 display_item: DisplayItem.DisplayItem):
+    def __init__(self, start_model: Model.PropertyModel[Geometry.FloatPoint], end_model: Model.PropertyModel[Geometry.FloatPoint], display_item: DisplayItem.DisplayItem):
         super().__init__()
         self.__start_model = start_model
         self.__end_model = end_model
@@ -2847,8 +2869,7 @@ class LineLengthModel(Model.PropertyModel[float]):
 
 
 class LineAngleModel(Model.PropertyModel[float]):
-    def __init__(self, start_model: Model.PropertyModel[typing.Any], end_model: Model.PropertyModel[typing.Any],
-                 display_item: DisplayItem.DisplayItem):
+    def __init__(self, start_model: Model.PropertyModel[Geometry.FloatPoint], end_model: Model.PropertyModel[Geometry.FloatPoint], display_item: DisplayItem.DisplayItem):
         super().__init__()
         self.__start_model = start_model
         self.__end_model = end_model
@@ -3055,12 +3076,14 @@ class GraphicsInspectorHandler(Declarative.Handler):
 
     def __create_line_shape_and_pos(self) -> Declarative.UIDescriptionResult:
         u = Declarative.DeclarativeUI()
-        start_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "start", title=_("Change Line Start"), command_id="change_line_start")
-        end_model = GraphicPropertyCommandModel[tuple[float, ...]](self.__document_controller, self.__display_item, self.__graphic, "end", title=_("Change Line End"), command_id="change_line_end")
-        self._x0_model = DisplayItemCalibratedDimensionValueModel(start_model, self.__display_item, dimension_index=1, is_size=False)
-        self._y0_model = DisplayItemCalibratedDimensionValueModel(start_model, self.__display_item, dimension_index=0, is_size=False)
-        self._x1_model = DisplayItemCalibratedDimensionValueModel(end_model, self.__display_item, dimension_index=1, is_size=False)
-        self._y1_model = DisplayItemCalibratedDimensionValueModel(end_model, self.__display_item, dimension_index=0, is_size=False)
+        start_model = GraphicPropertyCommandModel[Geometry.FloatPoint](self.__document_controller, self.__display_item, self.__graphic, "start", title=_("Change Line Start"), command_id="change_line_start")
+        end_model = GraphicPropertyCommandModel[Geometry.FloatPoint](self.__document_controller, self.__display_item, self.__graphic, "end", title=_("Change Line End"), command_id="change_line_end")
+        start_tuple_model = FloatPointToTuplePropertyModel(start_model)
+        end_tuple_model = FloatPointToTuplePropertyModel(end_model)
+        self._x0_model = DisplayItemCalibratedDimensionValueModel(start_tuple_model, self.__display_item, dimension_index=1, is_size=False)
+        self._y0_model = DisplayItemCalibratedDimensionValueModel(start_tuple_model, self.__display_item, dimension_index=0, is_size=False)
+        self._x1_model = DisplayItemCalibratedDimensionValueModel(end_tuple_model, self.__display_item, dimension_index=1, is_size=False)
+        self._y1_model = DisplayItemCalibratedDimensionValueModel(end_tuple_model, self.__display_item, dimension_index=0, is_size=False)
         self._length_model = LineLengthModel(start_model, end_model, self.__display_item)
         self._angle_model = LineAngleModel(start_model, end_model, self.__display_item)
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2734,13 +2734,11 @@ class DisplayItemCalibratedDimensionValueModel(Model.ValueModel[str]):
                 else:
                     new_value = calibration.convert_from_calibrated_value(value) / data_size / self.__factor
         value_tuple = self.__property_model.value
-        new_value_tuple = value_tuple
-        if value_tuple is not None and new_value is not None:
+        # Only update the model if the value at the dimension has changed.
+        if value_tuple is not None and new_value is not None and value_tuple[self.__dimension_index] != new_value:
             value_list = list(value_tuple)
             value_list[self.__dimension_index] = new_value
-            new_value_tuple = tuple(value_list)
-        if new_value_tuple != value_tuple:
-            self.__property_model.value = new_value_tuple
+            self.__property_model.value = tuple(value_list)
 
 
 class TupleToFloatPropertyElementModel(Model.ValueModel[float]):

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -390,6 +390,21 @@ class LinePlotDisplayInfo:
             self.__legend_entries = legend_entries
         return self.__legend_entries
 
+    @property
+    def frame_index(self) -> int:
+        for display_values in self.__display_values_list:
+            if display_values:
+                data_metadata = display_values.element_data_metadata
+                if data_metadata:
+                    # allow registered metadata_display components to populate a dictionary
+                    # the line plot canvas item will look at "frame_index"
+                    d: Persistence.PersistentDictType = dict()
+                    for component in Registry.get_components_by_type("metadata_display"):
+                        component.populate(d, data_metadata)
+                    # pull out the frame_index key
+                    return typing.cast(int, d.get("frame_index", 0))
+        return 0
+
     def apply_display_data_delta(self, display_data_delta: DisplayItem.DisplayDataDelta) -> LinePlotDisplayInfo:
         """Apply the display data delta changes to this display info and return a new display info with the changes applied."""
 
@@ -610,15 +625,6 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         # update the line plot display info.
         self.__line_plot_display_info = self.__line_plot_display_info.apply_display_data_delta(display_data_delta)
 
-        # update the frame rate info
-        display_values_list = display_data_delta.display_values_list
-        if display_values_list:
-            for display_values in display_values_list:
-                if display_values:
-                    data_metadata = display_values.element_data_metadata
-                    if data_metadata:
-                        self.__update_frame(data_metadata.metadata)
-
         # update the cursor info
         self.__update_cursor_info()
 
@@ -659,24 +665,14 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
             # update the graphics
             self.__line_graph_regions_canvas_item.set_regions(line_plot_display_info.regions)
 
+            # update frame rate info
+            if self.__frame_rate_canvas_item.display_frame_rate_id:
+                self.__frame_rate_canvas_item.frame_tick(line_plot_display_info.frame_index)
+
         self.__last_axes = line_plot_display_info.axes
 
     def set_focused(self, is_focused: bool) -> None:
         self.__line_graph_regions_canvas_item.set_is_focused(is_focused)
-
-    def __update_frame(self, metadata: DataAndMetadata.MetadataType) -> None:
-        # update frame rate info
-        if self.__frame_rate_canvas_item.display_frame_rate_id:
-            # allow registered metadata_display components to populate a dictionary
-            # the line plot canvas item will look at "frame_index"
-            d: Persistence.PersistentDictType = dict()
-            for component in Registry.get_components_by_type("metadata_display"):
-                component.populate(d, metadata)
-
-            # pull out the frame_index key
-            frame_index = d.get("frame_index", 0)
-
-            self.__frame_rate_canvas_item.frame_tick(frame_index)
 
     def __view_to_intervals(self, data_and_metadata: DataAndMetadata.DataAndMetadata, intervals: typing.List[typing.Tuple[float, float]]) -> None:
         """Change the view to encompass the channels and data represented by the given intervals."""

--- a/nion/swift/Thumbnails.py
+++ b/nion/swift/Thumbnails.py
@@ -130,7 +130,9 @@ class ThumbnailSource:
         ui = self._ui
         try:
             display_item = self.__display_item
-            if display_item.display_data_shape and len(display_item.display_data_shape) == 2:
+            display_calibration_info = display_item.display_calibration_info
+            display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+            if display_data_shape and len(display_data_shape) == 2:
                 pixel_shape = Geometry.IntSize(height=512, width=512)
             else:
                 pixel_shape = Geometry.IntSize(height=308, width=512)

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3551,7 +3551,7 @@ class DisplayCalibrationInfo:
             if uniform:
                 unit_set = set(calibration.units if calibration.units else '' for calibration in dimension_calibrations)
                 if len(unit_set) > 1:
-                    return CalibrationAndDataSize(Calibration.Calibration(), 1)
+                    return CalibrationAndDataSize(Calibration.Calibration(), display_data_shape[dimension_index])
             dimension_count = len(dimension_calibrations)
             if dimension_index < 0:
                 dimension_index = dimension_count + dimension_index

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3366,6 +3366,12 @@ class DisplayItem(Persistence.PersistentObject):
         return str(), str()
 
 
+@dataclasses.dataclass
+class CalibrationAndDataSize:
+    calibration: Calibration.Calibration
+    data_size: int
+
+
 class DisplayCalibrationInfo:
     """Represents the calibration information for a display.
 
@@ -3537,6 +3543,24 @@ class DisplayCalibrationInfo:
     @property
     def intensity_calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
         return get_intensity_calibration_styles(self.__data_metadata_list)
+
+    def get_dimension_calibration_and_data_size(self, dimension_index: int, *, uniform: bool = False) -> CalibrationAndDataSize:
+        dimension_calibrations = self.displayed_display_data_calibrations
+        display_data_shape = self.display_data_shape
+        if dimension_calibrations is not None and display_data_shape is not None and len(dimension_calibrations) == len(display_data_shape):
+            if uniform:
+                unit_set = set(calibration.units if calibration.units else '' for calibration in dimension_calibrations)
+                if len(unit_set) > 1:
+                    return CalibrationAndDataSize(Calibration.Calibration(), 1)
+            dimension_count = len(dimension_calibrations)
+            if dimension_index < 0:
+                dimension_index = dimension_count + dimension_index
+            if dimension_index >= 0 and dimension_index < dimension_count:
+                return CalibrationAndDataSize(dimension_calibrations[dimension_index], display_data_shape[dimension_index])
+            else:
+                return CalibrationAndDataSize(Calibration.Calibration(), 1)
+        else:
+            return CalibrationAndDataSize(Calibration.Calibration(), 1)
 
     @property
     def calibrated_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration] | None:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2158,7 +2158,6 @@ class DisplayItem(Persistence.PersistentObject):
         self.__display_data_channel_data_item_description_changed_event_listeners: typing.List[Event.EventListener] = list()
         self.__display_data_channel_data_item_proxy_changed_event_listeners: typing.List[Event.EventListener] = list()
 
-        self.display_property_changed_event = Event.Event()
         self.display_changed_event = Event.Event()
         self.display_item_will_close_event = Event.Event()  # used to shut down thumbnail
 
@@ -2419,10 +2418,6 @@ class DisplayItem(Persistence.PersistentObject):
         if name == "title":
             self.__specified_title_stream.value = value
             self.notify_property_changed("displayed_title")
-        if name == "calibration_style_id":
-            self.display_property_changed_event.fire("calibration_style_id")
-        if name == "intensity_calibration_style_id":
-            self.display_property_changed_event.fire("intensity_calibration_style_id")
 
     def __display_properties_changed(self, name: str, value: typing.Any) -> None:
         self.notify_property_changed(name)
@@ -2538,16 +2533,6 @@ class DisplayItem(Persistence.PersistentObject):
             else:
                 display_properties.pop(property_name, None)
             self.display_properties = display_properties
-            self.display_property_changed_event.fire(property_name)
-            # TODO: neither graphics_changed_event.fire is probably not necessary since these will change the display calibration info instead.
-            if property_name in ("displayed_dimensional_scales", "displayed_dimensional_calibrations", "displayed_intensity_calibration"):
-                self.graphics_changed_event.fire(self.graphic_selection)
-            if property_name in ("calibration_style_id", "intensity_calibration_style_id"):
-                self.display_property_changed_event.fire("displayed_dimensional_scales")
-                self.display_property_changed_event.fire("displayed_dimensional_calibrations")
-                self.display_property_changed_event.fire("displayed_intensity_calibration")
-                self.display_property_changed_event.fire("displayed_display_data_calibrations")
-                self.graphics_changed_event.fire(self.graphic_selection)
             self.display_changed_event.fire()
 
     def insert_display_layer(self, before_index: int, display_layer: DisplayLayer) -> None:
@@ -2827,11 +2812,6 @@ class DisplayItem(Persistence.PersistentObject):
     def __update_displays(self) -> None:
         for display_data_channel in self.display_data_channels:
             display_data_channel.update_display_data()
-
-        self.display_property_changed_event.fire("displayed_dimensional_scales")
-        self.display_property_changed_event.fire("displayed_dimensional_calibrations")
-        self.display_property_changed_event.fire("displayed_intensity_calibration")
-        self.display_property_changed_event.fire("displayed_display_data_calibrations")
 
         self.display_changed_event.fire()
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3601,7 +3601,7 @@ class DisplayCalibrationInfo:
 
     def __ne__(self, other: typing.Any) -> bool:
         if not isinstance(other, DisplayCalibrationInfo):
-            return False
+            return True
         display_calibration_info = other
         if not display_calibration_info:
             return True

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2182,7 +2182,11 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
         self.__display_layers_list = self.__display_item.display_layer_info_list
 
     def __get_display_calibration_info(self) -> DisplayCalibrationInfo:
-        return DisplayCalibrationInfo(self.display_data_shape,
+        return DisplayCalibrationInfo(self.dimensional_shape,
+                                      self.dimensional_calibrations,
+                                      self.intensity_calibration,
+                                      self.display_data_shape,
+                                      self.metadata,
                                       self.scales,
                                       self.displayed_dimensional_calibrations,
                                       self.displayed_intensity_calibration,
@@ -2489,7 +2493,7 @@ class DisplayItem(Persistence.PersistentObject):
         self._set_persistent_property_value("display_type", value)
 
     @property
-    def display_data_delta_stream(self) -> Stream.ValueStream[DisplayDataDelta]:
+    def display_data_delta_stream(self) -> DisplayDataDeltaStream:
         return self.__display_data_delta_stream
 
     @property
@@ -3232,10 +3236,6 @@ class DisplayItem(Persistence.PersistentObject):
         self.graphics_changed_event.fire(self.graphic_selection)
 
     @property
-    def calibration_style(self) -> CalibrationStyle:
-        return self.__display_data_delta_stream.calibration_style
-
-    @property
     def display_data_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
         return self.__display_data_delta_stream.display_data_shape
 
@@ -3244,29 +3244,9 @@ class DisplayItem(Persistence.PersistentObject):
         return self.__display_data_delta_stream.displayed_display_data_calibrations
 
     @property
-    def displayed_dimensional_scales(self) -> typing.Optional[typing.Tuple[float, ...]]:
-        """The scale of the fractional coordinate system.
-
-        For displays associated with a single data item, this matches the size of the data.
-
-        For displays associated with a composite data item, this must be stored in this class.
-        """
-        return self.__display_data_delta_stream.scales
-
-    @property
     def datum_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
         """The calibrations for only datum dimensions."""
         return self.__display_data_delta_stream.datum_calibrations
-
-    def get_displayed_dimensional_calibrations_with_calibration_style(self, calibration_style: CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
-        dimensional_shape = self.__display_data_delta_stream.dimensional_shape
-        dimensional_calibrations = self.__display_data_delta_stream.dimensional_calibrations
-        if dimensional_calibrations and dimensional_shape:
-            display_data_channel = self.display_data_channel
-            data_item = display_data_channel.data_item if display_data_channel else None
-            metadata = data_item.metadata if data_item else None
-            return calibration_style.get_dimensional_calibrations(dimensional_shape, dimensional_calibrations, metadata)
-        return [Calibration.Calibration() for c in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()]
 
     @property
     def displayed_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
@@ -3278,12 +3258,6 @@ class DisplayItem(Persistence.PersistentObject):
         """The calibrations for all data dimensions in a calibrated style if possible or None."""
         return self.__display_data_delta_stream.calibrated_dimensional_calibrations
 
-    def get_displayed_intensity_calibration_with_calibration_style(self, calibration_style: CalibrationStyle) -> Calibration.Calibration:
-        intensity_calibration = self.__display_data_delta_stream.intensity_calibration
-        if intensity_calibration:
-            return calibration_style.get_intensity_calibration(intensity_calibration)
-        return Calibration.Calibration()
-
     @property
     def displayed_intensity_calibration(self) -> Calibration.Calibration:
         return self.__display_data_delta_stream.displayed_intensity_calibration
@@ -3291,10 +3265,6 @@ class DisplayItem(Persistence.PersistentObject):
     @property
     def calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
         return self.__display_data_delta_stream.calibration_styles
-
-    @property
-    def intensity_calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
-        return self.__display_data_delta_stream.intensity_calibration_styles
 
     @dataclasses.dataclass
     class DataInfo:
@@ -3578,7 +3548,11 @@ class DisplayItem(Persistence.PersistentObject):
 
 class DisplayCalibrationInfo:
     def __init__(self,
+                 dimensional_shape: DataAndMetadata.ShapeType | None,
+                 dimensional_calibrations: typing.Sequence[Calibration.Calibration] | None,
+                 intensity_calibration: Calibration.Calibration | None,
                  display_data_shape: DataAndMetadata.ShapeType | None,
+                 display_data_metadata: DataAndMetadata.MetadataType | None,
                  displayed_dimensional_scales: typing.Tuple[float, ...] | None,
                  displayed_dimensional_calibrations: typing.Sequence[Calibration.Calibration],
                  displayed_intensity_calibration: Calibration.Calibration,
@@ -3589,7 +3563,11 @@ class DisplayCalibrationInfo:
                  intensity_calibration_styles: typing.Sequence[CalibrationStyle]
                  ) -> None:
         assert all(calibration.is_valid for calibration in displayed_dimensional_calibrations)
+        self.dimensional_shape = dimensional_shape
+        self.dimensional_calibrations = dimensional_calibrations
+        self.intensity_calibration = intensity_calibration
         self.display_data_shape = display_data_shape
+        self.display_data_metadata = display_data_metadata
         self.displayed_dimensional_scales = displayed_dimensional_scales
         self.displayed_dimensional_calibrations = displayed_dimensional_calibrations
         self.displayed_intensity_calibration = displayed_intensity_calibration
@@ -3605,23 +3583,31 @@ class DisplayCalibrationInfo:
         display_calibration_info = other
         if not display_calibration_info:
             return True
-        if  self.display_data_shape != display_calibration_info.display_data_shape:
+        if self.dimensional_shape != display_calibration_info.dimensional_shape:
             return True
-        if  self.displayed_dimensional_scales != display_calibration_info.displayed_dimensional_scales:
+        if self.dimensional_calibrations != display_calibration_info.dimensional_calibrations:
             return True
-        if  self.displayed_dimensional_calibrations != display_calibration_info.displayed_dimensional_calibrations:
+        if self.intensity_calibration != display_calibration_info.intensity_calibration:
             return True
-        if  self.displayed_intensity_calibration != display_calibration_info.displayed_intensity_calibration:
+        if self.display_data_shape != display_calibration_info.display_data_shape:
             return True
-        if  self.datum_calibrations != display_calibration_info.datum_calibrations:
+        if self.display_data_metadata != display_calibration_info.display_data_metadata:
             return True
-        if  type(self.calibration_style) != type(display_calibration_info.calibration_style):
+        if self.displayed_dimensional_scales != display_calibration_info.displayed_dimensional_scales:
             return True
-        if  type(self.intensity_calibration_style) != type(display_calibration_info.intensity_calibration_style):
+        if self.displayed_dimensional_calibrations != display_calibration_info.displayed_dimensional_calibrations:
             return True
-        if  self.calibration_styles != display_calibration_info.calibration_styles:
+        if self.displayed_intensity_calibration != display_calibration_info.displayed_intensity_calibration:
             return True
-        if  self.intensity_calibration_styles != display_calibration_info.intensity_calibration_styles:
+        if self.datum_calibrations != display_calibration_info.datum_calibrations:
+            return True
+        if type(self.calibration_style) != type(display_calibration_info.calibration_style):
+            return True
+        if type(self.intensity_calibration_style) != type(display_calibration_info.intensity_calibration_style):
+            return True
+        if self.calibration_styles != display_calibration_info.calibration_styles:
+            return True
+        if self.intensity_calibration_styles != display_calibration_info.intensity_calibration_styles:
             return True
         return False
 
@@ -3643,7 +3629,11 @@ class DisplayCalibrationInfoStream(Stream.ValueStream[DisplayCalibrationInfo]):
             self.__handle_display_data_delta_stream(None)
 
     def __handle_display_data_delta_stream(self, value: typing.Optional[DisplayDataDelta]) -> None:
-        self.value = value.display_calibration_info if value else None
+        if value:
+            if self.value is None or value.display_calibration_info_changed:
+                self.value = value.display_calibration_info
+        else:
+            self.value = None
 
 
 def sort_by_date_key(display_item: DisplayItem) -> typing.Tuple[typing.Optional[str], datetime.datetime, str]:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2217,6 +2217,20 @@ class DisplayItem(Persistence.PersistentObject):
             Stream.PropertyChangedEventStream[str](self, "intensity_calibration_style_id"),
         )
 
+        # configure the display_calibration_info_stream.
+
+        def handle_display_data_delta_stream(display_calibration_info_stream: Stream.ValueStream[DisplayCalibrationInfo], value: DisplayDataDelta | None) -> None:
+            if value is not None:
+                if display_calibration_info_stream.value is None or value.display_calibration_info_changed:
+                    display_calibration_info_stream.value = value.display_calibration_info
+            else:
+                display_calibration_info_stream.value = None
+
+        self.__display_calibration_info_stream = Stream.ValueStream[DisplayCalibrationInfo]()
+        self.__display_data_delta_stream_action = Stream.ValueStreamAction(self.__display_data_delta_stream, functools.partial(handle_display_data_delta_stream, self.__display_calibration_info_stream))
+
+        # configure the graphic selection changes listener.
+
         def graphic_selection_changed() -> None:
             # relay the message
             self.graphic_selection_changed_event.fire(self.graphic_selection)
@@ -3057,10 +3071,12 @@ class DisplayItem(Persistence.PersistentObject):
         self.graphics_changed_event.fire(self.graphic_selection)
 
     @property
+    def display_calibration_info_stream(self) -> Stream.ValueStream[DisplayCalibrationInfo]:
+        return self.__display_calibration_info_stream
+
+    @property
     def display_calibration_info(self) -> DisplayCalibrationInfo | None:
-        """Return the latest display calibration info."""
-        display_data_delta = self.__display_data_delta_stream.value
-        return display_data_delta.display_calibration_info if display_data_delta is not None else None
+        return self.__display_calibration_info_stream.value
 
     @dataclasses.dataclass
     class DataInfo:

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3569,30 +3569,6 @@ class DisplayCalibrationInfo:
         return None
 
 
-class DisplayCalibrationInfoStream(Stream.ValueStream[DisplayCalibrationInfo]):
-    def __init__(self, display_item_stream: Stream.AbstractStream[DisplayItem]) -> None:
-        super().__init__()
-        self.__display_item_stream = display_item_stream.add_ref()
-        self.__display_stream_listener = display_item_stream.value_stream.listen(ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__display_item_changed, self))
-        self.__display_data_delta_stream_action: typing.Optional[Stream.ValueStreamAction[DisplayDataDelta]] = None
-        self.__display_item_changed(display_item_stream.value)
-
-    def __display_item_changed(self, display_item: typing.Optional[DisplayItem]) -> None:
-        if display_item:
-            self.__display_data_delta_stream_action = Stream.ValueStreamAction(display_item.display_data_delta_stream, ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__handle_display_data_delta_stream, self))
-            self.__handle_display_data_delta_stream(display_item.display_data_delta_stream.value)
-        else:
-            self.__display_data_delta_stream_action = None
-            self.__handle_display_data_delta_stream(None)
-
-    def __handle_display_data_delta_stream(self, value: typing.Optional[DisplayDataDelta]) -> None:
-        if value:
-            if self.value is None or value.display_calibration_info_changed:
-                self.value = value.display_calibration_info
-        else:
-            self.value = None
-
-
 def sort_by_date_key(display_item: DisplayItem) -> typing.Tuple[typing.Optional[str], datetime.datetime, str]:
     """A sort key for display items. The sort by uuid makes it determinate."""
     assert not display_item._closed

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1945,11 +1945,7 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
         self.__display_values_list = list[typing.Optional[DisplayValues]]()
         self.__display_data_channel_actions = list[typing.Optional[Stream.ValueStreamAction[DisplayValues]]]()
 
-        self.__dimensional_calibrations: typing.Optional[DataAndMetadata.CalibrationListType] = None
-        self.__intensity_calibration: typing.Optional[Calibration.Calibration] = None
-        self.__scales = 0.0, 1.0
-        self.__dimensional_shape: typing.Optional[DataAndMetadata.ShapeType] = None
-        self.__is_composite_data: bool = False
+        self.__data_metadata_list = list[DataAndMetadata.DataMetadata | None]()
         self.__graphics = list[Graphics.Graphic]()
         self.__graphic_selection = copy.copy(display_item.graphic_selection)
         self.__display_layers = list[DisplayLayer]()
@@ -2011,30 +2007,6 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
             display_data_delta.mark_changed()
         self.__last_display_data_delta = display_data_delta
         self.send_value(display_data_delta)
-
-    @property
-    def dimensional_calibrations(self) -> typing.Optional[DataAndMetadata.CalibrationListType]:
-        return self.__dimensional_calibrations
-
-    @property
-    def intensity_calibration(self) -> typing.Optional[Calibration.Calibration]:
-        return self.__intensity_calibration
-
-    @property
-    def scales(self) -> typing.Tuple[float, float]:
-        return self.__scales
-
-    @property
-    def dimensional_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
-        return self.__dimensional_shape
-
-    @property
-    def metadata(self) -> typing.Optional[DataAndMetadata.MetadataType]:
-        return self.__metadata
-
-    @property
-    def is_composite_data(self) -> bool:
-        return self.__is_composite_data
 
     @property
     def graphics(self) -> typing.Sequence[Graphics.Graphic]:
@@ -2136,65 +2108,13 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
 
     def __update(self) -> None:
         display_values_list = self.__display_values_list
-        dimensional_calibrations: typing.Optional[DataAndMetadata.CalibrationListType] = None
-        intensity_calibration: typing.Optional[Calibration.Calibration] = None
-        scales = 0.0, 1.0
-        dimensional_shape: typing.Optional[DataAndMetadata.ShapeType] = None
-        metadata: typing.Optional[DataAndMetadata.MetadataType] = None
-        if display_values_list:
-            data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-            data_metadata0 = data_metadata_list[0]
-            if data_metadata0 and len(data_metadata0.dimensional_calibrations) > 0:
-                dimensional_calibrations = list(data_metadata0.dimensional_calibrations)
-                if len(dimensional_calibrations) > 1:
-                    intensity_calibration = data_metadata0.intensity_calibration
-                    scales = 0, data_metadata0.dimensional_shape[-1]
-                    dimensional_shape = data_metadata0.dimensional_shape
-                else:
-                    units = dimensional_calibrations[-1].units
-                    mn = math.inf
-                    mx = -math.inf
-                    for data_metadata in data_metadata_list:
-                        if data_metadata and data_metadata.dimensional_calibrations[-1].units == units:
-                            v = dimensional_calibrations[0].convert_from_calibrated_value(
-                                data_metadata.dimensional_calibrations[-1].convert_to_calibrated_value(0))
-                            mn = min(mn, v)
-                            mx = max(mx, v)
-                            v = dimensional_calibrations[0].convert_from_calibrated_value(
-                                data_metadata.dimensional_calibrations[-1].convert_to_calibrated_value(data_metadata.dimensional_shape[-1]))
-                            mn = min(mn, v)
-                            mx = max(mx, v)
-                    intensity_calibration = data_metadata0.intensity_calibration
-                    if math.isfinite(mn) and math.isfinite(mx):
-                        scales = mn, mx
-                        dimensional_shape = (int(mx - mn),)
-                    else:
-                        scales = 0, data_metadata0.dimensional_shape[-1]
-                        dimensional_shape = data_metadata0.dimensional_shape
-            if data_metadata0 and len(data_metadata_list) == 1:
-                metadata = data_metadata0.metadata
-        self.__dimensional_calibrations = dimensional_calibrations
-        self.__intensity_calibration = intensity_calibration
-        self.__scales = scales
-        self.__dimensional_shape = dimensional_shape
-        self.__metadata = metadata
-        self.__is_composite_data = len(display_values_list) > 1
+        self.__data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
         self.__display_layers_list = self.__display_item.display_layer_info_list
 
     def __get_display_calibration_info(self) -> DisplayCalibrationInfo:
-        return DisplayCalibrationInfo(self.dimensional_shape,
-                                      self.dimensional_calibrations,
-                                      self.intensity_calibration,
-                                      self.display_data_shape,
-                                      self.metadata,
-                                      self.scales,
-                                      self.displayed_dimensional_calibrations,
-                                      self.displayed_intensity_calibration,
-                                      self.calibration_style,
-                                      self.intensity_calibration_style,
-                                      list(self.datum_calibrations),
-                                      self.calibration_styles,
-                                      self.intensity_calibration_styles)
+        return DisplayCalibrationInfo(self.__data_metadata_list,
+                                      self.__calibration_style_id_stream.value,
+                                      self.__intensity_calibration_style_id_stream.value)
 
     def __update_display_calibration_info(self, value: typing.Optional[str]) -> None:
         self.__update()
@@ -2204,107 +2124,6 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
         self.__last_display_data_delta = None
         self.__update()
         self.__send_delta()
-
-    @property
-    def display_data_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
-        display_values_list = self.__display_values_list
-        data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-        if len(data_metadata_list) == 1 and (data_metadata := data_metadata_list[0]):
-            return DisplayDataShapeCalculator(data_metadata).shape
-        return self.dimensional_shape if self.is_composite_data else None
-
-    @property
-    def calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
-        display_values_list = self.__display_values_list
-        data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-        return get_calibration_styles(data_metadata_list)
-
-    @property
-    def intensity_calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
-        display_values_list = self.__display_values_list
-        data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-        return get_intensity_calibration_styles(data_metadata_list)
-
-    def get_calibration_style_for_id(self, calibration_style_id: typing.Optional[str]) -> typing.Optional[CalibrationStyle]:
-        for calibration_style in self.calibration_styles:
-            if calibration_style.calibration_style_id == calibration_style_id:
-                return calibration_style
-        return None
-
-    def get_intensity_calibration_style_for_id(self, calibration_style_id: typing.Optional[str]) -> typing.Optional[CalibrationStyle]:
-        for calibration_style in self.intensity_calibration_styles:
-            if calibration_style.calibration_style_id == calibration_style_id:
-                return calibration_style
-        return None
-
-    @property
-    def calibration_style(self) -> CalibrationStyle:
-        return self.get_calibration_style_for_id(self.__calibration_style_id_stream.value) or CalibrationStyleNative()
-
-    @property
-    def intensity_calibration_style(self) -> CalibrationStyle:
-        return self.get_intensity_calibration_style_for_id(self.__intensity_calibration_style_id_stream.value) or CalibrationStyleNative()
-
-    @property
-    def displayed_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
-        """The calibrations for all data dimensions in the displayed calibration style."""
-        if self.dimensional_calibrations and self.dimensional_shape:
-            return self.calibration_style.get_dimensional_calibrations(self.dimensional_shape, self.dimensional_calibrations, self.metadata)
-        return [Calibration.Calibration() for c in self.dimensional_calibrations] if self.dimensional_calibrations else [Calibration.Calibration()]
-
-    @property
-    def calibrated_dimensional_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
-        """Returns dimensional calibrations that are actually calibrated with units.
-
-        First checks the users displayed calibration style; if no units are present, checks the other calibration styles.
-        """
-        dimensional_calibrations = self.dimensional_calibrations
-        dimensional_shape = self.dimensional_shape
-        if dimensional_calibrations and dimensional_shape:
-            potential_dimensional_calibrations = self.calibration_style.get_dimensional_calibrations(dimensional_shape,
-                                                                                                     dimensional_calibrations,
-                                                                                                     self.metadata)
-            if potential_dimensional_calibrations:
-                if any(dimensional_calibration.units for dimensional_calibration in potential_dimensional_calibrations):
-                    return potential_dimensional_calibrations
-            for calibration_style in self.calibration_styles:
-                potential_dimensional_calibrations = calibration_style.get_dimensional_calibrations(dimensional_shape,
-                                                                                                    dimensional_calibrations,
-                                                                                                    self.metadata)
-                if potential_dimensional_calibrations:
-                    if any(dimensional_calibration.units for dimensional_calibration in
-                           potential_dimensional_calibrations):
-                        return potential_dimensional_calibrations
-        return None
-
-    @property
-    def displayed_intensity_calibration(self) -> Calibration.Calibration:
-        if self.intensity_calibration:
-            return self.intensity_calibration_style.get_intensity_calibration(self.intensity_calibration)
-        return Calibration.Calibration()
-
-    @property
-    def displayed_display_data_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
-        """The calibrations for only datum dimensions, in the displayed calibration style."""
-        displayed_dimensional_calibrations = self.displayed_dimensional_calibrations
-        display_values_list = self.__display_values_list
-        data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-        if len(data_metadata_list) == 1 and (data_metadata := data_metadata_list[0]):
-            indexes = DisplayDataShapeCalculator(data_metadata).indexes
-            return [displayed_dimensional_calibrations[i] for i in indexes] if indexes else None
-        return displayed_dimensional_calibrations if self.is_composite_data else None
-
-    @property
-    def datum_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
-        """The calibrations for only datum dimensions."""
-        display_values_list = self.__display_values_list
-        data_metadata_list = [display_values.data_metadata if display_values else None for display_values in display_values_list]
-        if len(data_metadata_list) == 1 and (data_metadata := data_metadata_list[0]):
-            datum_calibrations = DisplayDataShapeCalculator(data_metadata).calibrations
-            if datum_calibrations is not None:
-                return datum_calibrations
-        dimensional_calibrations = self.dimensional_calibrations
-        return [Calibration.Calibration() for c in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()]
 
 
 class DisplayItem(Persistence.PersistentObject):
@@ -2562,7 +2381,9 @@ class DisplayItem(Persistence.PersistentObject):
         self.display_changed_event.fire()
         self.graphics_changed_event.fire(self.graphic_selection)
         if self.used_display_type == "line_plot":
-            if self.display_data_shape and len(self.display_data_shape) == 2:
+            display_calibration_info = self.display_calibration_info
+            display_data_shape = display_calibration_info.display_data_shape if display_calibration_info else None
+            if display_data_shape and len(display_data_shape) == 2:
                 for display_layer in self.display_layers:
                     # use the version of remove that does not cascade
                     self.remove_item("display_layers", typing.cast(Persistence.PersistentObject, display_layer))
@@ -3236,19 +3057,6 @@ class DisplayItem(Persistence.PersistentObject):
         self.graphics_changed_event.fire(self.graphic_selection)
 
     @property
-    def display_data_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
-        return self.__display_data_delta_stream.display_data_shape
-
-    @property
-    def displayed_display_data_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
-        return self.__display_data_delta_stream.displayed_display_data_calibrations
-
-    @property
-    def datum_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
-        """The calibrations for only datum dimensions."""
-        return self.__display_data_delta_stream.datum_calibrations
-
-    @property
     def display_calibration_info(self) -> DisplayCalibrationInfo | None:
         """Return the latest display calibration info."""
         display_data_delta = self.__display_data_delta_stream.value
@@ -3263,12 +3071,18 @@ class DisplayItem(Persistence.PersistentObject):
 
     @property
     def data_info(self) -> DisplayItem.DataInfo:
-        display_data_shape = self.display_data_shape
-        assert display_data_shape is not None
         display_calibration_info = self.display_calibration_info
-        calibrated_dimensional_calibrations = display_calibration_info.calibrated_dimensional_calibrations if display_calibration_info is not None else None
+        if not display_calibration_info:
+            return DisplayItem.DataInfo(
+                data_shape=tuple(),
+                calibrated_dimensional_calibrations=None,
+                data_shape_str=str(),
+                calibrated_dimensional_calibrations_str=None
+            )
+        calibrated_dimensional_calibrations = display_calibration_info.calibrated_dimensional_calibrations
+        display_data_shape = display_calibration_info.display_data_shape or tuple()
         calibrated_dimensional_calibration_str_list = list[str]()
-        if calibrated_dimensional_calibrations:
+        if calibrated_dimensional_calibrations is not None:
             # make the assumption that the display data is the last dimensions of the data. generate a negative index
             # for each entry in the display data shape, then use that index to get the calibrated value from the list
             # of calibrated dimensional calibrations.
@@ -3278,12 +3092,12 @@ class DisplayItem(Persistence.PersistentObject):
             data_item = self.data_item
             if len(display_data_shape) == 2 and data_item and data_item.is_datum_1d:
                 for index in range(-len(display_data_shape), 0):
-                    converter = CalibratedSizeFloatToStringConverter(self.display_data_shape, calibrated_dimensional_calibrations[:-1], index, uniform=False)
+                    converter = CalibratedSizeFloatToStringConverter(display_data_shape, calibrated_dimensional_calibrations[:-1], index, uniform=False)
                     calibrated_value = converter.convert_to_calibrated_value(1.0)
                     calibrated_dimensional_calibration_str_list.append(converter.convert_calibrated_value_to_str(calibrated_value))
             else:
                 for index in range(-len(display_data_shape), 0):
-                    converter = CalibratedSizeFloatToStringConverter(self.display_data_shape, calibrated_dimensional_calibrations, index, uniform=False)
+                    converter = CalibratedSizeFloatToStringConverter(display_data_shape, calibrated_dimensional_calibrations, index, uniform=False)
                     calibrated_value = converter.convert_to_calibrated_value(1.0)
                     calibrated_dimensional_calibration_str_list.append(converter.convert_calibrated_value_to_str(calibrated_value))
         calibrated_dimensional_calibrations_str = ", ".join(calibrated_dimensional_calibration_str_list) if calibrated_dimensional_calibration_str_list else None
@@ -3422,8 +3236,9 @@ class DisplayItem(Persistence.PersistentObject):
 
     def get_value_and_position_text(self, pos: typing.Optional[typing.Tuple[int, ...]]) -> typing.Tuple[str, str]:
         display_data_channel = self.display_data_channel
-        dimensional_calibrations = self.__display_data_delta_stream.displayed_dimensional_calibrations
-        intensity_calibration = self.__display_data_delta_stream.displayed_intensity_calibration
+        display_calibration_info = self.display_calibration_info
+        dimensional_calibrations = display_calibration_info.displayed_dimensional_calibrations if display_calibration_info else tuple()
+        intensity_calibration = display_calibration_info.displayed_intensity_calibration if display_calibration_info else Calibration.Calibration()
 
         if not all(map(operator.attrgetter("is_valid"), dimensional_calibrations)):
             dimensional_calibrations = [Calibration.Calibration() for _ in dimensional_calibrations]
@@ -3432,7 +3247,7 @@ class DisplayItem(Persistence.PersistentObject):
             intensity_calibration = Calibration.Calibration()
 
         if display_data_channel is None or pos is None:
-            if self.__display_data_delta_stream.is_composite_data and (pos is not None and len(pos) == 1):
+            if display_calibration_info and display_calibration_info.is_composite_data and (pos is not None and len(pos) == 1):
                 return u"{0}".format(dimensional_calibrations[-1].convert_to_calibrated_value_str(pos[0])), str()
             return str(), str()
 
@@ -3536,69 +3351,176 @@ class DisplayItem(Persistence.PersistentObject):
 
 
 class DisplayCalibrationInfo:
-    def __init__(self,
-                 dimensional_shape: DataAndMetadata.ShapeType | None,
-                 dimensional_calibrations: typing.Sequence[Calibration.Calibration] | None,
-                 intensity_calibration: Calibration.Calibration | None,
-                 display_data_shape: DataAndMetadata.ShapeType | None,
-                 display_data_metadata: DataAndMetadata.MetadataType | None,
-                 displayed_dimensional_scales: typing.Tuple[float, ...] | None,
-                 displayed_dimensional_calibrations: typing.Sequence[Calibration.Calibration],
-                 displayed_intensity_calibration: Calibration.Calibration,
-                 calibration_style: CalibrationStyle,
-                 intensity_calibration_style: CalibrationStyle,
-                 datum_calibrations: typing.Sequence[Calibration.Calibration],
-                 calibration_styles: typing.Sequence[CalibrationStyle],
-                 intensity_calibration_styles: typing.Sequence[CalibrationStyle]
-                 ) -> None:
-        assert all(calibration.is_valid for calibration in displayed_dimensional_calibrations)
-        self.dimensional_shape = dimensional_shape
-        self.dimensional_calibrations = dimensional_calibrations
-        self.intensity_calibration = intensity_calibration
-        self.display_data_shape = display_data_shape
-        self.display_data_metadata = display_data_metadata
-        self.displayed_dimensional_scales = displayed_dimensional_scales
-        self.displayed_dimensional_calibrations = displayed_dimensional_calibrations
-        self.displayed_intensity_calibration = displayed_intensity_calibration
-        self.calibration_style = calibration_style
-        self.intensity_calibration_style = intensity_calibration_style
-        self.datum_calibrations = tuple(datum_calibrations)
-        self.calibration_styles = tuple(calibration_styles)
-        self.intensity_calibration_styles = tuple(intensity_calibration_styles)
+    """Represents the calibration information for a display.
 
-    def __ne__(self, other: typing.Any) -> bool:
+    All methods are safe to use on the main thread and do not trigger additional computations.
+
+    These objects can be tested for equality.
+    """
+    def __init__(self,
+                 data_metadata_list: typing.Sequence[DataAndMetadata.DataMetadata | None],
+                 calibration_style_id: str | None,
+                 intensity_calibration_style_id: str | None
+                 ) -> None:
+        dimensional_calibrations: typing.Optional[DataAndMetadata.CalibrationListType] = None
+        intensity_calibration: typing.Optional[Calibration.Calibration] = None
+        displayed_dimensional_scales = 0.0, 1.0
+        dimensional_shape: typing.Optional[DataAndMetadata.ShapeType] = None
+        display_data_metadata: DataAndMetadata.DataMetadata | None = None
+        if data_metadata_list:
+            data_metadata0 = data_metadata_list[0]
+            if data_metadata0 and len(data_metadata0.dimensional_calibrations) > 0:
+                dimensional_calibrations = list(data_metadata0.dimensional_calibrations)
+                if len(dimensional_calibrations) > 1:
+                    intensity_calibration = data_metadata0.intensity_calibration
+                    displayed_dimensional_scales = 0, data_metadata0.dimensional_shape[-1]
+                    dimensional_shape = data_metadata0.dimensional_shape
+                else:
+                    units = dimensional_calibrations[-1].units
+                    mn = math.inf
+                    mx = -math.inf
+                    for data_metadata_ in data_metadata_list:
+                        if data_metadata_ and data_metadata_.dimensional_calibrations[-1].units == units:
+                            v = dimensional_calibrations[0].convert_from_calibrated_value(
+                                data_metadata_.dimensional_calibrations[-1].convert_to_calibrated_value(0))
+                            mn = min(mn, v)
+                            mx = max(mx, v)
+                            v = dimensional_calibrations[0].convert_from_calibrated_value(
+                                data_metadata_.dimensional_calibrations[-1].convert_to_calibrated_value(data_metadata_.dimensional_shape[-1]))
+                            mn = min(mn, v)
+                            mx = max(mx, v)
+                    intensity_calibration = data_metadata0.intensity_calibration
+                    if math.isfinite(mn) and math.isfinite(mx):
+                        displayed_dimensional_scales = mn, mx
+                        dimensional_shape = (int(mx - mn),)
+                    else:
+                        displayed_dimensional_scales = 0, data_metadata0.dimensional_shape[-1]
+                        dimensional_shape = data_metadata0.dimensional_shape
+            if data_metadata0 and len(data_metadata_list) == 1:
+                display_data_metadata = data_metadata0
+        is_composite_data = len(data_metadata_list) > 1
+        self.__data_metadata_list = tuple(data_metadata_list)
+        self.__dimensional_shape = dimensional_shape
+        self.__dimensional_calibrations = dimensional_calibrations
+        self.__intensity_calibration = intensity_calibration
+        self.__display_data_metadata = display_data_metadata
+        self.__is_composite_data = is_composite_data
+        self.__displayed_dimensional_scales = displayed_dimensional_scales
+        self.__calibration_style_id = calibration_style_id
+        self.__intensity_calibration_style_id = intensity_calibration_style_id
+
+    def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, DisplayCalibrationInfo):
-            return True
-        display_calibration_info = other
-        if not display_calibration_info:
-            return True
-        if self.dimensional_shape != display_calibration_info.dimensional_shape:
-            return True
-        if self.dimensional_calibrations != display_calibration_info.dimensional_calibrations:
-            return True
-        if self.intensity_calibration != display_calibration_info.intensity_calibration:
-            return True
-        if self.display_data_shape != display_calibration_info.display_data_shape:
-            return True
-        if self.display_data_metadata != display_calibration_info.display_data_metadata:
-            return True
-        if self.displayed_dimensional_scales != display_calibration_info.displayed_dimensional_scales:
-            return True
-        if self.displayed_dimensional_calibrations != display_calibration_info.displayed_dimensional_calibrations:
-            return True
-        if self.displayed_intensity_calibration != display_calibration_info.displayed_intensity_calibration:
-            return True
-        if self.datum_calibrations != display_calibration_info.datum_calibrations:
-            return True
-        if type(self.calibration_style) != type(display_calibration_info.calibration_style):
-            return True
-        if type(self.intensity_calibration_style) != type(display_calibration_info.intensity_calibration_style):
-            return True
-        if self.calibration_styles != display_calibration_info.calibration_styles:
-            return True
-        if self.intensity_calibration_styles != display_calibration_info.intensity_calibration_styles:
-            return True
-        return False
+            return False
+        if self.__data_metadata_list != other.__data_metadata_list:
+            return False
+        if self.__calibration_style_id != other.__calibration_style_id:
+            return False
+        if self.__intensity_calibration_style_id != other.__intensity_calibration_style_id:
+            return False
+        return True
+
+    @property
+    def is_composite_data(self) -> bool:
+        return self.__is_composite_data
+
+    @property
+    def displayed_dimensional_scales(self) -> tuple[float, float]:
+        return self.__displayed_dimensional_scales
+
+    @property
+    def calibration_style_id(self) -> str | None:
+        return self.__calibration_style_id
+
+    @property
+    def intensity_calibration_style_id(self) -> str | None:
+        return self.__intensity_calibration_style_id
+
+    def get_dimensional_calibrations_for_calibration_style(self, calibration_style: CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        """Returns the dimensional calibrations for the given calibration style. If the dimensional calibrations are not valid, returns default calibrations."""
+        dimensional_shape = self.__dimensional_shape
+        dimensional_calibrations = self.__dimensional_calibrations
+        if dimensional_calibrations and dimensional_shape:
+            data_metadata_metadata = self.__display_data_metadata.metadata if self.__display_data_metadata else None
+            return calibration_style.get_dimensional_calibrations(dimensional_shape, dimensional_calibrations, data_metadata_metadata)
+        return [Calibration.Calibration() for c in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()]
+
+    def get_intensity_calibrations_for_calibration_style(self, calibration_style: CalibrationStyle) -> typing.Sequence[Calibration.Calibration]:
+        """Returns the intensity calibrations for the given calibration style. If the intensity calibration is not valid, returns a default calibration."""
+        intensity_calibration = self.__intensity_calibration
+        if intensity_calibration:
+            return [calibration_style.get_intensity_calibration(intensity_calibration)]
+        return [Calibration.Calibration()]
+
+    @property
+    def display_data_shape(self) -> DataAndMetadata.ShapeType | None:
+        display_data_metadata = self.__display_data_metadata
+        if display_data_metadata:
+            return DisplayDataShapeCalculator(display_data_metadata).shape
+        return self.__dimensional_shape if self.__is_composite_data else None
+
+    @property
+    def displayed_display_data_calibrations(self) -> typing.Sequence[Calibration.Calibration] | None:
+        """The calibrations for only datum dimensions, in the displayed calibration style."""
+        displayed_dimensional_calibrations = self.displayed_dimensional_calibrations
+        display_data_metadata = self.__display_data_metadata
+        if not self.__is_composite_data and display_data_metadata is not None:
+            indexes = DisplayDataShapeCalculator(display_data_metadata).indexes
+            return [displayed_dimensional_calibrations[i] for i in indexes] if indexes else None
+        return displayed_dimensional_calibrations
+
+    @property
+    def datum_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
+        """The calibrations for only datum dimensions."""
+        display_data_metadata = self.__display_data_metadata
+        if not self.__is_composite_data and display_data_metadata is not None:
+            datum_calibrations = DisplayDataShapeCalculator(display_data_metadata).calibrations
+            if datum_calibrations is not None:
+                return tuple(datum_calibrations)
+        dimensional_calibrations = self.__dimensional_calibrations
+        return tuple([Calibration.Calibration() for c in dimensional_calibrations] if dimensional_calibrations else [Calibration.Calibration()])
+
+    def __get_calibration_style_for_id(self, calibration_style_id: typing.Optional[str]) -> typing.Optional[CalibrationStyle]:
+        for calibration_style in self.calibration_styles:
+            if calibration_style.calibration_style_id == calibration_style_id:
+                return calibration_style
+        return None
+
+    def __get_intensity_calibration_style_for_id(self, calibration_style_id: typing.Optional[str]) -> typing.Optional[CalibrationStyle]:
+        for calibration_style in self.intensity_calibration_styles:
+            if calibration_style.calibration_style_id == calibration_style_id:
+                return calibration_style
+        return None
+
+    @property
+    def calibration_style(self) -> CalibrationStyle:
+        return self.__get_calibration_style_for_id(self.__calibration_style_id) or CalibrationStyleNative()
+
+    @property
+    def intensity_calibration_style(self) -> CalibrationStyle:
+        return self.__get_intensity_calibration_style_for_id(self.__intensity_calibration_style_id) or CalibrationStyleNative()
+
+    @property
+    def displayed_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
+        """The calibrations for all data dimensions in the displayed calibration style."""
+        if self.__dimensional_calibrations and self.__dimensional_shape:
+            display_data_metadata_metadata = self.__display_data_metadata.metadata if self.__display_data_metadata else None
+            return self.calibration_style.get_dimensional_calibrations(self.__dimensional_shape, self.__dimensional_calibrations, display_data_metadata_metadata)
+        return [Calibration.Calibration() for c in self.__dimensional_calibrations] if self.__dimensional_calibrations else [Calibration.Calibration()]
+
+    @property
+    def displayed_intensity_calibration(self) -> Calibration.Calibration:
+        if self.__intensity_calibration:
+            return self.intensity_calibration_style.get_intensity_calibration(self.__intensity_calibration)
+        return Calibration.Calibration()
+
+    @property
+    def calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
+        return get_calibration_styles(self.__data_metadata_list)
+
+    @property
+    def intensity_calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
+        return get_intensity_calibration_styles(self.__data_metadata_list)
 
     @property
     def calibrated_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration] | None:
@@ -3606,20 +3528,20 @@ class DisplayCalibrationInfo:
 
         First checks the users displayed calibration style; if no units are present, checks the other calibration styles.
         """
-        dimensional_calibrations = self.dimensional_calibrations
-        dimensional_shape = self.dimensional_shape
+        dimensional_calibrations = self.__dimensional_calibrations
+        dimensional_shape = self.__dimensional_shape
         if dimensional_calibrations and dimensional_shape:
-            display_data_metadata = self.display_data_metadata
+            display_data_metadata_metadata = self.__display_data_metadata.metadata if self.__display_data_metadata else None
             potential_dimensional_calibrations = self.calibration_style.get_dimensional_calibrations(dimensional_shape,
                                                                                                      dimensional_calibrations,
-                                                                                                     display_data_metadata)
+                                                                                                     display_data_metadata_metadata)
             if potential_dimensional_calibrations:
                 if any(dimensional_calibration.units for dimensional_calibration in potential_dimensional_calibrations):
                     return potential_dimensional_calibrations
             for calibration_style in self.calibration_styles:
                 potential_dimensional_calibrations = calibration_style.get_dimensional_calibrations(dimensional_shape,
                                                                                                     dimensional_calibrations,
-                                                                                                    display_data_metadata)
+                                                                                                    display_data_metadata_metadata)
                 if potential_dimensional_calibrations:
                     if any(dimensional_calibration.units for dimensional_calibration in
                            potential_dimensional_calibrations):

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3249,9 +3249,10 @@ class DisplayItem(Persistence.PersistentObject):
         return self.__display_data_delta_stream.datum_calibrations
 
     @property
-    def calibrated_dimensional_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
-        """The calibrations for all data dimensions in a calibrated style if possible or None."""
-        return self.__display_data_delta_stream.calibrated_dimensional_calibrations
+    def display_calibration_info(self) -> DisplayCalibrationInfo | None:
+        """Return the latest display calibration info."""
+        display_data_delta = self.__display_data_delta_stream.value
+        return display_data_delta.display_calibration_info if display_data_delta is not None else None
 
     @dataclasses.dataclass
     class DataInfo:
@@ -3264,7 +3265,8 @@ class DisplayItem(Persistence.PersistentObject):
     def data_info(self) -> DisplayItem.DataInfo:
         display_data_shape = self.display_data_shape
         assert display_data_shape is not None
-        calibrated_dimensional_calibrations = self.calibrated_dimensional_calibrations
+        display_calibration_info = self.display_calibration_info
+        calibrated_dimensional_calibrations = display_calibration_info.calibrated_dimensional_calibrations if display_calibration_info is not None else None
         calibrated_dimensional_calibration_str_list = list[str]()
         if calibrated_dimensional_calibrations:
             # make the assumption that the display data is the last dimensions of the data. generate a negative index
@@ -3597,6 +3599,32 @@ class DisplayCalibrationInfo:
         if self.intensity_calibration_styles != display_calibration_info.intensity_calibration_styles:
             return True
         return False
+
+    @property
+    def calibrated_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration] | None:
+        """Returns dimensional calibrations that are actually calibrated with units.
+
+        First checks the users displayed calibration style; if no units are present, checks the other calibration styles.
+        """
+        dimensional_calibrations = self.dimensional_calibrations
+        dimensional_shape = self.dimensional_shape
+        if dimensional_calibrations and dimensional_shape:
+            display_data_metadata = self.display_data_metadata
+            potential_dimensional_calibrations = self.calibration_style.get_dimensional_calibrations(dimensional_shape,
+                                                                                                     dimensional_calibrations,
+                                                                                                     display_data_metadata)
+            if potential_dimensional_calibrations:
+                if any(dimensional_calibration.units for dimensional_calibration in potential_dimensional_calibrations):
+                    return potential_dimensional_calibrations
+            for calibration_style in self.calibration_styles:
+                potential_dimensional_calibrations = calibration_style.get_dimensional_calibrations(dimensional_shape,
+                                                                                                    dimensional_calibrations,
+                                                                                                    display_data_metadata)
+                if potential_dimensional_calibrations:
+                    if any(dimensional_calibration.units for dimensional_calibration in
+                           potential_dimensional_calibrations):
+                        return potential_dimensional_calibrations
+        return None
 
 
 class DisplayCalibrationInfoStream(Stream.ValueStream[DisplayCalibrationInfo]):

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -186,16 +186,17 @@ def calculate_display_range(display_limits: DisplayLimitsType, data_range: typin
     return data_range
 
 
-class CalibrationStyleLike(typing.Protocol):
-    label: str
-    calibration_style_id: str
-    is_calibrated: bool = False
+class CalibrationStyle:
+    def __init__(self, label: str, calibration_style_id: str, is_calibrated: bool = False) -> None:
+        self.label = label
+        self.calibration_style_id = calibration_style_id
+        self.is_calibrated = is_calibrated
 
+    def __repr__(self) -> str:
+        return f"CalibrationStyle(label={self.label}, calibration_style_id={self.calibration_style_id}, is_calibrated={self.is_calibrated})"
 
-class CalibrationStyle(CalibrationStyleLike):
-    label: str
-    calibration_style_id: str
-    is_calibrated: bool = False
+    def __eq__(self, other: typing.Any) -> bool:
+        return isinstance(other, CalibrationStyle) and self.label == other.label and self.calibration_style_id == other.calibration_style_id and self.is_calibrated == other.is_calibrated
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         return list()
@@ -205,9 +206,8 @@ class CalibrationStyle(CalibrationStyleLike):
 
 
 class CalibrationStyleNative(CalibrationStyle):
-    label = _("Calibrated")
-    calibration_style_id = "calibrated"
-    is_calibrated = True
+    def __init__(self) -> None:
+        super().__init__(_("Calibrated"), "calibrated", True)
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         if all(calibration.is_valid for calibration in dimensional_calibrations):
@@ -217,10 +217,7 @@ class CalibrationStyleNative(CalibrationStyle):
 
 class CalibrationDescriptionCalibrationStyle(CalibrationStyle):
     def __init__(self, label: str, calibration_description: CalibrationDescription) -> None:
-        super().__init__()
-        self.label = label
-        self.calibration_style_id = calibration_description.calibration_style_id
-        self.is_calibrated = True
+        super().__init__(label, calibration_description.calibration_style_id, True)
         self.calibration_description = calibration_description
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
@@ -233,40 +230,40 @@ class CalibrationDescriptionCalibrationStyle(CalibrationStyle):
 
 
 class CalibrationStylePixelsTopLeft(CalibrationStyle):
-    label = _("Pixels (Top-Left)")
-    calibration_style_id = "pixels-top-left"
+    def __init__(self) -> None:
+        super().__init__(_("Pixels (Top-Left)"), "pixels-top-left", False)
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         return [Calibration.Calibration() for display_dimension in dimensional_shape]
 
 
 class CalibrationStylePixelsCenter(CalibrationStyle):
-    label = _("Pixels (Center)")
-    calibration_style_id = "pixels-center"
+    def __init__(self) -> None:
+        super().__init__(_("Pixels (Center)"), "pixels-center", False)
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         return [Calibration.Calibration(offset=-display_dimension/2) for display_dimension in dimensional_shape]
 
 
 class CalibrationStyleFractionalTopLeft(CalibrationStyle):
-    label = _("Fractional (Top Left)")
-    calibration_style_id = "relative-top-left"
+    def __init__(self) -> None:
+        super().__init__(_("Fractional (Top Left)"), "relative-top-left", False)
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         return [Calibration.Calibration(scale=1.0/display_dimension) for display_dimension in dimensional_shape]
 
 
 class CalibrationStyleFractionalCenter(CalibrationStyle):
-    label = _("Fractional (Center)")
-    calibration_style_id = "relative-center"
+    def __init__(self) -> None:
+        super().__init__(_("Fractional (Center)"), "relative-center", False)
 
     def get_dimensional_calibrations(self, dimensional_shape: DataAndMetadata.ShapeType, dimensional_calibrations: DataAndMetadata.CalibrationListType, metadata: typing.Optional[DataAndMetadata.MetadataType]) -> DataAndMetadata.CalibrationListType:
         return [Calibration.Calibration(scale=2.0/display_dimension, offset=-1.0) for display_dimension in dimensional_shape]
 
 
 class IntensityCalibrationStyleUncalibrated(CalibrationStyle):
-    label = _("Uncalibrated")
-    calibration_style_id = "uncalibrated"
+    def __init__(self) -> None:
+        super().__init__(_("Uncalibrated"), "uncalibrated", False)
 
     def get_intensity_calibration(self, calibration: Calibration.Calibration) -> Calibration.Calibration:
         return Calibration.Calibration()
@@ -2191,7 +2188,9 @@ class DisplayDataDeltaStream(Stream.ValueStream[DisplayDataDelta]):
                                       self.displayed_intensity_calibration,
                                       self.calibration_style,
                                       self.intensity_calibration_style,
-                                      list(self.datum_calibrations))
+                                      list(self.datum_calibrations),
+                                      self.calibration_styles,
+                                      self.intensity_calibration_styles)
 
     def __update_display_calibration_info(self, value: typing.Optional[str]) -> None:
         self.__update()
@@ -3579,13 +3578,15 @@ class DisplayItem(Persistence.PersistentObject):
 
 class DisplayCalibrationInfo:
     def __init__(self,
-                 display_data_shape: typing.Optional[DataAndMetadata.ShapeType],
-                 displayed_dimensional_scales: typing.Optional[typing.Tuple[float, ...]],
+                 display_data_shape: DataAndMetadata.ShapeType | None,
+                 displayed_dimensional_scales: typing.Tuple[float, ...] | None,
                  displayed_dimensional_calibrations: typing.Sequence[Calibration.Calibration],
                  displayed_intensity_calibration: Calibration.Calibration,
                  calibration_style: CalibrationStyle,
                  intensity_calibration_style: CalibrationStyle,
-                 datum_calibrations: list[Calibration.Calibration]
+                 datum_calibrations: typing.Sequence[Calibration.Calibration],
+                 calibration_styles: typing.Sequence[CalibrationStyle],
+                 intensity_calibration_styles: typing.Sequence[CalibrationStyle]
                  ) -> None:
         assert all(calibration.is_valid for calibration in displayed_dimensional_calibrations)
         self.display_data_shape = display_data_shape
@@ -3594,7 +3595,9 @@ class DisplayCalibrationInfo:
         self.displayed_intensity_calibration = displayed_intensity_calibration
         self.calibration_style = calibration_style
         self.intensity_calibration_style = intensity_calibration_style
-        self.datum_calibrations = datum_calibrations
+        self.datum_calibrations = tuple(datum_calibrations)
+        self.calibration_styles = tuple(calibration_styles)
+        self.intensity_calibration_styles = tuple(intensity_calibration_styles)
 
     def __ne__(self, other: typing.Any) -> bool:
         if not isinstance(other, DisplayCalibrationInfo):
@@ -3615,6 +3618,10 @@ class DisplayCalibrationInfo:
         if  type(self.calibration_style) != type(display_calibration_info.calibration_style):
             return True
         if  type(self.intensity_calibration_style) != type(display_calibration_info.intensity_calibration_style):
+            return True
+        if  self.calibration_styles != display_calibration_info.calibration_styles:
+            return True
+        if  self.intensity_calibration_styles != display_calibration_info.intensity_calibration_styles:
             return True
         return False
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3249,18 +3249,9 @@ class DisplayItem(Persistence.PersistentObject):
         return self.__display_data_delta_stream.datum_calibrations
 
     @property
-    def displayed_dimensional_calibrations(self) -> typing.Sequence[Calibration.Calibration]:
-        """The calibrations for all data dimensions in the displayed calibration style."""
-        return self.__display_data_delta_stream.displayed_dimensional_calibrations
-
-    @property
     def calibrated_dimensional_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
         """The calibrations for all data dimensions in a calibrated style if possible or None."""
         return self.__display_data_delta_stream.calibrated_dimensional_calibrations
-
-    @property
-    def displayed_intensity_calibration(self) -> Calibration.Calibration:
-        return self.__display_data_delta_stream.displayed_intensity_calibration
 
     @dataclasses.dataclass
     class DataInfo:
@@ -3429,8 +3420,8 @@ class DisplayItem(Persistence.PersistentObject):
 
     def get_value_and_position_text(self, pos: typing.Optional[typing.Tuple[int, ...]]) -> typing.Tuple[str, str]:
         display_data_channel = self.display_data_channel
-        dimensional_calibrations = self.displayed_dimensional_calibrations
-        intensity_calibration = self.displayed_intensity_calibration
+        dimensional_calibrations = self.__display_data_delta_stream.displayed_dimensional_calibrations
+        intensity_calibration = self.__display_data_delta_stream.displayed_intensity_calibration
 
         if not all(map(operator.attrgetter("is_valid"), dimensional_calibrations)):
             dimensional_calibrations = [Calibration.Calibration() for _ in dimensional_calibrations]

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3237,21 +3237,12 @@ class DisplayItem(Persistence.PersistentObject):
         return self.__display_data_delta_stream.calibration_style
 
     @property
-    def intensity_calibration_style(self) -> CalibrationStyle:
-        return self.__display_data_delta_stream.intensity_calibration_style
-
-    @property
     def display_data_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
         return self.__display_data_delta_stream.display_data_shape
 
     @property
     def displayed_display_data_calibrations(self) -> typing.Optional[typing.Sequence[Calibration.Calibration]]:
         return self.__display_data_delta_stream.displayed_display_data_calibrations
-
-    @property
-    def dimensional_shape(self) -> typing.Optional[DataAndMetadata.ShapeType]:
-        """Shape of the underlying data, if only one."""
-        return self.display_data_channel.dimensional_shape if self.display_data_channel else None
 
     @property
     def displayed_dimensional_scales(self) -> typing.Optional[typing.Tuple[float, ...]]:
@@ -3297,12 +3288,6 @@ class DisplayItem(Persistence.PersistentObject):
     @property
     def displayed_intensity_calibration(self) -> Calibration.Calibration:
         return self.__display_data_delta_stream.displayed_intensity_calibration
-
-    def __get_calibration_style_for_id(self, calibration_style_id: str) -> typing.Optional[CalibrationStyle]:
-        return self.__display_data_delta_stream.get_calibration_style_for_id(calibration_style_id)
-
-    def __get_intensity_calibration_style_for_id(self, calibration_style_id: str) -> typing.Optional[CalibrationStyle]:
-        return self.__display_data_delta_stream.get_intensity_calibration_style_for_id(calibration_style_id)
 
     @property
     def calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
@@ -3610,17 +3595,6 @@ class DisplayCalibrationInfo:
         self.calibration_style = calibration_style
         self.intensity_calibration_style = intensity_calibration_style
         self.datum_calibrations = datum_calibrations
-
-    @classmethod
-    def from_display_item(cls, display_item: DisplayItem) -> DisplayCalibrationInfo:
-        return DisplayCalibrationInfo(
-            display_item.display_data_shape,
-            display_item.displayed_dimensional_scales,
-            copy.deepcopy(display_item.displayed_dimensional_calibrations),
-            copy.deepcopy(display_item.displayed_intensity_calibration),
-            display_item.calibration_style,
-            display_item.intensity_calibration_style,
-            list(display_item.datum_calibrations))
 
     def __ne__(self, other: typing.Any) -> bool:
         if not isinstance(other, DisplayCalibrationInfo):

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3262,10 +3262,6 @@ class DisplayItem(Persistence.PersistentObject):
     def displayed_intensity_calibration(self) -> Calibration.Calibration:
         return self.__display_data_delta_stream.displayed_intensity_calibration
 
-    @property
-    def calibration_styles(self) -> typing.Sequence[CalibrationStyle]:
-        return self.__display_data_delta_stream.calibration_styles
-
     @dataclasses.dataclass
     class DataInfo:
         data_shape: typing.Tuple[int, ...]

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -3619,6 +3619,26 @@ class DisplayCalibrationInfo:
         return False
 
 
+class DisplayCalibrationInfoStream(Stream.ValueStream[DisplayCalibrationInfo]):
+    def __init__(self, display_item_stream: Stream.AbstractStream[DisplayItem]) -> None:
+        super().__init__()
+        self.__display_item_stream = display_item_stream.add_ref()
+        self.__display_stream_listener = display_item_stream.value_stream.listen(ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__display_item_changed, self))
+        self.__display_data_delta_stream_action: typing.Optional[Stream.ValueStreamAction[DisplayDataDelta]] = None
+        self.__display_item_changed(display_item_stream.value)
+
+    def __display_item_changed(self, display_item: typing.Optional[DisplayItem]) -> None:
+        if display_item:
+            self.__display_data_delta_stream_action = Stream.ValueStreamAction(display_item.display_data_delta_stream, ReferenceCounting.weak_partial(DisplayCalibrationInfoStream.__handle_display_data_delta_stream, self))
+            self.__handle_display_data_delta_stream(display_item.display_data_delta_stream.value)
+        else:
+            self.__display_data_delta_stream_action = None
+            self.__handle_display_data_delta_stream(None)
+
+    def __handle_display_data_delta_stream(self, value: typing.Optional[DisplayDataDelta]) -> None:
+        self.value = value.display_calibration_info if value else None
+
+
 def sort_by_date_key(display_item: DisplayItem) -> typing.Tuple[typing.Optional[str], datetime.datetime, str]:
     """A sort key for display items. The sort by uuid makes it determinate."""
     assert not display_item._closed

--- a/nion/swift/test/DisplayItem_test.py
+++ b/nion/swift/test/DisplayItem_test.py
@@ -674,12 +674,12 @@ class TestDisplayItemClass(unittest.TestCase):
                 data_item = DataItem.DataItem(numpy.zeros((8, ), numpy.uint32))
                 document_model.append_data_item(data_item)
                 display_item = document_model.get_display_item_for_data_item(data_item)
-                self.assertIsNone(display_item.calibrated_dimensional_calibrations)
+                self.assertIsNone(display_item.data_info.calibrated_dimensional_calibrations)
                 data_item.dimensional_calibrations = [Calibration.Calibration(3.0, 0.5, "nm")]
-                self.assertEqual(1, len(display_item.calibrated_dimensional_calibrations))
-                self.assertEqual("nm", display_item.calibrated_dimensional_calibrations[0].units)
+                self.assertEqual(1, len(display_item.data_info.calibrated_dimensional_calibrations))
+                self.assertEqual("nm", display_item.data_info.calibrated_dimensional_calibrations[0].units)
                 display_item.calibration_style_id = "pixels-center"
-                self.assertEqual("nm", display_item.calibrated_dimensional_calibrations[0].units)
+                self.assertEqual("nm", display_item.data_info.calibrated_dimensional_calibrations[0].units)
 
     def test_data_info_for_calibrated_image(self):
         with create_memory_profile_context() as profile_context:

--- a/nion/swift/test/DisplayItem_test.py
+++ b/nion/swift/test/DisplayItem_test.py
@@ -823,7 +823,8 @@ class TestDisplayItemClass(unittest.TestCase):
                 for expected, shape, is_sequence, collection_dimension_count, datum_dimension_count in l:
                     data_item = DataItem.new_data_item(DataAndMetadata.new_data_and_metadata(numpy.ones(shape), data_descriptor=DataAndMetadata.DataDescriptor(is_sequence, collection_dimension_count, datum_dimension_count)))
                     document_model.append_data_item(data_item)
-                    self.assertEqual(len(expected), len(document_model.display_items[-1].displayed_display_data_calibrations))
+                    display_calibration_info = document_model.display_items[-1].display_calibration_info
+                    self.assertEqual(len(expected), len(display_calibration_info.displayed_display_data_calibrations))
                     self.assertEqual(expected, DisplayItem.DisplayDataShapeCalculator(data_item.data_metadata).indexes)
 
     def test_display_data_processor_retains_dimensional_calibrations(self) -> None:

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -3065,7 +3065,7 @@ class TestDisplayPanelClass(unittest.TestCase):
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(26.0) * 1.2, axes.uncalibrated_data_max)
             self.assertAlmostEqual(data_item1.intensity_calibration.convert_from_calibrated_value(0.0) * 1.2, axes.uncalibrated_data_min)
 
-    def test_display_tracker_updates_when_inherited_title_updates(self):
+    def test_display_panel_title_updates_when_inherited_title_updates(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()
             document_model = document_controller.document_model
@@ -3080,15 +3080,11 @@ class TestDisplayPanelClass(unittest.TestCase):
             self.assertEqual("red", display_item.displayed_title)
             self.assertEqual("red (Negate)", display_item2.displayed_title)
             display_panel = document_controller.selected_display_panel
-            display_tracker = DisplayPanel.DisplayTracker(display_item2, DisplayPanel.DisplayPanelUISettings(document_controller.ui), display_panel, document_controller.event_loop, False)
-            with contextlib.closing(display_tracker):
-                title_changed = False
-                def handle_title_changed(title: str) -> None:
-                    nonlocal title_changed
-                    title_changed = True
-                display_tracker.on_title_changed = handle_title_changed
-                data_item.title = "green"
-                self.assertTrue(title_changed)
+            display_panel.set_display_item(display_item2)
+            print(display_panel.header_canvas_item.title)
+            self.assertEqual("red (Negate)", display_panel.header_canvas_item.title)
+            data_item.title = "green"
+            self.assertEqual("green (Negate)", display_panel.header_canvas_item.title)
 
     def test_index_sliders_update_when_data_created_later(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/Graphics_test.py
+++ b/nion/swift/test/Graphics_test.py
@@ -1566,7 +1566,7 @@ class TestGraphicsClass(unittest.TestCase):
             interval_graphic = Graphics.IntervalGraphic()
             interval_graphic.interval = (0.25, 0.75)
             display_item.add_graphic(interval_graphic)
-            self.assertEqual(display_item.display_data_delta_stream.scales[-1], 100)
+            self.assertEqual(display_item.display_calibration_info.displayed_dimensional_scales[-1], 100)
             data_item.set_data(numpy.zeros((50, ), numpy.uint32))
             self.assertEqual(interval_graphic.interval, (0.25, 0.75))
 
@@ -1580,7 +1580,7 @@ class TestGraphicsClass(unittest.TestCase):
             interval_graphic = Graphics.IntervalGraphic()
             interval_graphic.interval = (0.25, 0.75)
             display_item.add_graphic(interval_graphic)
-            self.assertEqual(display_item.display_data_delta_stream.scales[-1], 100)
+            self.assertEqual(display_item.display_calibration_info.displayed_dimensional_scales[-1], 100)
             display_item.dimensional_scales = (1,)
             self.assertEqual(interval_graphic.interval, (0.25, 0.75))
 

--- a/nion/swift/test/Graphics_test.py
+++ b/nion/swift/test/Graphics_test.py
@@ -1566,7 +1566,7 @@ class TestGraphicsClass(unittest.TestCase):
             interval_graphic = Graphics.IntervalGraphic()
             interval_graphic.interval = (0.25, 0.75)
             display_item.add_graphic(interval_graphic)
-            self.assertEqual(display_item.displayed_dimensional_scales[-1], 100)
+            self.assertEqual(display_item.display_data_delta_stream.scales[-1], 100)
             data_item.set_data(numpy.zeros((50, ), numpy.uint32))
             self.assertEqual(interval_graphic.interval, (0.25, 0.75))
 
@@ -1580,7 +1580,7 @@ class TestGraphicsClass(unittest.TestCase):
             interval_graphic = Graphics.IntervalGraphic()
             interval_graphic.interval = (0.25, 0.75)
             display_item.add_graphic(interval_graphic)
-            self.assertEqual(display_item.displayed_dimensional_scales[-1], 100)
+            self.assertEqual(display_item.display_data_delta_stream.scales[-1], 100)
             display_item.dimensional_scales = (1,)
             self.assertEqual(interval_graphic.interval, (0.25, 0.75))
 

--- a/nion/swift/test/HistogramPanel_test.py
+++ b/nion/swift/test/HistogramPanel_test.py
@@ -130,7 +130,7 @@ class TestHistogramPanelClass(unittest.TestCase):
             stats1_text = histogram_panel._statistics_widget._stats1_property.value
             stats2_text = histogram_panel._statistics_widget._stats2_property.value
             # now change the data and verify that statistics gets recomputed via document model
-            display_item.intensity_calibration_style_id = display_item.display_data_delta_stream.intensity_calibration_styles[-1].calibration_style_id
+            display_item.intensity_calibration_style_id = display_item.display_calibration_info.intensity_calibration_styles[-1].calibration_style_id
             # wait for statistics task to be complete
             histogram_panel._histogram_processor._evaluate_immediate()
             self.assertNotEqual(stats1_text, histogram_panel._statistics_widget._stats1_property.value)
@@ -271,7 +271,7 @@ class TestHistogramPanelClass(unittest.TestCase):
                 histogram_processor.display_data_and_metadata = display_values.display_data_and_metadata
                 histogram_processor.display_range = display_values.display_range
                 histogram_processor.display_data_range = display_values.data_range
-                histogram_processor.displayed_intensity_calibration = display_item.display_data_delta_stream.displayed_intensity_calibration
+                histogram_processor.displayed_intensity_calibration = display_item.display_calibration_info.displayed_intensity_calibration
                 had_histogram = False
                 had_statistics = False
                 def property_changed(key: str) -> None:

--- a/nion/swift/test/HistogramPanel_test.py
+++ b/nion/swift/test/HistogramPanel_test.py
@@ -271,7 +271,7 @@ class TestHistogramPanelClass(unittest.TestCase):
                 histogram_processor.display_data_and_metadata = display_values.display_data_and_metadata
                 histogram_processor.display_range = display_values.display_range
                 histogram_processor.display_data_range = display_values.data_range
-                histogram_processor.displayed_intensity_calibration = display_item.displayed_intensity_calibration
+                histogram_processor.displayed_intensity_calibration = display_item.display_data_delta_stream.displayed_intensity_calibration
                 had_histogram = False
                 had_statistics = False
                 def property_changed(key: str) -> None:

--- a/nion/swift/test/HistogramPanel_test.py
+++ b/nion/swift/test/HistogramPanel_test.py
@@ -130,7 +130,7 @@ class TestHistogramPanelClass(unittest.TestCase):
             stats1_text = histogram_panel._statistics_widget._stats1_property.value
             stats2_text = histogram_panel._statistics_widget._stats2_property.value
             # now change the data and verify that statistics gets recomputed via document model
-            display_item.intensity_calibration_style_id = display_item.intensity_calibration_styles[-1].calibration_style_id
+            display_item.intensity_calibration_style_id = display_item.display_data_delta_stream.intensity_calibration_styles[-1].calibration_style_id
             # wait for statistics task to be complete
             histogram_panel._histogram_processor._evaluate_immediate()
             self.assertNotEqual(stats1_text, histogram_panel._statistics_widget._stats1_property.value)

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -85,18 +85,6 @@ class TestInspectorClass(unittest.TestCase):
             document_controller.periodic()  # force UI to update
             document_controller.notify_focused_display_changed(None)
 
-    def test_calibration_value_and_size_float_to_string_converter_works_with_display(self):
-        with TestContext.create_memory_context() as test_context:
-            document_controller = test_context.create_document_controller()
-            document_model = document_controller.document_model
-            data_item = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
-            document_model.append_data_item(data_item)
-            display_item = document_model.get_display_item_for_data_item(data_item)
-            converter = Inspector.CalibratedValueFloatToStringConverter(display_item, 0)
-            converter.convert(0.5)
-            converter = Inspector.CalibratedSizeFloatToStringConverter(display_item, 0)
-            converter.convert(0.5)
-
     def test_adjusting_rectangle_width_should_keep_center_constant(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()
@@ -397,37 +385,6 @@ class TestInspectorClass(unittest.TestCase):
             document_controller.periodic()  # needed to update the inspector
             line_handler = inspector_panel.column.find_widget_by_id("graphics_inspector_section")._handler._graphic_handlers[0]
             self.assertEqual(line_handler._line_profile_width_model.value, "10.0 mm")
-
-    def test_float_to_string_converter_strips_units(self):
-        with TestContext.create_memory_context() as test_context:
-            document_controller = test_context.create_document_controller()
-            document_model = document_controller.document_model
-            data_item = DataItem.DataItem(numpy.zeros((256, 256), numpy.uint32))
-            document_model.append_data_item(data_item)
-            display_item = document_model.get_display_item_for_data_item(data_item)
-            display_item.calibration_style_id = "pixels-top-left"
-            converter = Inspector.CalibratedValueFloatToStringConverter(display_item, 0)
-            locale.setlocale(locale.LC_ALL, '')
-            self.assertAlmostEqual(converter.convert_back("0.5"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back(".5"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("00.5"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("0.500"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("0.500e0"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("+.5"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("-.5"), -0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("+0.5"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("0.5x"), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back("x0.5"), 0.0)
-            self.assertAlmostEqual(converter.convert_back(" 0.5 "), 0.5 / 256)
-            self.assertAlmostEqual(converter.convert_back(""), 0.0)
-            self.assertAlmostEqual(converter.convert_back("  "), 0.0)
-            self.assertAlmostEqual(converter.convert_back(" x"), 0.0)
-            try:
-                locale.setlocale(locale.LC_ALL, 'de_DE')
-                self.assertAlmostEqual(converter.convert_back("0,500"), 0.5 / 256)
-                self.assertAlmostEqual(converter.convert_back("0.500"), 0.5 / 256)
-            except locale.Error as e:
-                pass
 
     def test_inspector_handles_sliced_3d_data(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -25,6 +25,7 @@ from nion.utils import Binding
 from nion.utils import Converter
 from nion.utils import Geometry
 from nion.utils import Observable
+from nion.utils import Registry
 
 
 Facade.initialize()
@@ -1773,6 +1774,52 @@ class TestInspectorClass(unittest.TestCase):
             self.assertFalse(display_item.graphics[0].label)
             command.redo()
             self.assertEqual("abc", display_item.graphics[0].label)
+
+    def test_dimensional_calibration_style_model_index_updates(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.random.randn(8))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            calibration_style_model = Inspector.CalibrationStyleModel(document_controller, display_item, Inspector.DimensionalCalibrationStyleModelAdapter())
+            self.assertEqual(0, calibration_style_model.index)
+            calibration_style_model.index = 1
+            self.assertEqual(1, calibration_style_model.index)
+
+    def test_intensity_calibration_style_model_index_and_items(self):
+        # tests that the list of calibration style model items is stable when the index changes (intensity)
+        class CalibrationProvider:
+            def get_calibration_descriptions(self, data_metadata: DataAndMetadata.DataMetadata, **kwargs: typing.Any) -> typing.Sequence[DisplayItem.CalibrationDescription]:
+                calibration_descriptions = list()
+                calibration_descriptions.append(DisplayItem.CalibrationDescription("intensity-y", "calculated", "data", Calibration.Calibration(scale=2.0, units="y"), None))
+                calibration_descriptions.append(DisplayItem.CalibrationDescription("intensity-z", "calculated", "data", Calibration.Calibration(scale=2.0, units="z"), None))
+                return calibration_descriptions
+
+        calibration_provider = CalibrationProvider()
+        Registry.register_component(calibration_provider, {"calibration-provider"})
+        try:
+            with TestContext.create_memory_context() as test_context:
+                document_controller = test_context.create_document_controller()
+                document_model = document_controller.document_model
+                data_item = DataItem.DataItem(numpy.random.randn(8))
+                data_item.intensity_calibration = Calibration.Calibration(scale=3.0, units="x")
+                document_model.append_data_item(data_item)
+                display_item = document_model.get_display_item_for_data_item(data_item)
+                calibration_style_model = Inspector.CalibrationStyleModel(document_controller, display_item, Inspector.IntensityCalibrationStyleModelAdapter())
+                calibration_style_items = calibration_style_model.items
+                self.assertEqual(0, calibration_style_model.index)
+                calibration_style_model.index = 2
+                self.assertEqual(2, calibration_style_model.index)
+                self.assertEqual(calibration_style_items, calibration_style_model.items)
+                calibration_style_model.index = 1
+                self.assertEqual(1, calibration_style_model.index)
+                self.assertEqual(calibration_style_items, calibration_style_model.items)
+                calibration_style_model.index = 0
+                self.assertEqual(0, calibration_style_model.index)
+                self.assertEqual(calibration_style_items, calibration_style_model.items)
+        finally:
+            Registry.unregister_component(calibration_provider, {"calibration-provider"})
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -114,6 +114,7 @@ class TestInspectorClass(unittest.TestCase):
             size_width_binding = Inspector.CalibratedSizeBinding(0, display_item, Binding.TuplePropertyBinding(rect_graphic, "size", 0))
             size_width_binding.update_source("0.6")
             self.assertEqual(center, rect_graphic.center)
+            size_width_binding = None
             rect_graphic.close()
 
     def test_calibration_inspector_section_binds(self):

--- a/nion/swift/test/Inspector_test.py
+++ b/nion/swift/test/Inspector_test.py
@@ -326,6 +326,46 @@ class TestInspectorClass(unittest.TestCase):
             self.assertAlmostEqual(line_region.end[0], -0.25, 3)
             self.assertAlmostEqual(line_region.end[1], 0.5, 3)
 
+    def test_line_angle_field_updates_when_setting_positions(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((100, 100), numpy.uint32))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            line_region = Graphics.LineGraphic()
+            line_region.start = (0, 0)
+            line_region.end = (1, 1)
+            display_item.add_graphic(line_region)
+            display_item.calibration_style_id = "calibrated"
+            # find the inspector panel
+            display_panel = document_controller.selected_display_panel
+            display_panel.set_display_panel_display_item(display_item)
+            document_controller.periodic()  # needed to build the inspector
+            inspector_panel = document_controller.find_dock_panel("inspector-panel")
+            data_item.set_dimensional_calibration(0, Calibration.Calibration(units="mm"))
+            data_item.set_dimensional_calibration(1, Calibration.Calibration(units="mm"))
+            document_controller.periodic()  # needed to update the inspector
+            line_handler = inspector_panel.column.find_widget_by_id("graphics_inspector_section")._handler._graphic_handlers[0]
+            line_handler._x0_model.value = "10"
+            line_handler._x1_model.value = "90"
+            line_handler._y0_model.value = "10"
+            line_handler._y1_model.value = "90"
+            self.assertAlmostEqual(line_region.start[0], 0.1)
+            self.assertAlmostEqual(line_region.start[1], 0.1)
+            self.assertAlmostEqual(line_region.end[0], 0.9)
+            self.assertAlmostEqual(line_region.end[1], 0.9)
+            self.assertEqual(line_handler._angle_model.value, "-45.0000\N{DEGREE SIGN}")
+            line_handler._x0_model.value = "20 mm"
+            line_handler._x1_model.value = "80 mm"
+            line_handler._y0_model.value = "20 mm"
+            line_handler._y1_model.value = "80 mm"
+            self.assertAlmostEqual(line_region.start[0], 0.2)
+            self.assertAlmostEqual(line_region.start[1], 0.2)
+            self.assertAlmostEqual(line_region.end[0], 0.8)
+            self.assertAlmostEqual(line_region.end[1], 0.8)
+            self.assertEqual(line_handler._angle_model.value, "-45.0000\N{DEGREE SIGN}")
+
     def test_graphics_inspector_uses_non_calibrated_units_for_non_uniformly_calibrated_data(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -1277,14 +1277,14 @@ class TestStorageClass(unittest.TestCase):
                 document_model.append_data_item(data_item)
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 self.assertEqual("calibrated", display_item.calibration_style_id)
-                self.assertEqual("calibrated", display_item.display_data_delta_stream.calibration_style.calibration_style_id)
+                self.assertEqual("calibrated", display_item.display_calibration_info.calibration_style_id)
             # read it back
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 data_item = document_model.data_items[0]
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 self.assertEqual("calibrated", display_item.calibration_style_id)
-                self.assertEqual("calibrated", display_item.display_data_delta_stream.calibration_style.calibration_style_id)
+                self.assertEqual("calibrated", display_item.display_calibration_info.calibration_style_id)
 
     def test_reloaded_graphics_load_properly(self):
         with create_memory_profile_context() as profile_context:

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -1277,14 +1277,14 @@ class TestStorageClass(unittest.TestCase):
                 document_model.append_data_item(data_item)
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 self.assertEqual("calibrated", display_item.calibration_style_id)
-                self.assertEqual("calibrated", display_item.calibration_style.calibration_style_id)
+                self.assertEqual("calibrated", display_item.display_data_delta_stream.calibration_style.calibration_style_id)
             # read it back
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 data_item = document_model.data_items[0]
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 self.assertEqual("calibrated", display_item.calibration_style_id)
-                self.assertEqual("calibrated", display_item.calibration_style.calibration_style_id)
+                self.assertEqual("calibrated", display_item.display_data_delta_stream.calibration_style.calibration_style_id)
 
     def test_reloaded_graphics_load_properly(self):
         with create_memory_profile_context() as profile_context:


### PR DESCRIPTION
- **Remove unused DisplayItem methods.**
- **Move DisplayCalibrationInfoStream to DisplayItem for general use.**
- **Improve typing of CalibrationStyle and DisplayCalibrationInfo.**
- **Fix error is DisplayCalibrationInfo.__ne__.**
- **Update CalibrationStyleModel to utilize DisplayCalibrationInfo.**
- **Rework GraphicsSectionHandler to use CalibrationStyleModel.**
- **Change histogram cursor handling to use DisplayCalibrationInfo.**
- **Introduce a DisplayItem.display_calibration_info method. Use for 'data info'.**
- **Consolidate most calibration results into DisplayCalibrationInfo.**
- **Replace DisplayItemCalibratedValueModel with DisplayItemCalibratedDimensionValueModel.**
- **Refactor CalibratedBinding and subclasses to use display_calibration_info stream.**
- **Move some common code to display_calibration_info methods.**
- **Refactor CalibratedLengthBinding to use display_calibration_info stream.**
- **Refactor remaining inspector cases display_calibration_info.**
- **Remove unused display_property_changed_event and related code.**
- **Eliminate DisplayCalibrationInfoStream in favor of a one-use FollowStream in HistogramPanel.**
- **Eliminate DisplayTypeMonitor by merging it into DisplayTracker class.**
- **Consolidate DisplayTracker into DisplayPanel for simplification.**
- **Move frame rate handling inside thread.**

This is an internal change that should not have any significant behavior or performance chances. It is a ongoing project to ensure that any data access for display is done on a thread.

This change updates all access to `DisplayCalibrationInfo` to go through a small number of interfaces which will eventually be replaced by a single stream that is only updated on a thread.

This change touches much of the calibration UI in the inspector, the histogram, cursor handing, and both the line plot and image displays.

This change also consolidates the utility classes `DisplayTypeMonitor` and `DisplayTracker` into `DisplayPanel`. This simplifies the code and allows for a more unified changes going forward.
