### PR TITLE
Add verify filename utility function

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1041,16 +1041,15 @@ class NewProjectAction(UIWindow.Action):
                     return True
 
                 def verify_project_name(text: str) -> None:
-                    valid = text == Utility.simplify_filename(text)
-                    if valid:
-                        create_project_button.enabled = True
+                    is_valid, errors = Utility.verify_filename_is_legal(text)
+                    create_project_button.enabled = is_valid
+                    if errors is None:
                         create_project_button.tool_tip = None
                         project_name_status_label.text = None
                     else:
-                        create_project_button.enabled = False
-                        invalid_chars_str = _("Invalid Characters in Project Name")
-                        create_project_button.tool_tip = invalid_chars_str
-                        project_name_status_label.text = invalid_chars_str
+                        error_str = "\n".join(errors)
+                        create_project_button.tool_tip = error_str
+                        project_name_status_label.text = error_str
                         project_name_status_label.text_color = "red"
                 column = self.ui.create_column_widget()
 

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import datetime
 import functools
+import gettext
 import logging
 import os
 import pathlib
@@ -24,6 +25,8 @@ import numpy
 
 # local libraries
 from nion.utils import DateTime
+
+_ = gettext.gettext
 
 
 # datetimes are _local_ datetimes and must use this specific ISO 8601 format. 2013-11-17T08:43:21.389391
@@ -448,6 +451,42 @@ ILLEGAL_FILENAME_CHARS_REGEX = r'[<>:/\\|?*"\0-\31]'  # Capture illegal characte
 ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX = f'^[. ]|{ILLEGAL_FILENAME_CHARS_REGEX}|[. ]$'
 ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
                      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
+
+
+def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[bool, typing.Sequence[str] | None]:
+    """Check if a filename is allowed on all platforms.
+
+    Returns a tuple with a bool indicating if the path is valid or not, and a list of error messages or None when there are no errors.
+    Checks the filename is not in ILLEGAL_FILENAMES and no matches in the ILLEGAL_FILENAME_CHARS_REGEX.
+    Even when the platform can support the filename if it is illegal on any platforms it will not be allowed so there can be cross-platform file compatibility.
+    """
+    assert maximum_length > 5
+    errors = []
+    if filename.startswith("."):
+        errors.append(_("Leading periods cause files to be hidden on some platforms"))
+
+    if len(filename) > maximum_length:
+        errors.append(_("Exceeds the allowed length of {max} characters").format(max=maximum_length))
+
+    if filename == "":
+        errors.append(_("Cannot be empty"))
+    if len(filename) > 1:  # A filename can be " " or "." but cannot end with those characters, the "." will be caught by the leading periods check and so shouldn't be duplicated
+        if filename.endswith(" "):
+            errors.append(_("Cannot end with a whitespace"))
+        if filename.endswith("."):
+            errors.append(_("Cannot end with a period"))
+
+    if filename.upper() in ILLEGAL_FILENAMES:
+        errors.append(_("\"{filename}\" is illegal as it is reserved on some platforms").format(filename=filename))
+    matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
+    matches = sorted(set(matches))
+    if matches:
+        if len(matches) == 1:
+            errors.append(_("Contains illegal character '{character}'").format(character=matches[0]))
+        else:
+            errors.append(_("Contains illegal characters {characters}").format(characters=matches))
+
+    return len(errors) == 0, errors or None
 
 
 def simplify_filename(filename: str, replacement_char: str = '_', maximum_length: int = 128) -> str:

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -443,23 +443,25 @@ def sample_stack_all(count: int = 10, interval: float = 0.1) -> None:
     threading.Thread(target=do_sample).start()
 
 
+# See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+ILLEGAL_FILENAME_CHARS_REGEX = r'[<>:/\\|?*"\0-\31]'  # Capture illegal characters <, >, :, /, \, |, ?, *, and " as well as characters with integer representation between 0 and 31
+ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX = f'^[. ]|{ILLEGAL_FILENAME_CHARS_REGEX}|[. ]$'
+ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+                     'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
+
+
 def simplify_filename(filename: str, replacement_char: str = '_', maximum_length: int = 128) -> str:
     # This function replaces any illegal characters in a file name. Not a full path.
     # macOS illegal characters = \0 /
     # linux illegal characters = \0 /
     # Windows illegal characters = < > : / \ | ? * " ASCII values 0-31 (non-printable chars)
     # Windows illegal filenames = CON PRN AUX NUL COM1 COM2 COM3 COM4 COM5 COM6 COM7 COM8 COM9
