### PR TITLE
Prevent export when no options are selected

### DIFF
--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -46,7 +46,6 @@ class ExportDialogViewModel:
         self.include_date = Model.PropertyModel(date)
         self.include_dimensions = Model.PropertyModel(dimensions)
         self.include_sequence = Model.PropertyModel(sequence)
-        self.include_prefix = Model.PropertyModel(prefix is not None)
         self.prefix = Model.PropertyModel[str](prefix)
         self.directory = Model.PropertyModel(directory)
         self.directory_warning = Model.PropertyModel(str())
@@ -65,12 +64,17 @@ class ExportDialogViewModel:
         if not self.is_directory_valid:
             self.directory.value = None  # Clear the initial directory if it was invalid
 
-        def update_export_button(__: typing.Any) -> None:
+        def update_export_button(*__: typing.Any) -> None:
             invalid_reasons = list[str]()
 
             prefix_str = self.prefix.value or str()
-            if prefix_str != Utility.simplify_filename(prefix_str):
-                invalid_reasons.append(_("Prefix contains invalid characters"))
+            if prefix_str != "":
+                if prefix_str != Utility.simplify_filename(prefix_str):
+                    invalid_reasons.append(_("Prefix contains invalid characters"))
+            elif not (self.include_title.value or self.include_date.value or
+                      self.include_dimensions.value or self.include_sequence.value):
+                # There must be at least one option enabled otherwise the filenames will be empty
+                invalid_reasons.append(_("Filename requires at least one option to be selected"))
 
             is_directory_valid = self.__is_directory_valid.value or False
             if not is_directory_valid:
@@ -86,9 +90,18 @@ class ExportDialogViewModel:
                 self.export_button_tool_tip.value = None
                 self.directory_warning.value = str()
 
-        self.__is_directory_valid_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream[str](self.__is_directory_valid, "value"), update_export_button)
-        self.__prefix_action = Stream.ValueStreamAction(prefix_stream, update_export_button)
+        input_streams: typing.Sequence[Stream.PropertyChangedEventStream[typing.Any]] = [
+            # Update the button when one of the options changes
+            prefix_stream,
+            Stream.PropertyChangedEventStream(self.include_title, "value"),
+            Stream.PropertyChangedEventStream(self.include_date, "value"),
+            Stream.PropertyChangedEventStream(self.include_dimensions, "value"),
+            Stream.PropertyChangedEventStream(self.include_sequence, "value"),
+            # Also update the button when the directory changes validity
+            Stream.PropertyChangedEventStream(self.__is_directory_valid, "value")
+        ]
 
+        self.__export_button_update_stream: Stream.CombineLatestStream[typing.Any, typing.Any] = Stream.CombineLatestStream(input_streams, update_export_button)
         update_export_button(None)
 
     @property

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -63,18 +63,20 @@ class ExportDialogViewModel:
         if not self.is_directory_valid:
             self.directory.value = None  # Clear the initial directory if it was invalid
 
-        def update_export_button(*__: typing.Any) -> None:
+        def update_export_button(prefix_value: str | None, include_title: bool | None,
+                                 include_date: bool | None, include_dimensions: bool | None,
+                                 include_sequence: bool | None, is_directory_valid: bool | None) -> None:
+            """Update the export button enabled state and tooltip based on the current options selected and directory validity."""
             invalid_reasons = list[str]()
 
-            prefix_str = self.prefix.value or str()
+            prefix_str = prefix_value or str()
             if prefix_str != Utility.simplify_filename(prefix_str):
                 invalid_reasons.append(_("Prefix contains invalid characters"))
 
-            if prefix_str == "" and not (self.include_title.value or self.include_date.value or self.include_dimensions.value or self.include_sequence.value):
+            if not (prefix_str or include_title or include_date or include_dimensions or include_sequence):
                 # There must be at least one option enabled otherwise the filenames will be empty
                 invalid_reasons.append(_("Filename requires at least one option to be selected"))
 
-            is_directory_valid = self.__is_directory_valid.value or False
             if not is_directory_valid:
                 invalid_reasons.append(_("Directory does not exist"))
                 self.directory.value = None  # Clear the directory if it is invalid
@@ -88,7 +90,7 @@ class ExportDialogViewModel:
                 self.export_button_tool_tip.value = None
                 self.directory_warning.value = str()
 
