### PR TITLE
Fix Sigma default value for Gaussian Window computation

### DIFF
--- a/nion/swift/model/Processing.py
+++ b/nion/swift/model/Processing.py
@@ -284,7 +284,7 @@ class ProcessingGaussianWindow(ProcessingBase):
         sigma = parameters.get_float_value("sigma", 0.3)
         if src_xdata and src_xdata.datum_dimension_count == 1:
             w = src_xdata.datum_dimension_shape[0]
-            return {"target": src_xdata * scipy.signal.windows.gaussian(src_xdata.datum_dimension_shape[0], std=w / 2)}
+            return {"target": src_xdata * scipy.signal.windows.gaussian(src_xdata.datum_dimension_shape[0], std=w / 2 / sigma)}
         elif src_xdata and src_xdata.datum_dimension_count == 2:
             # uses circularly rotated approach of generating 2D filter from 1D
             h, w = src_xdata.datum_dimension_shape

--- a/nion/swift/model/Processing.py
+++ b/nion/swift/model/Processing.py
@@ -272,7 +272,7 @@ class ProcessingGaussianWindow(ProcessingBase):
             },
         ]
         self.parameters = [
-            {"name": "sigma", "type": "real", "value": 1.0}
+            {"name": "sigma", "type": "real", "value": 0.3}
         ]
         self.outputs = [
             {"name": "target", "label": _("Result")},
@@ -281,7 +281,7 @@ class ProcessingGaussianWindow(ProcessingBase):
 
     def process(self, parameters: Symbolic.ComputationParameters) -> typing.Mapping[str, _ProcessingResult]:
         src_xdata = parameters.get_data_and_metadata("src")
-        sigma = parameters.get_float_value("sigma", 1.0)
+        sigma = parameters.get_float_value("sigma", 0.3)
         if src_xdata and src_xdata.datum_dimension_count == 1:
             w = src_xdata.datum_dimension_shape[0]
             return {"target": src_xdata * scipy.signal.windows.gaussian(src_xdata.datum_dimension_shape[0], std=w / 2)}


### PR DESCRIPTION
From @bentps, it is more likely that the user will want a sigma closer to 0.3 values than 1 when running a Gaussian Window Computation, the resulting computation will also give a better visual cue that the computation was run.