-    #                             LPT1 LPT2 LPT3 LPT4 LPT5 LPT6 LPT7 LPT8 LPT9
+    #                             LPT1 LPT2 LPT3 LPT4 LPT5 LPT6 LPT7 LPT8 LPT9 COM¹ COM² COM³ LPT¹ LPT² LPT³
     # those files names are illegal with or without a suffix, upper and lower case
     # Windows file names cannot start or end with periods or spaces
 
     assert maximum_length > 5
     assert len(replacement_char) == 1
-
-    # since windows is the most restrictive and covers the others, just focus on that
-    illegal_chars = r'^[. ]|[<>:/\\|?*\"]|[\0-\31]|[. ]$'
-    illegal_names = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
-                     'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9']
 
     # fix path length first so we don't uncover . or space at the start
     updated_filename = filename
@@ -474,11 +476,11 @@ def simplify_filename(filename: str, replacement_char: str = '_', maximum_length
             updated_filename = stem[:maximum_length - len(suffix)] + suffix
 
     # replace illegal characters with replacement_char
-    updated_filename = re.sub(illegal_chars, replacement_char, updated_filename)
+    updated_filename = re.sub(ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX, replacement_char, updated_filename)
 
     # if filename (without suffix) is illegal name - prepend replacement_char
     file_name_without_suffix = pathlib.Path(updated_filename).stem
-    if file_name_without_suffix.upper() in illegal_names:
+    if file_name_without_suffix.upper() in ILLEGAL_FILENAMES:
         updated_filename = replacement_char + updated_filename
         if len(updated_filename) > maximum_length:
             # should only happen if the illegal name and suffix were already maximum_length

--- a/nion/swift/test/Utility_test.py
+++ b/nion/swift/test/Utility_test.py
@@ -73,6 +73,44 @@ class TestUtilityClass(unittest.TestCase):
             finally:
                 os.remove(file_path)
 
+    def test_verify_path_is_legal_catches_illegal_names(self) -> None:
+        test_filenames = [("", "Cannot be empty"),
+                          ("file.", "Cannot end with a period"),
+                          ("file ", "Cannot end with a whitespace"),
+                          ("COM¹", "\"COM¹\" is illegal as it is reserved on some platforms"),
+                          ("5>3>2024", "Contains illegal character '>'"),
+                          ("1234567890" * 13, "Exceeds the allowed length of 128 characters"),
+                          ("NUL", "\"NUL\" is illegal as it is reserved on some platforms"),
+                          ("abc\n\rdef", "Contains illegal characters ['\\n', '\\r']"),
+                          ("\26", "Contains illegal character '\x16'")]
+
+        for test_input, expected in test_filenames:
+            with self.subTest(test_input=test_input):
+                is_valid, errors = Utility.verify_filename_is_legal(test_input)
+                self.assertFalse(is_valid)
+                self.assertEqual(errors, [expected])
+
+    def test_verify_path_is_legal_returns_multiple_errors(self) -> None:
+        multi_error_filenames = [("/file.", ["Cannot end with a period", "Contains illegal character '/'"]),
+                                 ("*>" + "1234567890" * 13, ["Exceeds the allowed length of 128 characters", r"Contains illegal characters ['*', '>']"])]
+
+        for test_input, expected in multi_error_filenames:
+            with self.subTest(test_input=test_input):
+                is_valid, errors = Utility.verify_filename_is_legal(test_input)
+                self.assertFalse(is_valid)
+                self.assertEqual(errors, expected)
+
+    def test_verify_path_is_legal_returns_true_for_valid_names(self) -> None:
+        valid_filenames = ["file",
+                           "file.name",
+                           "1234567890" * 12,
+                           "NUL123"]
+        for test_input in valid_filenames:
+            with self.subTest(test_input=test_input):
+                is_valid, errors = Utility.verify_filename_is_legal(test_input)
+                self.assertTrue(is_valid)
+                self.assertEqual(errors, None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1848.
Adds a utility function verify_filename_is_legal which checks a filename and returns a relevant error message if it is illegal.
The function checks run are identical to simplify_filename but will give specific error messages if there are any.

The PR changes the usage of simplify filename in the New Project Dialog to instead use this new function.