-        export_filename_option_streams: typing.Sequence[Stream.PropertyChangedEventStream[typing.Any]] = [
+        export_filename_option_streams: typing.Sequence[Stream.PropertyChangedEventStream[str | bool]] = [
             # Update the button when one of the options changes
             Stream.PropertyChangedEventStream(self.prefix, "value"),
             Stream.PropertyChangedEventStream(self.include_title, "value"),
@@ -99,8 +101,8 @@ class ExportDialogViewModel:
             Stream.PropertyChangedEventStream(self.__is_directory_valid, "value")
         ]
 
-        self.__export_button_update_stream: Stream.CombineLatestStream[typing.Any, typing.Any] = Stream.CombineLatestStream(export_filename_option_streams , update_export_button)
-        update_export_button(None)
+        self.__export_button_update_stream: Stream.CombineLatestStream[str | bool, None] = Stream.CombineLatestStream(export_filename_option_streams, update_export_button)
+        update_export_button(self.prefix.value, self.include_title.value, self.include_date.value, self.include_dimensions.value, self.include_sequence.value, self.__is_directory_valid.value)
 
     @property
     def directory_path_object(self) -> pathlib.Path:

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -54,7 +54,6 @@ class ExportDialogViewModel:
         self.writer = Model.PropertyModel(writer)
 
         directory_stream = Stream.PropertyChangedEventStream[str](self.directory, "value")
-        prefix_stream = Stream.PropertyChangedEventStream[str](self.prefix, "value")
 
         def validate_directory(directory: str | None) -> bool:
             return directory is not None and pathlib.Path(directory).is_dir()
@@ -68,11 +67,10 @@ class ExportDialogViewModel:
             invalid_reasons = list[str]()
 
             prefix_str = self.prefix.value or str()
-            if prefix_str != "":
-                if prefix_str != Utility.simplify_filename(prefix_str):
-                    invalid_reasons.append(_("Prefix contains invalid characters"))
-            elif not (self.include_title.value or self.include_date.value or
-                      self.include_dimensions.value or self.include_sequence.value):
+            if prefix_str != Utility.simplify_filename(prefix_str):
+                invalid_reasons.append(_("Prefix contains invalid characters"))
+
+            if prefix_str == "" and not (self.include_title.value or self.include_date.value or self.include_dimensions.value or self.include_sequence.value):
                 # There must be at least one option enabled otherwise the filenames will be empty
                 invalid_reasons.append(_("Filename requires at least one option to be selected"))
 
@@ -90,9 +88,9 @@ class ExportDialogViewModel:
                 self.export_button_tool_tip.value = None
                 self.directory_warning.value = str()
 
-        input_streams: typing.Sequence[Stream.PropertyChangedEventStream[typing.Any]] = [
+        export_filename_option_streams: typing.Sequence[Stream.PropertyChangedEventStream[typing.Any]] = [
             # Update the button when one of the options changes
-            prefix_stream,
+            Stream.PropertyChangedEventStream(self.prefix, "value"),
             Stream.PropertyChangedEventStream(self.include_title, "value"),
             Stream.PropertyChangedEventStream(self.include_date, "value"),
             Stream.PropertyChangedEventStream(self.include_dimensions, "value"),
@@ -101,7 +99,7 @@ class ExportDialogViewModel:
             Stream.PropertyChangedEventStream(self.__is_directory_valid, "value")
         ]
 
-        self.__export_button_update_stream: Stream.CombineLatestStream[typing.Any, typing.Any] = Stream.CombineLatestStream(input_streams, update_export_button)
+        self.__export_button_update_stream: Stream.CombineLatestStream[typing.Any, typing.Any] = Stream.CombineLatestStream(export_filename_option_streams , update_export_button)
         update_export_button(None)
 
     @property

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -38,6 +38,13 @@ if typing.TYPE_CHECKING:
 _ = gettext.gettext
 
 
+@dataclasses.dataclass(frozen=True)
+class ExportOptionsValidity:
+    """Contains the  export validity result of compute_export_options_validity."""
+    is_directory_valid: bool  # Is the directory a valid path
+    invalid_reasons: typing.Sequence[str]  # Reasons the export options are not valid
+
+
 class ExportDialogViewModel:
     """Represents the export dialog model."""
 
@@ -63,11 +70,11 @@ class ExportDialogViewModel:
         if not self.is_directory_valid:
             self.directory.value = None  # Clear the initial directory if it was invalid
 
-        def update_export_button(prefix_value: str | None, include_title: bool | None,
-                                 include_date: bool | None, include_dimensions: bool | None,
-                                 include_sequence: bool | None, is_directory_valid: bool | None) -> None:
-            """Update the export button enabled state and tooltip based on the current options selected and directory validity."""
-            invalid_reasons = list[str]()
+        def compute_export_options_validity(prefix_value: str | None, include_title: bool | None,
+                                            include_date: bool | None, include_dimensions: bool | None,
+                                            include_sequence: bool | None, is_directory_valid: bool | None) -> ExportOptionsValidity:
+            """Use the combined values of the export filename options and the directory validity to get a list of invalid reasons."""
+            invalid_reasons: list[str] = []
 
             prefix_str = prefix_value or str()
             if prefix_str != Utility.simplify_filename(prefix_str):
@@ -79,12 +86,19 @@ class ExportDialogViewModel:
 
             if not is_directory_valid:
                 invalid_reasons.append(_("Directory does not exist"))
+
+            return ExportOptionsValidity(bool(is_directory_valid), invalid_reasons)
+
+        def handle_export_options_validity_changed(export_validity: ExportOptionsValidity | None) -> None:
+            """Update the export button's enabled state and tooltip based on the computed invalid reasons and directory validity."""
+            export_validity = export_validity or ExportOptionsValidity(False, [])
+            if not export_validity.is_directory_valid:
                 self.directory.value = None  # Clear the directory if it is invalid
 
-            if invalid_reasons:
+            if export_validity.invalid_reasons:
                 self.export_button_enabled.value = False
-                self.export_button_tool_tip.value = ", ".join(invalid_reasons)
-                self.directory_warning.value = ", ".join(invalid_reasons)
+                self.export_button_tool_tip.value = ", ".join(export_validity.invalid_reasons)
+                self.directory_warning.value = "\n".join(export_validity.invalid_reasons)
             else:
                 self.export_button_enabled.value = True
                 self.export_button_tool_tip.value = None
@@ -101,8 +115,14 @@ class ExportDialogViewModel:
             Stream.PropertyChangedEventStream(self.__is_directory_valid, "value")
         ]
 
-        self.__export_button_update_stream: Stream.CombineLatestStream[str | bool, None] = Stream.CombineLatestStream(export_filename_option_streams, update_export_button)
-        update_export_button(self.prefix.value, self.include_title.value, self.include_date.value, self.include_dimensions.value, self.include_sequence.value, self.__is_directory_valid.value)
+        self.__export_button_update_action = Stream.ValueStreamAction(
+            Stream.CombineLatestStream(export_filename_option_streams, compute_export_options_validity),
+            handle_export_options_validity_changed
+        )
+
+        handle_export_options_validity_changed(compute_export_options_validity(self.prefix.value, self.include_title.value,
+                                                                               self.include_date.value, self.include_dimensions.value,
+                                                                               self.include_sequence.value, self.__is_directory_valid.value))
 
     @property
     def directory_path_object(self) -> pathlib.Path:

--- a/nion/swift/test/ExportDialog_test.py
+++ b/nion/swift/test/ExportDialog_test.py
@@ -23,7 +23,7 @@ class TestExportDialog(unittest.TestCase):
         self._test_setup = typing.cast(typing.Any, None)
         TestContext.end_leaks(self)
 
-    def test_model(self):
+    def test_model(self) -> None:
         model = ExportDialog.ExportDialogViewModel(
             title=True,
             date=False,
@@ -46,6 +46,29 @@ class TestExportDialog(unittest.TestCase):
         self.assertIsNotNone(model.directory_warning.value)
         self.assertFalse(model.export_button_enabled.value)
         self.assertIsNotNone(model.export_button_tool_tip.value)
+
+    def test_model_prevents_no_options_selection(self) -> None:
+        model = ExportDialog.ExportDialogViewModel(
+            title=False,
+            date=False,
+            dimensions=False,
+            sequence=False,
+            writer=None,
+            prefix=None,
+            directory=str(pathlib.Path.cwd())  # The directory is valid for this test to isolate the error of no options
+        )
+        # Check the export button is disabled when all the options are disabled
+        self.assertFalse(model.export_button_enabled.value)
+        self.assertIsNotNone(model.export_button_tool_tip.value)
+        # Check the export button updates to be valid when an option is enabled
+        model.include_date.value = True
+        self.assertTrue(model.export_button_enabled.value)
+        self.assertIsNone(model.export_button_tool_tip.value)
+        # Now check that the button also updates to enabled when the prefix is set
+        model.include_date.value = False
+        model.prefix.value = "prefix"
+        self.assertTrue(model.export_button_enabled.value)
+        self.assertIsNone(model.export_button_tool_tip.value)
 
     def test_filename(self) -> None:
         model = ExportDialog.ExportDialogViewModel(

--- a/nion/swift/test/ExportDialog_test.py
+++ b/nion/swift/test/ExportDialog_test.py
@@ -33,9 +33,9 @@ class TestExportDialog(unittest.TestCase):
             prefix=None,
             directory=None)
         # initial case - no directory
-        self.assertIsNotNone(model.directory_warning.value)
+        self.assertTrue(model.directory_warning.value)  # The warning and tool tip can be '' or None if the button is in an invalid state
         self.assertFalse(model.export_button_enabled.value)
-        self.assertIsNotNone(model.export_button_tool_tip.value)
+        self.assertTrue(model.export_button_tool_tip.value)
         # directory case
         model.directory.value = str(pathlib.Path.cwd())
         self.assertFalse(model.directory_warning.value)
@@ -43,11 +43,11 @@ class TestExportDialog(unittest.TestCase):
         self.assertFalse(model.export_button_tool_tip.value)
         # bad prefix case
         model.prefix.value = "bad/prefix"
-        self.assertIsNotNone(model.directory_warning.value)
+        self.assertTrue(model.directory_warning.value)
         self.assertFalse(model.export_button_enabled.value)
-        self.assertIsNotNone(model.export_button_tool_tip.value)
+        self.assertTrue(model.export_button_tool_tip.value)
 
-    def test_model_prevents_no_options_selection(self) -> None:
+    def test_model_updates_button_status_when_options_change(self) -> None:
         model = ExportDialog.ExportDialogViewModel(
             title=False,
             date=False,
@@ -59,16 +59,38 @@ class TestExportDialog(unittest.TestCase):
         )
         # Check the export button is disabled when all the options are disabled
         self.assertFalse(model.export_button_enabled.value)
-        self.assertIsNotNone(model.export_button_tool_tip.value)
+        self.assertTrue(model.export_button_tool_tip.value)
         # Check the export button updates to be valid when an option is enabled
         model.include_date.value = True
         self.assertTrue(model.export_button_enabled.value)
-        self.assertIsNone(model.export_button_tool_tip.value)
-        # Now check that the button also updates to enabled when the prefix is set
+        self.assertFalse(model.export_button_tool_tip.value)
+        # Check the export button goes back to disabled when the value changes back
         model.include_date.value = False
+        self.assertFalse(model.export_button_enabled.value)
+        self.assertTrue(model.export_button_tool_tip.value)
+
+    def test_model_updates_button_status_when_prefix_changes(self) -> None:
+        """Test that the changes to the prefix string will update the button's validity."""
+        model = ExportDialog.ExportDialogViewModel(
+            title=False,
+            date=False,
+            dimensions=False,
+            sequence=False,
+            writer=None,
+            prefix=None,
+            directory=str(pathlib.Path.cwd())  # The directory is valid for this test to isolate the error of no options
+        )
+        # The export button starts disabled when all options are disabled
+        self.assertFalse(model.export_button_enabled.value)
+        self.assertTrue(model.export_button_tool_tip.value)
+        # Now check that the button updates to enabled when the prefix is set
         model.prefix.value = "prefix"
         self.assertTrue(model.export_button_enabled.value)
-        self.assertIsNone(model.export_button_tool_tip.value)
+        self.assertFalse(model.export_button_tool_tip.value)
+        # Check that the button becomes invalid when the prefix becomes invalid
+        model.prefix.value = ""
+        self.assertFalse(model.export_button_enabled.value)
+        self.assertTrue(model.export_button_tool_tip.value)
 
     def test_filename(self) -> None:
         model = ExportDialog.ExportDialogViewModel(

--- a/nion/swift/test/ExportDialog_test.py
+++ b/nion/swift/test/ExportDialog_test.py
@@ -33,8 +33,8 @@ class TestExportDialog(unittest.TestCase):
             prefix=None,
             directory=None)
         # initial case - no directory
-        # The warning and tool tip can be '' or None when the button is in a valid state
-        # So we check that the truthfulness when there is expected to be an invalid state to ensure there is a warning and tool-tip present
+        # The warning and tooltip can be '' or None when the button is in a valid state
+        # So we check the truthiness of the values when the state is expected to be invalid, to confirm a warning and tooltip are present
         self.assertTrue(model.directory_warning.value)
         self.assertFalse(model.export_button_enabled.value)
         self.assertTrue(model.export_button_tool_tip.value)

--- a/nion/swift/test/ExportDialog_test.py
+++ b/nion/swift/test/ExportDialog_test.py
@@ -33,7 +33,9 @@ class TestExportDialog(unittest.TestCase):
             prefix=None,
             directory=None)
         # initial case - no directory
-        self.assertTrue(model.directory_warning.value)  # The warning and tool tip can be '' or None if the button is in an invalid state
+        # The warning and tool tip can be '' or None when the button is in a valid state
+        # So we check that the truthfulness when there is expected to be an invalid state to ensure there is a warning and tool-tip present
+        self.assertTrue(model.directory_warning.value)
         self.assertFalse(model.export_button_enabled.value)
         self.assertTrue(model.export_button_tool_tip.value)
         # directory case
@@ -48,6 +50,7 @@ class TestExportDialog(unittest.TestCase):
         self.assertTrue(model.export_button_tool_tip.value)
 
     def test_model_updates_button_status_when_options_change(self) -> None:
+        """Test that when no options are selected the export button is disabled, and that when an option is selected the export button becomes enabled."""
         model = ExportDialog.ExportDialogViewModel(
             title=False,
             date=False,


### PR DESCRIPTION
Fixes #1871. Refactor the export dialog to use CombineLatestStream to call the update_export_button whenever there is a change to any of the options in order to make sure when all the options are deselected the export button becomes disabled.