### PR TITLE
Renaming projects on disk

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -968,7 +968,7 @@ class Application(UIApplication.BaseApplication):
         new_project_reference: Profile.ProjectReference | None = None
         try:
             new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
-            error_message = rename_result.error_message
+            error_message = "\n".join(rename_result.error_messages)
         except Exception as e:
             error_message = _("Exception during renaming project")
             logging.exception(f"{error_message}:\n{e}")
@@ -1269,7 +1269,8 @@ class NameProjectViewModel:
         self.profile = profile
 
     @classmethod
-    def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile) -> ProjectNameVerificationResult:
+    def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile,
+                            project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) -> ProjectNameVerificationResult:
         """Verify that a project name is a valid filename and doesn't already exist.
 
         Returns a tuple with the first element being whether the project name is valid and the second being a sequence of error messages.
@@ -1278,26 +1279,25 @@ class NameProjectViewModel:
             return ProjectNameVerificationResult(False, ["Project name cannot be empty"])
         if project_name != Utility.simplify_filename(project_name):
             return ProjectNameVerificationResult(False, ["Project Name contains illegal characters"])
-        new_project_path = pathlib.Path(base_directory, project_name).with_suffix(".nsproj")
-        errors = []
-        new_data_path = new_project_path.parent / f"{project_name} Data"
-        new_project_path_exists = new_project_path.exists()
-        data_path_exists = new_data_path.is_dir()
-        if new_project_path_exists:
-            errors.append(_("Project Name") + f" \"{new_project_path.name}\" " + _("already exists"))
-        if data_path_exists:
-            errors.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
 
-        # Check for an orphaned project reference exists, it would need to be removed manually
-        project_reference = profile.get_project_reference_by_path(new_project_path)
-        if not new_project_path_exists and not data_path_exists and project_reference is not None:
-            errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
+        errors: list[str] = []
+        if project_name_available_fn is None:
+            return ProjectNameVerificationResult(True, errors)
+
+        name_available_result = project_name_available_fn(project_name, base_directory)
+        errors.extend(name_available_result.error_messages)
+        if not errors and name_available_result.project_path:
+            # Check for an orphaned project reference exists, it would need to be removed manually
+            project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
+            if project_reference is not None:
+                errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
 
         is_valid = len(errors) == 0
         return ProjectNameVerificationResult(is_valid, errors)
 
     def update_project_status_label(self, text: str) -> None:
-        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile)
+        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile,
+                                                                    FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available)
         self.accept_button_enabled.value = project_name_verification_result.is_valid
         if not project_name_verification_result.error_messages:  # The name is valid and doesn't already exist.
             self.project_name_status_label.value = str()

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1325,7 +1325,7 @@ class NameProjectDialog(Declarative.Handler):
         self.ui = ui
         self.__application = application
         self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile)
-
+        self._project_name_line_edit: UserInterface.LineEditWidget | None = None
         # build the UI
         u = Declarative.DeclarativeUI()
 
@@ -1364,7 +1364,7 @@ class NameProjectDialog(Declarative.Handler):
 
         project_name_row = u.create_row(
             u.create_spacing(26),
-            u.create_line_edit(text="@binding(viewmodel.filename.value)", width=400, on_text_edited="handle_project_name_changed"),
+            u.create_line_edit(name="_project_name_line_edit", text="@binding(viewmodel.filename.value)", width=400, on_text_edited="handle_project_name_changed"),
             u.create_stretch(),
             u.create_spacing(13)
         )

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1280,7 +1280,7 @@ class NameProjectViewModel:
             -> FileStorageSystem.ProjectNameResult:
         """Verify that a project name is a valid filename and doesn't already exist.
 
-        Returns a ProjectNameVerificationResult with is_valid, and a sequence of error messages.
+        Returns a ProjectNameResult with a sequence of error messages if there are any.
         """
         if project_name == "":
             return FileStorageSystem.ProjectNameResult(["Project name cannot be empty"], None)

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -747,7 +747,9 @@ class Application(UIApplication.BaseApplication):
                             action = RenameProjectAction(project_reference)
                             document_controller = self.__application.document_controllers[0]
                             action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
+
                         menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
+
                         menu.popup(gx, gy)
                     return True
 
@@ -950,33 +952,35 @@ class Application(UIApplication.BaseApplication):
 
         If the project reference is the current project, it will be closed and reopened after renaming to update the title.
         """
-        self._enter_prevent_close_state()
-        old_title = project_reference.title
-        renaming_current_project = self.profile.last_project_reference == project_reference.uuid
-        document_controller = self.document_controllers[0]
-        assert document_controller is not None
-        if renaming_current_project:
-            document_controller.request_close()
-        error_message: str | None = None
-        new_project_reference: Profile.ProjectReference | None = None
-        try:
-            new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
-            error_message = "\n".join(rename_result.error_messages)
-        except Exception as e:
-            error_message = _("Exception during renaming project")
-            logging.exception(f"{error_message}:\n{e}")
+        with self.prevent_close():
+            old_title = project_reference.title
+            renaming_current_project = self.profile.last_project_reference == project_reference.uuid
+            document_controller = self.document_controllers[0]
+            assert document_controller is not None
+            if renaming_current_project:
+                document_controller.request_close()
+            error_message: str | None = None
+            new_project_reference: Profile.ProjectReference | None = None
+            try:
+                new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
+                error_message = "\n".join(rename_result.error_messages)
+            except Exception as e:
+                # Catch and log any exceptions during the rename process
+                error_message = _("Exception during renaming project")
+                logging.exception(e)
+                new_project_reference = project_reference
+            finally:
+                # Reopen the project only when renaming the current project and when the project reference is returned
+                if renaming_current_project and new_project_reference is not None:
+                    self.switch_project_reference(new_project_reference)
+                    assert new_project_reference.project is not None
+                    new_project_reference.project.title = name
+                    self.profile.last_project_reference = new_project_reference.uuid
 
-        if renaming_current_project and new_project_reference is not None:  # Reopen the project only when renaming the current project and when the project reference is returned
-            self.switch_project_reference(new_project_reference)
-            assert new_project_reference.project is not None
-            new_project_reference.project.title = name
-            self.profile.last_project_reference = new_project_reference.uuid
-
-        if error_message:
-            self.__show_project_error_dialog(_("Error Renaming Project"), error_message)
-        else:
-            logging.info(f"Renamed Project \"{old_title}\" to \"{name}\"")
-        self._exit_prevent_close_state()
+                if error_message:
+                    self.__show_project_error_dialog(_("Error Renaming Project"), error_message)
+                else:
+                    logging.info(f"Renamed Project \"{old_title}\" to \"{name}\"")
 
 
 def get_root_dir() -> str:
@@ -1335,8 +1339,6 @@ class NameProjectDialog(Declarative.Handler):
         self.accept_fn = accept_fn
         # build the UI
         u = Declarative.DeclarativeUI()
-
-
 
         title = dialog_name
         directory_header = u.create_row(

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -742,6 +742,19 @@ class Application(UIApplication.BaseApplication):
                             profile.remove_project_reference(project_reference_item.project_reference)
 
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
+
+                        def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
+                            document_controller = self.__application.document_controllers[0]
+                            if document_controller is not None:
+                                directory = project_reference.path.parent.as_posix()
+
+                                def handle_rename_clicked(new_name: str, _: str) -> bool:
+                                    self.__application.rename_project(project_reference, new_name)
+                                    return False  # Don't close the dialog since it will have already been closed when reopening the project
+
+                                NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_reference.title, handle_rename_clicked, "Rename Project", False)
+
+                        menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
                         menu.popup(gx, gy)
                     return True
 
@@ -1209,6 +1222,35 @@ class ChooseProjectAction(UIWindow.Action):
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
+class RenameCurrentProjectAction(UIWindow.Action):
+    action_id = "project.rename_current_project"
+    action_name = _("Rename Project")
+
+    def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        raise NotImplementedError()
+
+    def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        context = typing.cast(DocumentController.DocumentController.ActionContext, context_)
+        document_controller = typing.cast(DocumentController.DocumentController, context.window)
+        application = typing.cast(Application, context.application)
+
+        current_project_reference = None
+        last_project_uuid = application.profile.last_project_reference
+        if last_project_uuid is not None:
+            current_project_reference = application.profile.get_project_reference(last_project_uuid)
+
+        if current_project_reference is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        def handle_rename_clicked(new_name: str, _: str) -> bool:
+            assert current_project_reference is not None
+            application.rename_project(current_project_reference, new_name)
+            return False  # Don't close the dialog since it will have already been closed when reopening the project
+
+        directory = current_project_reference.path.parent.as_posix()
+        NameProjectDialog(application.ui, document_controller, application, directory, current_project_reference.title, handle_rename_clicked, "Rename Project", False)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
 
 @dataclasses.dataclass(frozen=True)
 class ProjectNameVerificationResult:
@@ -1372,3 +1414,4 @@ class NameProjectDialog(Declarative.Handler):
 UIWindow.register_action(NewProjectAction())
 UIWindow.register_action(OpenProjectAction())
 UIWindow.register_action(ChooseProjectAction())
+UIWindow.register_action(RenameCurrentProjectAction())

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -745,14 +745,13 @@ class Application(UIApplication.BaseApplication):
 
                         def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
                             document_controller = self.__application.document_controllers[0]
-                            if document_controller is not None:
-                                directory = project_reference.path.parent.as_posix()
+                            directory = project_reference.path.parent.as_posix()
 
-                                def handle_rename_clicked(new_name: str, _: str) -> bool:
-                                    self.__application.rename_project(project_reference, new_name)
-                                    return False  # Don't close the dialog since it will have already been closed when reopening the project
+                            def handle_rename_clicked(new_name: str, _: str) -> bool:
+                                self.__application.rename_project(project_reference, new_name)
+                                return False  # Don't close the dialog since it will have already been closed when reopening the project
 
-                                NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_reference.title, handle_rename_clicked, "Rename Project", False)
+                            NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_reference.title, handle_rename_clicked, "Rename Project", False)
 
                         menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
                         menu.popup(gx, gy)
@@ -1223,6 +1222,10 @@ class ChooseProjectAction(UIWindow.Action):
 
 
 class RenameCurrentProjectAction(UIWindow.Action):
+    """Renames the current project, if it exists. If the current project is not found, this action does nothing.
+
+    The invoke method must be used to call the rename function, calling execute will raise a NotImplementedError.
+    """
     action_id = "project.rename_current_project"
     action_name = _("Rename Project")
 
@@ -1254,6 +1257,7 @@ class RenameCurrentProjectAction(UIWindow.Action):
 
 @dataclasses.dataclass(frozen=True)
 class ProjectNameVerificationResult:
+    """The return of verify_project_name, containing whether the name is valid and any error messages to show if it is not."""
     is_valid: bool
     error_messages: typing.Sequence[str]
 
@@ -1270,10 +1274,11 @@ class NameProjectViewModel:
 
     @classmethod
     def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile,
-                            project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) -> ProjectNameVerificationResult:
+                            project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
+            -> ProjectNameVerificationResult:
         """Verify that a project name is a valid filename and doesn't already exist.
 
-        Returns a tuple with the first element being whether the project name is valid and the second being a sequence of error messages.
+        Returns a ProjectNameVerificationResult with is_valid, and a sequence of error messages.
         """
         if project_name == "":
             return ProjectNameVerificationResult(False, ["Project name cannot be empty"])
@@ -1324,7 +1329,7 @@ class NameProjectDialog(Declarative.Handler):
         # build the UI
         u = Declarative.DeclarativeUI()
 
-        def handle_rename_clicked() -> bool:
+        def handle_accept_clicked() -> bool:
             self.dialog.request_close()
             return accept_fn(self.viewmodel.filename.value or "Untitled", self.viewmodel.directory.value or str())
 
@@ -1390,7 +1395,7 @@ class NameProjectDialog(Declarative.Handler):
 
         self.dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(column, title=title), self))
         self.dialog.add_button(_("Cancel"), lambda: True)
-        self._accept_button = self.dialog.add_button(dialog_name, handle_rename_clicked)
+        self._accept_button = self.dialog.add_button(dialog_name, handle_accept_clicked)
 
         def update_accept_button(_: typing.Any) -> None:
             self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1290,8 +1290,9 @@ class NameProjectViewModel:
         """
         if project_name == "":
             return FileStorageSystem.ProjectNameResult(["Project name cannot be empty"], None)
-        if project_name != Utility.simplify_filename(project_name):
-            return FileStorageSystem.ProjectNameResult(["Project Name contains illegal characters"], None)
+        is_valid, errors = Utility.verify_filename_is_legal(project_name)
+        if not is_valid and errors:
+            return FileStorageSystem.ProjectNameResult(errors, None)
 
         errors: list[str] = []
         name_available_result = project_storage_system.check_project_name_is_available(project_name, base_directory)

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1251,10 +1251,10 @@ class RenameProjectAction(UIWindow.Action):
         if self.project_reference is None:
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
-        if self.project_reference.project is not None:
-            project_storage_system = self.project_reference.project.project_storage_system
-        else:
+        if self.project_reference.project is None:
             project_storage_system = self.project_reference.make_storage(application.profile.profile_context)
+        else:
+            project_storage_system = self.project_reference.project.project_storage_system
 
         if project_storage_system is None:
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
@@ -1290,13 +1290,13 @@ class NameProjectViewModel:
         """
         if project_name == "":
             return FileStorageSystem.ProjectNameResult(["Project name cannot be empty"], None)
-        is_valid, errors = Utility.verify_filename_is_legal(project_name)
-        if not is_valid and errors:
-            return FileStorageSystem.ProjectNameResult(errors, None)
+        is_valid, error_messages = Utility.verify_filename_is_legal(project_name)
+        if not is_valid and error_messages:
+            return FileStorageSystem.ProjectNameResult(error_messages, None)
 
         errors: list[str] = []
         name_available_result = project_storage_system.check_project_name_is_available(project_name, base_directory)
-        errors.extend(name_available_result.error_messages)
+        errors.extend(name_available_result.error_messages or [])
         if name_available_result.success and name_available_result.project_path:
             # Check for an orphaned project reference exists, it would need to be removed manually
             project_reference = profile.get_project_reference_by_path(name_available_result.project_path)

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -746,12 +746,15 @@ class Application(UIApplication.BaseApplication):
                         def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
                             document_controller = self.__application.document_controllers[0]
                             directory = project_reference.path.parent.as_posix()
+                            project_storage_system = project_reference.make_storage(self.__application.profile.profile_context) if project_reference.project is None else project_reference.project.project_storage_system
+                            check_project_name_is_available = project_storage_system.check_project_name_is_available if project_storage_system else None
 
                             def handle_rename_clicked(new_name: str, _: str) -> bool:
                                 self.__application.rename_project(project_reference, new_name)
                                 return False  # Don't close the dialog since it will have already been closed when reopening the project
 
-                            NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_reference.title, handle_rename_clicked, "Rename Project", False)
+                            NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_name=project_reference.title,
+                                              accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_name_available_fn=check_project_name_is_available)
 
                         menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
                         menu.popup(gx, gy)
@@ -1245,66 +1248,63 @@ class RenameCurrentProjectAction(UIWindow.Action):
         if current_project_reference is None:
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
+        project_storage_system = current_project_reference.make_storage(application.profile.profile_context) if current_project_reference.project is None else current_project_reference.project.project_storage_system
+        if project_storage_system is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
         def handle_rename_clicked(new_name: str, _: str) -> bool:
             assert current_project_reference is not None
             application.rename_project(current_project_reference, new_name)
             return False  # Don't close the dialog since it will have already been closed when reopening the project
 
         directory = current_project_reference.path.parent.as_posix()
-        NameProjectDialog(application.ui, document_controller, application, directory, current_project_reference.title, handle_rename_clicked, "Rename Project", False)
+        NameProjectDialog(application.ui, document_controller, application, directory, project_name=current_project_reference.title,
+                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_name_available_fn=project_storage_system.check_project_name_is_available)
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
-
-
-@dataclasses.dataclass(frozen=True)
-class ProjectNameVerificationResult:
-    """The return of verify_project_name, containing whether the name is valid and any error messages to show if it is not."""
-    is_valid: bool
-    error_messages: typing.Sequence[str]
 
 
 class NameProjectViewModel:
     """Represents the NameProjectDialog model."""
-    def __init__(self, filename: str, directory: str, profile: Profile.Profile):
+    def __init__(self, filename: str, directory: str, profile: Profile.Profile, project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None):
         self.filename = Model.PropertyModel(filename)
         self.filename_warning = Model.PropertyModel(str())
         self.project_name_status_label = Model.PropertyModel(str())
         self.accept_button_enabled = Model.PropertyModel(False)
         self.directory = Model.PropertyModel(directory)
         self.profile = profile
+        self.project_name_available_fn = project_name_available_fn
 
     @classmethod
     def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile,
                             project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
-            -> ProjectNameVerificationResult:
+            -> FileStorageSystem.ProjectNameResult:
         """Verify that a project name is a valid filename and doesn't already exist.
 
         Returns a ProjectNameVerificationResult with is_valid, and a sequence of error messages.
         """
         if project_name == "":
-            return ProjectNameVerificationResult(False, ["Project name cannot be empty"])
+            return FileStorageSystem.ProjectNameResult(["Project name cannot be empty"], None)
         if project_name != Utility.simplify_filename(project_name):
-            return ProjectNameVerificationResult(False, ["Project Name contains illegal characters"])
+            return FileStorageSystem.ProjectNameResult(["Project Name contains illegal characters"], None)
 
         errors: list[str] = []
         if project_name_available_fn is None:
-            return ProjectNameVerificationResult(True, errors)
+            return FileStorageSystem.ProjectNameResult(errors, None)
 
         name_available_result = project_name_available_fn(project_name, base_directory)
         errors.extend(name_available_result.error_messages)
-        if not errors and name_available_result.project_path:
+        if name_available_result.success and name_available_result.project_path:
             # Check for an orphaned project reference exists, it would need to be removed manually
             project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
             if project_reference is not None:
                 errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
 
-        is_valid = len(errors) == 0
-        return ProjectNameVerificationResult(is_valid, errors)
+        return FileStorageSystem.ProjectNameResult(errors, None)
 
     def update_project_status_label(self, text: str) -> None:
-        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile,
-                                                                    FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available)
-        self.accept_button_enabled.value = project_name_verification_result.is_valid
-        if not project_name_verification_result.error_messages:  # The name is valid and doesn't already exist.
+        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile, self.project_name_available_fn)
+        self.accept_button_enabled.value = project_name_verification_result.success
+        if project_name_verification_result.success:  # The name is valid and doesn't already exist.
             self.project_name_status_label.value = str()
         else:  # Display the error messages.
             error_str = "\n".join(project_name_verification_result.error_messages)
@@ -1314,17 +1314,18 @@ class NameProjectViewModel:
 class NameProjectDialog(Declarative.Handler):
     def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController,
                  application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], bool],
-                 dialog_name: str, choose_directory_visible: bool):
+                 dialog_name: str, choose_directory_visible: bool, project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None):
         """Declarative Dialog handler for creating/renaming a project.
 
         accept_fn will receive the name and directory when the confirm button is pressed and should return whether this dialog should close itself.
         choose_directory_visible will show the choose directory button when set to True.
         dialog_name is the text to show on the confirm button and in the dialog title.
+        project_name_available_fn is the ProjectStorageSystem function to check if the project exists, that takes the project name and base directory and returns a ProjectNameResult. If None, no check for an existing project will be done.
         """
         super().__init__()
         self.ui = ui
         self.__application = application
-        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile)
+        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, project_name_available_fn)
         self._project_name_line_edit: UserInterface.LineEditWidget | None = None
         # build the UI
         u = Declarative.DeclarativeUI()

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -744,18 +744,9 @@ class Application(UIApplication.BaseApplication):
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
 
                         def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
+                            action = RenameProjectAction(project_reference)
                             document_controller = self.__application.document_controllers[0]
-                            directory = project_reference.path.parent.as_posix()
-                            project_storage_system = project_reference.make_storage(self.__application.profile.profile_context) if project_reference.project is None else project_reference.project.project_storage_system
-                            check_project_name_is_available = project_storage_system.check_project_name_is_available if project_storage_system else None
-
-                            def handle_rename_clicked(new_name: str, _: str) -> bool:
-                                self.__application.rename_project(project_reference, new_name)
-                                return False  # Don't close the dialog since it will have already been closed when reopening the project
-
-                            NameProjectDialog(self.__application.ui, document_controller, self.__application, directory, project_name=project_reference.title,
-                                              accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_name_available_fn=check_project_name_is_available)
-
+                            action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
                         menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
                         menu.popup(gx, gy)
                     return True
@@ -1224,59 +1215,74 @@ class ChooseProjectAction(UIWindow.Action):
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
-class RenameCurrentProjectAction(UIWindow.Action):
+class RenameProjectAction(UIWindow.Action):
     """Renames the current project, if it exists. If the current project is not found, this action does nothing.
 
     The invoke method must be used to call the rename function, calling execute will raise a NotImplementedError.
     """
     action_id = "project.rename_current_project"
     action_name = _("Rename Project")
+    action_parameters = [
+        UIWindow.ActionStringProperty("name")
+    ]
+
+    def __init__(self, project_reference: Profile.ProjectReference | None = None) -> None:
+        super().__init__()
+        self.project_reference = project_reference
 
     def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
-        raise NotImplementedError()
+        assert self.project_reference is not None
+        project_name = self.get_string_property(context, "name")
+        assert project_name is not None
+        application = typing.cast(Application, context.application)
+        application.rename_project(self.project_reference, project_name)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
     def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
         context = typing.cast(DocumentController.DocumentController.ActionContext, context_)
         document_controller = typing.cast(DocumentController.DocumentController, context.window)
         application = typing.cast(Application, context.application)
 
-        current_project_reference = None
-        last_project_uuid = application.profile.last_project_reference
-        if last_project_uuid is not None:
-            current_project_reference = application.profile.get_project_reference(last_project_uuid)
+        if self.project_reference is None:  # If the project reference is not set then use the current project reference
+            last_project_uuid = application.profile.last_project_reference
+            if last_project_uuid is not None:
+                self.project_reference = application.profile.get_project_reference(last_project_uuid)
 
-        if current_project_reference is None:
+        if self.project_reference is None:
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
-        project_storage_system = current_project_reference.make_storage(application.profile.profile_context) if current_project_reference.project is None else current_project_reference.project.project_storage_system
+        if self.project_reference.project is not None:
+            project_storage_system = self.project_reference.project.project_storage_system
+        else:
+            project_storage_system = self.project_reference.make_storage(application.profile.profile_context)
+
         if project_storage_system is None:
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
-        def handle_rename_clicked(new_name: str, _: str) -> bool:
-            assert current_project_reference is not None
-            application.rename_project(current_project_reference, new_name)
-            return False  # Don't close the dialog since it will have already been closed when reopening the project
+        def handle_rename_clicked(new_name: str, _: str) -> None:
+            self.set_string_property(context,"name", new_name)
+            self.execute(context)
 
-        directory = current_project_reference.path.parent.as_posix()
-        NameProjectDialog(application.ui, document_controller, application, directory, project_name=current_project_reference.title,
-                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_name_available_fn=project_storage_system.check_project_name_is_available)
+        directory = self.project_reference.path.parent.as_posix()
+        NameProjectDialog(application.ui, document_controller, application, directory, project_name=self.project_reference.title,
+                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_storage_system=project_storage_system)
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
 class NameProjectViewModel:
     """Represents the NameProjectDialog model."""
-    def __init__(self, filename: str, directory: str, profile: Profile.Profile, project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None):
+    def __init__(self, filename: str, directory: str, profile: Profile.Profile, project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem):
         self.filename = Model.PropertyModel(filename)
         self.filename_warning = Model.PropertyModel(str())
         self.project_name_status_label = Model.PropertyModel(str())
         self.accept_button_enabled = Model.PropertyModel(False)
         self.directory = Model.PropertyModel(directory)
         self.profile = profile
-        self.project_name_available_fn = project_name_available_fn
+        self.project_storage_system = project_storage_system
 
     @classmethod
     def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile,
-                            project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
+                            project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem) \
             -> FileStorageSystem.ProjectNameResult:
         """Verify that a project name is a valid filename and doesn't already exist.
 
@@ -1288,10 +1294,7 @@ class NameProjectViewModel:
             return FileStorageSystem.ProjectNameResult(["Project Name contains illegal characters"], None)
 
         errors: list[str] = []
-        if project_name_available_fn is None:
-            return FileStorageSystem.ProjectNameResult(errors, None)
-
-        name_available_result = project_name_available_fn(project_name, base_directory)
+        name_available_result = project_storage_system.check_project_name_is_available(project_name, base_directory)
         errors.extend(name_available_result.error_messages)
         if name_available_result.success and name_available_result.project_path:
             # Check for an orphaned project reference exists, it would need to be removed manually
@@ -1302,7 +1305,7 @@ class NameProjectViewModel:
         return FileStorageSystem.ProjectNameResult(errors, None)
 
     def update_project_status_label(self, text: str) -> None:
-        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile, self.project_name_available_fn)
+        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile, self.project_storage_system)
         self.accept_button_enabled.value = project_name_verification_result.success
         if project_name_verification_result.success:  # The name is valid and doesn't already exist.
             self.project_name_status_label.value = str()
@@ -1313,11 +1316,12 @@ class NameProjectViewModel:
 
 class NameProjectDialog(Declarative.Handler):
     def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController,
-                 application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], bool],
-                 dialog_name: str, choose_directory_visible: bool, project_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None):
+                 application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], None],
+                 dialog_name: str, choose_directory_visible: bool,
+                 project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem):
         """Declarative Dialog handler for creating/renaming a project.
 
-        accept_fn will receive the name and directory when the confirm button is pressed and should return whether this dialog should close itself.
+        accept_fn will receive the name and directory when the confirm button is pressed
         choose_directory_visible will show the choose directory button when set to True.
         dialog_name is the text to show on the confirm button and in the dialog title.
         project_name_available_fn is the ProjectStorageSystem function to check if the project exists, that takes the project name and base directory and returns a ProjectNameResult. If None, no check for an existing project will be done.
@@ -1325,14 +1329,13 @@ class NameProjectDialog(Declarative.Handler):
         super().__init__()
         self.ui = ui
         self.__application = application
-        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, project_name_available_fn)
+        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, project_storage_system)
         self._project_name_line_edit: UserInterface.LineEditWidget | None = None
+        self.accept_fn = accept_fn
         # build the UI
         u = Declarative.DeclarativeUI()
 
-        def handle_accept_clicked() -> bool:
-            self.dialog.request_close()
-            return accept_fn(self.viewmodel.filename.value or "Untitled", self.viewmodel.directory.value or str())
+
 
         title = dialog_name
         directory_header = u.create_row(
@@ -1365,7 +1368,8 @@ class NameProjectDialog(Declarative.Handler):
 
         project_name_row = u.create_row(
             u.create_spacing(26),
-            u.create_line_edit(name="_project_name_line_edit", text="@binding(viewmodel.filename.value)", width=400, on_text_edited="handle_project_name_changed"),
+            u.create_line_edit(name="_project_name_line_edit", text="@binding(viewmodel.filename.value)", width=400,
+                               on_text_edited="handle_project_name_changed", on_escape_pressed="handle_cancel", on_return_pressed="handle_accept"),
             u.create_stretch(),
             u.create_spacing(13)
         )
@@ -1396,7 +1400,7 @@ class NameProjectDialog(Declarative.Handler):
 
         self.dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(column, title=title), self))
         self.dialog.add_button(_("Cancel"), lambda: True)
-        self._accept_button = self.dialog.add_button(dialog_name, handle_accept_clicked)
+        self._accept_button = self.dialog.add_button(dialog_name, self.handle_accept_clicked)
 
         def update_accept_button(_: typing.Any) -> None:
             self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False
@@ -1404,8 +1408,12 @@ class NameProjectDialog(Declarative.Handler):
 
         self.__accept_button_enabled_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
         self.__accept_button_tool_tip_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
+
         self.viewmodel.update_project_status_label(self.viewmodel.filename.value or str())
         self.dialog.show()
+        assert self._project_name_line_edit is not None
+        self._project_name_line_edit.focused = True
+        self._project_name_line_edit.select_all()
 
     def handle_project_name_changed(self, _widget: UserInterface.LineEditWidget, text: str) -> None:
         self.viewmodel.update_project_status_label(text)
@@ -1416,8 +1424,23 @@ class NameProjectDialog(Declarative.Handler):
             self.viewmodel.directory.value = existing_directory
             self.ui.set_persistent_string("project_directory", existing_directory)
 
+    def handle_accept_clicked(self) -> bool:
+        self.viewmodel.update_project_status_label(self.viewmodel.filename.value or str())
+        if self._accept_button.enabled:
+            self.dialog.request_close()
+            self.accept_fn(self.viewmodel.filename.value or "Untitled", self.viewmodel.directory.value or str())
+        return False
+
+    def handle_accept(self, widget: UserInterface.Widget) -> bool:
+        return self.handle_accept_clicked()
+
+    def handle_cancel(self, widget: UserInterface.Widget) -> bool:
+        print("Cancel")
+        self.dialog.request_close()
+        return True
+
 
 UIWindow.register_action(NewProjectAction())
 UIWindow.register_action(OpenProjectAction())
 UIWindow.register_action(ChooseProjectAction())
-UIWindow.register_action(RenameCurrentProjectAction())
+UIWindow.register_action(RenameProjectAction())

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -939,6 +939,39 @@ class Application(UIApplication.BaseApplication):
 
         self.event_loop.call_later(command_delay or 0.0, execute_next_command, commands, list(commands), command_delay or 0.0, repeat or 1)
 
+    def rename_project(self, project_reference: Profile.ProjectReference, name: str) -> None:
+        """Rename the project reference to the given name.
+
+        If the project reference is the current project, it will be closed and reopened after renaming to update the title.
+        """
+        self._enter_prevent_close_state()
+        old_title = project_reference.title
+        renaming_current_project = self.profile.last_project_reference == project_reference.uuid
+        document_controller = self.document_controllers[0]
+        assert document_controller is not None
+        if renaming_current_project:
+            document_controller.request_close()
+        error_message: str | None = None
+        new_project_reference: Profile.ProjectReference | None = None
+        try:
+            new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
+            error_message = rename_result.error_message
+        except Exception as e:
+            error_message = _("Exception during renaming project")
+            logging.exception(f"{error_message}:\n{e}")
+
+        if renaming_current_project and new_project_reference is not None:  # Reopen the project only when renaming the current project and when the project reference is returned
+            self.switch_project_reference(new_project_reference)
+            assert new_project_reference.project is not None
+            new_project_reference.project.title = name
+            self.profile.last_project_reference = new_project_reference.uuid
+
+        if error_message:
+            self.__show_project_error_dialog(_("Error Renaming Project"), error_message)
+        else:
+            logging.info(f"Renamed Project \"{old_title}\" to \"{name}\"")
+        self._exit_prevent_close_state()
+
 
 def get_root_dir() -> str:
     root_dir = os.path.dirname((os.path.dirname(os.path.abspath(__file__))))

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -59,6 +59,7 @@ from nion.utils import Geometry
 from nion.utils import ListModel
 from nion.utils import Model
 from nion.utils import Registry
+from nion.utils import Stream
 
 if typing.TYPE_CHECKING:
     from nion.swift.model import DisplayItem
@@ -1173,6 +1174,166 @@ class ChooseProjectAction(UIWindow.Action):
         application = typing.cast(Application, context.application)
         application.show_choose_project_dialog()
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectNameVerificationResult:
+    is_valid: bool
+    error_messages: typing.Sequence[str]
+
+
+class NameProjectViewModel:
+    """Represents the NameProjectDialog model."""
+    def __init__(self, filename: str, directory: str, profile: Profile.Profile):
+        self.filename = Model.PropertyModel(filename)
+        self.filename_warning = Model.PropertyModel(str())
+        self.project_name_status_label = Model.PropertyModel(str())
+        self.accept_button_enabled = Model.PropertyModel(False)
+        self.directory = Model.PropertyModel(directory)
+        self.profile = profile
+
+    @classmethod
+    def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile) -> ProjectNameVerificationResult:
+        """Verify that a project name is a valid filename and doesn't already exist.
+
+        Returns a tuple with the first element being whether the project name is valid and the second being a sequence of error messages.
+        """
+        if project_name == "":
+            return ProjectNameVerificationResult(False, ["Project name cannot be empty"])
+        if project_name != Utility.simplify_filename(project_name):
+            return ProjectNameVerificationResult(False, ["Project Name contains illegal characters"])
+        new_project_path = pathlib.Path(base_directory, project_name).with_suffix(".nsproj")
+        errors = []
+        new_data_path = new_project_path.parent / f"{project_name} Data"
+        new_project_path_exists = new_project_path.exists()
+        data_path_exists = new_data_path.is_dir()
+        if new_project_path_exists:
+            errors.append(_("Project Name") + f" \"{new_project_path.name}\" " + _("already exists"))
+        if data_path_exists:
+            errors.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
+
+        # Check for an orphaned project reference exists, it would need to be removed manually
+        project_reference = profile.get_project_reference_by_path(new_project_path)
+        if not new_project_path_exists and not data_path_exists and project_reference is not None:
+            errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
+
+        is_valid = len(errors) == 0
+        return ProjectNameVerificationResult(is_valid, errors)
+
+    def update_project_status_label(self, text: str) -> None:
+        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile)
+        self.accept_button_enabled.value = project_name_verification_result.is_valid
+        if not project_name_verification_result.error_messages:  # The name is valid and doesn't already exist.
+            self.project_name_status_label.value = str()
+        else:  # Display the error messages.
+            error_str = "\n".join(project_name_verification_result.error_messages)
+            self.project_name_status_label.value = error_str
+
+
+class NameProjectDialog(Declarative.Handler):
+    def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController,
+                 application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], bool],
+                 dialog_name: str, choose_directory_visible: bool):
+        """Declarative Dialog handler for creating/renaming a project.
+
+        accept_fn will receive the name and directory when the confirm button is pressed and should return whether this dialog should close itself.
+        choose_directory_visible will show the choose directory button when set to True.
+        dialog_name is the text to show on the confirm button and in the dialog title.
+        """
+        super().__init__()
+        self.ui = ui
+        self.__application = application
+        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile)
+
+        # build the UI
+        u = Declarative.DeclarativeUI()
+
+        def handle_rename_clicked() -> bool:
+            self.dialog.request_close()
+            return accept_fn(self.viewmodel.filename.value or "Untitled", self.viewmodel.directory.value or str())
+
+        title = dialog_name
+        directory_header = u.create_row(
+            u.create_spacing(13),
+            u.create_label(text=_("Projects Folder: ")),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        show_directory_row = u.create_row(
+            u.create_spacing(26),
+            u.create_label(text="@binding(viewmodel.directory.value)", min_width=280, size_policy_horizontal='min-expanding', text_alignment_vertical='top'),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        choose_directory_row = u.create_row(
+            u.create_spacing(26),
+            u.create_push_button(text=_("Choose..."), on_clicked="choose_directory"),
+            u.create_stretch(),
+            u.create_spacing(13), visible=choose_directory_visible
+        )
+
+        project_name_header_row = u.create_row(
+            u.create_spacing(13),
+            u.create_label(text=_("Project Name: ")),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        project_name_row = u.create_row(
+            u.create_spacing(26),
+            u.create_line_edit(text="@binding(viewmodel.filename.value)", width=400, on_text_edited="handle_project_name_changed"),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        project_name_status_row = u.create_row(
+            u.create_spacing(26),
+            u.create_label(text="@binding(viewmodel.project_name_status_label.value)", color="red"),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        column = u.create_column(
+            u.create_spacing(12),
+            directory_header,
+            u.create_spacing(8),
+            show_directory_row,
+            u.create_spacing(8),
+            choose_directory_row,
+            u.create_spacing(8),
+            project_name_header_row,
+            u.create_spacing(8),
+            project_name_row,
+            u.create_spacing(4),
+            project_name_status_row,
+            u.create_stretch(),
+            u.create_spacing(16)
+        )
+
+        self.dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(column, title=title), self))
+        self.dialog.add_button(_("Cancel"), lambda: True)
+        self._accept_button = self.dialog.add_button(dialog_name, handle_rename_clicked)
+
+        def update_accept_button(_: typing.Any) -> None:
+            self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False
+            self._accept_button.tool_tip = self.viewmodel.project_name_status_label.value or str()
+
+        self.__accept_button_enabled_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
+        self.__accept_button_tool_tip_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
+        self.viewmodel.update_project_status_label(self.viewmodel.filename.value or str())
+        self.dialog.show()
+
+    def handle_project_name_changed(self, _widget: UserInterface.LineEditWidget, text: str) -> None:
+        self.viewmodel.update_project_status_label(text)
+
+    def choose_directory(self, _widget: UserInterface.PushButtonWidget) -> None:
+        existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Project Directory"), self.viewmodel.directory.value or str())
+        if existing_directory:
+            self.viewmodel.directory.value = existing_directory
+            self.ui.set_persistent_string("project_directory", existing_directory)
 
 
 UIWindow.register_action(NewProjectAction())

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1269,53 +1269,52 @@ class RenameProjectAction(UIWindow.Action):
 
         directory = self.project_reference.path.parent.as_posix()
         NameProjectDialog(application.ui, document_controller, application, directory, project_name=self.project_reference.title,
-                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False, project_storage_system=project_storage_system)
+                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False,
+                          check_name_available_fn=project_storage_system.check_project_name_is_available)
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
 class NameProjectViewModel:
     """Represents the NameProjectDialog model."""
-    def __init__(self, filename: str, directory: str, profile: Profile.Profile, project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem):
+    def __init__(self, filename: str, directory: str, profile: Profile.Profile, check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None):
         self.filename = Model.PropertyModel(filename)
         self.filename_warning = Model.PropertyModel(str())
         self.project_name_status_label = Model.PropertyModel(str())
         self.accept_button_enabled = Model.PropertyModel(False)
         self.directory = Model.PropertyModel(directory)
         self.profile = profile
-        self.project_storage_system = project_storage_system
+        self.check_name_available_fn = check_name_available_fn
 
-    @classmethod
-    def verify_project_name(cls, project_name: str, base_directory: str, profile: Profile.Profile,
-                            project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem) \
-            -> FileStorageSystem.ProjectNameResult:
-        """Verify that a project name is a valid filename and doesn't already exist.
-
-        Returns a ProjectNameResult with a sequence of error messages if there are any.
-        """
+    @staticmethod
+    def verify_project_name(project_name: str, base_directory: str, profile: Profile.Profile,
+                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
+            -> tuple[bool, typing.Sequence[str] | None]:
+        """Verify that a project name is a valid filename and doesn't already exist."""
         if project_name == "":
-            return FileStorageSystem.ProjectNameResult(["Project name cannot be empty"], None)
+            return False, ["Project name cannot be empty"]
         is_valid, error_messages = Utility.verify_filename_is_legal(project_name)
         if not is_valid and error_messages:
-            return FileStorageSystem.ProjectNameResult(error_messages, None)
+            return is_valid, error_messages
 
         errors: list[str] = []
-        name_available_result = project_storage_system.check_project_name_is_available(project_name, base_directory)
-        errors.extend(name_available_result.error_messages or [])
-        if name_available_result.success and name_available_result.project_path:
-            # Check for an orphaned project reference exists, it would need to be removed manually
-            project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
-            if project_reference is not None:
-                errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
+        if check_name_available_fn:
+            name_available_result = check_name_available_fn(project_name, base_directory)
+            errors.extend(name_available_result.error_messages or [])
+            if name_available_result.success and name_available_result.project_path:
+                # Check for an orphaned project reference exists, it would need to be removed manually
+                project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
+                if project_reference is not None:
+                    errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
 
-        return FileStorageSystem.ProjectNameResult(errors, None)
+        return not errors, errors
 
     def update_project_status_label(self, text: str) -> None:
-        project_name_verification_result = self.verify_project_name(text, self.directory.value or str(), self.profile, self.project_storage_system)
-        self.accept_button_enabled.value = project_name_verification_result.success
-        if project_name_verification_result.success:  # The name is valid and doesn't already exist.
+        is_valid, errors = self.verify_project_name(text, self.directory.value or str(), self.profile, self.check_name_available_fn)
+        self.accept_button_enabled.value = is_valid
+        if is_valid:  # The name is valid and doesn't already exist.
             self.project_name_status_label.value = str()
-        else:  # Display the error messages.
-            error_str = "\n".join(project_name_verification_result.error_messages)
+        elif errors:  # Display the error messages.
+            error_str = "\n".join(errors)
             self.project_name_status_label.value = error_str
 
 
@@ -1323,7 +1322,7 @@ class NameProjectDialog(Declarative.Handler):
     def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController,
                  application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], None],
                  dialog_name: str, choose_directory_visible: bool,
-                 project_storage_system: type[FileStorageSystem.ProjectStorageSystem] | FileStorageSystem.ProjectStorageSystem):
+                 check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult]):
         """Declarative Dialog handler for creating/renaming a project.
 
         accept_fn will receive the name and directory when the confirm button is pressed
@@ -1334,7 +1333,7 @@ class NameProjectDialog(Declarative.Handler):
         super().__init__()
         self.ui = ui
         self.__application = application
-        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, project_storage_system)
+        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, check_name_available_fn)
         self._project_name_line_edit: UserInterface.LineEditWidget | None = None
         self.accept_fn = accept_fn
         # build the UI

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1434,10 +1434,10 @@ class NameProjectDialog(Declarative.Handler):
         return False
 
     def handle_accept(self, widget: UserInterface.Widget) -> bool:
-        return self.handle_accept_clicked()
+        self.handle_accept_clicked()
+        return True
 
     def handle_cancel(self, widget: UserInterface.Widget) -> bool:
-        print("Cancel")
         self.dialog.request_close()
         return True
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import abc
 import contextlib
 import copy
+import dataclasses
 import datetime
+import gettext
 import json
 import logging
 import traceback
@@ -28,6 +30,7 @@ from nion.swift.model import StorageHandler
 from nion.swift.model import Utility
 from nion.utils import Event
 
+_ = gettext.gettext
 
 # define the versions that get stored in the JSON files
 PROFILE_VERSION = 2
@@ -41,6 +44,18 @@ _CreateStorageHandlerFn = typing.Type[StorageHandler.StorageHandler]
 
 
 _g_large_format_size = 16 * 1024 * 1024
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectRenameResult:
+    """Result of the rename_project method.
+
+    project_path will be None when the project path did not change otherwise it will be the new project path.
+    error_message will be empty when there are no errors, otherwise it will be an error message.
+    Only the error message being empty should be used to determine whether the rename was successful.
+    """
+    error_message: str
+    project_path: pathlib.Path | None
 
 
 class ReaderInfo:
@@ -607,6 +622,16 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType: ...
 
+    def rename_project(self, name: str) -> ProjectRenameResult:
+        """Rename the project.
+
+        Returns a ProjectRenameResult.
+        ProjectRenameResult.project_path will be None when the project path did not change otherwise it will be the new project path.
+        ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
+        The project path changing names does not indicate success, only the error message being empty should be used to determine success.
+        """
+        return ProjectRenameResult("Project renaming is not supported for this storage system.", None)
+
     #
 
     @property
@@ -1114,6 +1139,48 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                         logging.error(str(e))
                         raise
         return storage_handlers
+
+    def rename_project(self, name: str) -> ProjectRenameResult:
+        """Renames the project file with the given name. See ProjectStorageSystem.rename_project.
+
+        The returned ProjectRenameResult.project_path will be the new project path or None if the project file was not renamed.
+        ProjectRenameResult.error_message will be empty when the rename was successful otherwise it will contain error message for the user, the exception is written separately to the logger.
+        The project file and data folder (if the data folder exists) are attempted to be renamed.
+        If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
+        If undoing the renaming of the project file files then the project file's name will have changed so the new project path will be not None, but there will still be an error message.
+        """
+        old_project_path = self.__project_path
+        old_title = old_project_path.stem
+        old_data_path = self.__project_data_path or old_project_path.parent / f"{old_title} Data"
+        new_project_path = old_project_path.with_name(f"{name}.nsproj")
+        error_message = None
+        project_path = None
+        try:
+            if old_project_path.exists():
+                project_path = old_project_path.rename(new_project_path)
+        except Exception as e:
+            logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
+            error_message = _("Exception while renaming the Project File")
+            project_path = None
+
+        if error_message is None:  # Only rename the data folder if the project file was renamed
+            new_data_path = old_data_path.parent / f"{name} Data"
+            try:
+                if old_data_path.exists():
+                    old_data_path.rename(new_data_path)
+            except Exception as e:
+                error_message = _("Exception while renaming the Data Folder")
+                logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
+                try:  # Try to undo the rename of the project file when the data folder failed to rename
+                    if new_project_path.exists():
+                        new_project_path.rename(new_project_path.with_name(f"{old_title}.nsproj"))
+                        project_path = None
+                except Exception as e2:
+                    error_message = _("WARNING: Project File and Data Folder names have diverged")
+                    logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
+                    project_path = self.__project_path.with_name(f"{name}.nsproj")  # The undo failed meaning the project path remains as the new one
+
+        return ProjectRenameResult(error_message or str(), project_path)
 
 
 class MemoryStorageHandler(StorageHandler.StorageHandler):

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -47,14 +47,14 @@ _g_large_format_size = 16 * 1024 * 1024
 
 
 @dataclasses.dataclass(frozen=True)
-class ProjectRenameResult:
-    """Result of the rename_project method.
+class ProjectNameResult:
+    """Result of checking a project name and renaming a project.
 
-    project_path will be None when the project path did not change otherwise it will be the new project path.
-    error_message will be empty when there are no errors, otherwise it will be an error message.
-    Only the error message being empty should be used to determine whether the rename was successful.
+    project_path will be None when the project path does not change otherwise it will be the new project path.
+    error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
+    Only the error_messages being empty should be used to determine whether the check/rename was successful.
     """
-    error_message: str
+    error_messages: typing.Sequence[str]
     project_path: pathlib.Path | None
 
 
@@ -622,7 +622,12 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType: ...
 
-    def rename_project(self, name: str) -> ProjectRenameResult:
+    @classmethod
+    def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:
+        """Check if the provided project name is available for use."""
+        return ProjectNameResult([], None)
+
+    def rename_project(self, name: str) -> ProjectNameResult:
         """Rename the project.
 
         Returns a ProjectRenameResult.
@@ -630,7 +635,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
         ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
         The project path changing names does not indicate success, only the error message being empty should be used to determine success.
         """
-        return ProjectRenameResult("Project renaming is not supported for this storage system.", None)
+        return ProjectNameResult(["Project renaming is not supported for this storage system."], None)
 
     #
 
@@ -1140,7 +1145,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                         raise
         return storage_handlers
 
-    def rename_project(self, name: str) -> ProjectRenameResult:
+    def rename_project(self, name: str) -> ProjectNameResult:
         """Renames the project file with the given name. See ProjectStorageSystem.rename_project.
 
         The returned ProjectRenameResult.project_path will be the new project path or None if the project file was not renamed.
@@ -1153,35 +1158,53 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         old_title = old_project_path.stem
         old_data_path = self.__project_data_path or old_project_path.parent / f"{old_title} Data"
         new_project_path = old_project_path.with_name(f"{name}.nsproj")
-        error_message = None
-        project_path = None
+        error_messages = []
+        project_path: pathlib.Path | None = None
         try:
             if old_project_path.exists():
                 project_path = old_project_path.rename(new_project_path)
         except Exception as e:
             logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
-            error_message = _("Exception while renaming the Project File")
+            error_messages.append(_("Exception while renaming the Project File"))
             project_path = None
 
-        if error_message is None:  # Only rename the data folder if the project file was renamed
+        if not error_messages:  # Only rename the data folder if the project file was renamed
             new_data_path = old_data_path.parent / f"{name} Data"
             try:
                 if old_data_path.exists():
                     old_data_path.rename(new_data_path)
             except Exception as e:
-                error_message = _("Exception while renaming the Data Folder")
+                error_messages.append(_("Exception while renaming the Data Folder"))
                 logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
                 try:  # Try to undo the rename of the project file when the data folder failed to rename
                     if new_project_path.exists():
                         new_project_path.rename(new_project_path.with_name(f"{old_title}.nsproj"))
                         project_path = None
                 except Exception as e2:
-                    error_message = _("WARNING: Project File and Data Folder names have diverged")
+                    error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
                     logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
                     project_path = self.__project_path.with_name(f"{name}.nsproj")  # The undo failed meaning the project path remains as the new one
 
-        return ProjectRenameResult(error_message or str(), project_path)
+        return ProjectNameResult(error_messages, project_path)
 
+    @classmethod
+    def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:
+        """Check if the provided project name is available for use.
+
+        Checks that no project file or data folder exist in the directory that already use the name provided.
+        Returns ProjectNameResult with the calculated project_path, and error_messages for when the project file or data folder already exist.
+        """
+        new_project_path = pathlib.Path(directory, name).with_suffix(".nsproj")
+        error_messages = []
+        new_data_path = new_project_path.parent / f"{name} Data"
+        new_project_path_exists = new_project_path.exists()
+        data_path_exists = new_data_path.is_dir()
+        if new_project_path_exists:
+            error_messages.append(_("Project Name") + f" \"{new_project_path.name}\" " + _("already exists"))
+        if data_path_exists:
+            error_messages.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
+
+        return ProjectNameResult(error_messages, new_project_path)
 
 class MemoryStorageHandler(StorageHandler.StorageHandler):
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -48,7 +48,7 @@ _g_large_format_size = 16 * 1024 * 1024
 
 @dataclasses.dataclass(frozen=True)
 class ProjectNameResult:
-    """Result of checking a project name and renaming a project.
+    """Result of checking a project name is available or of renaming a project.
 
     project_path will be None when the project path does not change otherwise it will be the new project path.
     error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
@@ -624,7 +624,12 @@ class ProjectStorageSystem(PersistentStorageSystem):
 
     @classmethod
     def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:
-        """Check if the provided project name is available for use."""
+        """Check if the provided project name is available for use.
+
+        Returns a ProjectNameResult.
+        ProjectNameResult.project_path is set to the path that would be used for the project if the name is available, otherwise None.
+        ProjectNameResult.error_message contains a sequence of error messages if there are any.
+        """
         return ProjectNameResult([], None)
 
     def rename_project(self, name: str) -> ProjectNameResult:
@@ -1152,7 +1157,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         ProjectRenameResult.error_message will be empty when the rename was successful otherwise it will contain error message for the user, the exception is written separately to the logger.
         The project file and data folder (if the data folder exists) are attempted to be renamed.
         If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
-        If undoing the renaming of the project file files then the project file's name will have changed so the new project path will be not None, but there will still be an error message.
+        If undoing the renaming of the project file fails then the project file's name will have changed so the new project path will be not None, but there will still be an error message.
         """
         old_project_path = self.__project_path
         old_title = old_project_path.stem
@@ -1205,6 +1210,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
             error_messages.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
 
         return ProjectNameResult(error_messages, new_project_path)
+
 
 class MemoryStorageHandler(StorageHandler.StorageHandler):
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -640,7 +640,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
         """Rename the project.
 
         Returns a ProjectRenameResult.
-        ProjectRenameResult.project_path will be None when the project path did not change otherwise it will be the new project path.
+        ProjectRenameResult.project_path will be the new project path or the original if the project path did not change.
         ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
         The project path changing names does not indicate success, only the ProjectNameResult.success should be used to check success.
         """
@@ -1157,42 +1157,36 @@ class FileProjectStorageSystem(ProjectStorageSystem):
     def rename_project(self, name: str) -> ProjectNameResult:
         """Renames the project file with the given name. See ProjectStorageSystem.rename_project.
 
-        The returned ProjectRenameResult.project_path will be the new project path or None if the project file was not renamed.
+        The returned ProjectRenameResult.project_path will be the new project path.
         ProjectRenameResult.error_message will be empty when the rename was successful otherwise it will contain error message for the user, the exception is written separately to the logger.
         The project file and data folder (if the data folder exists) are attempted to be renamed.
         If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
-        If undoing the renaming of the project file fails then the project file's name will have changed so the new project path will be not None, but there will still be an error message.
+        If undoing the renaming of the project file fails then the project file's name will have changed, but there will still be an error message.
         """
         old_data_path = self.__project_data_path
         old_project_path = self.__project_path
-        old_title = old_project_path.stem
         new_project_path = old_project_path.with_name(f"{name}.nsproj")
-        error_messages = []
-        project_path: pathlib.Path | None = None
         try:
-            project_path = old_project_path.rename(new_project_path)
+            self.__project_path = old_project_path.rename(new_project_path)
         except Exception as e:
             logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
-            error_messages.append(_("Exception while renaming the Project File"))
-            project_path = None
+            return ProjectNameResult([_("Exception while renaming the Project File")], self.__project_path)
 
-        if not error_messages:  # Only rename the data folder if the project file was renamed
-            try:
-                if old_data_path is not None:
-                    old_data_path.rename(old_data_path.parent / f"{name} Data")
-            except Exception as e:
-                error_messages.append(_("Exception while renaming the Data Folder"))
-                logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
-                try:  # Try to undo the rename of the project file when the data folder failed to rename
-                    if new_project_path.exists():
-                        new_project_path.rename(new_project_path.with_name(f"{old_title}.nsproj"))
-                        project_path = None
-                except Exception as e2:
-                    error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
-                    logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
-                    project_path = self.__project_path.with_name(f"{name}.nsproj")  # The undo failed meaning the project path remains as the new one
+        error_messages = []
+        try:
+            if old_data_path is not None:
+                self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
+        except Exception as e:
+            error_messages.append(_("Exception while renaming the Data Folder"))
+            logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
+            try:  # Try to undo the rename of the project file when the data folder failed to rename
+                if new_project_path.exists():
+                    self.__project_path = new_project_path.rename(old_project_path)
+            except Exception as e2:
+                error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
+                logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
 
-        return ProjectNameResult(error_messages, project_path)
+        return ProjectNameResult(error_messages, self.__project_path)
 
     @classmethod
     def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -52,10 +52,14 @@ class ProjectNameResult:
 
     project_path will be None when the project path does not change otherwise it will be the new project path.
     error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
-    Only the error_messages being empty should be used to determine whether the check/rename was successful.
+    The success property is True when there are no errors and False when there are errors.
     """
     error_messages: typing.Sequence[str]
     project_path: pathlib.Path | None
+
+    @property
+    def success(self) -> bool:
+        return not self.error_messages
 
 
 class ReaderInfo:
@@ -638,7 +642,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
         Returns a ProjectRenameResult.
         ProjectRenameResult.project_path will be None when the project path did not change otherwise it will be the new project path.
         ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
-        The project path changing names does not indicate success, only the error message being empty should be used to determine success.
+        The project path changing names does not indicate success, only the ProjectNameResult.success should be used to check success.
         """
         return ProjectNameResult(["Project renaming is not supported for this storage system."], None)
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1159,25 +1159,23 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
         If undoing the renaming of the project file fails then the project file's name will have changed so the new project path will be not None, but there will still be an error message.
         """
+        old_data_path = self.__project_data_path
         old_project_path = self.__project_path
         old_title = old_project_path.stem
-        old_data_path = self.__project_data_path or old_project_path.parent / f"{old_title} Data"
         new_project_path = old_project_path.with_name(f"{name}.nsproj")
         error_messages = []
         project_path: pathlib.Path | None = None
         try:
-            if old_project_path.exists():
-                project_path = old_project_path.rename(new_project_path)
+            project_path = old_project_path.rename(new_project_path)
         except Exception as e:
             logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
             error_messages.append(_("Exception while renaming the Project File"))
             project_path = None
 
         if not error_messages:  # Only rename the data folder if the project file was renamed
-            new_data_path = old_data_path.parent / f"{name} Data"
             try:
-                if old_data_path.exists():
-                    old_data_path.rename(new_data_path)
+                if old_data_path is not None:
+                    old_data_path.rename(old_data_path.parent / f"{name} Data")
             except Exception as e:
                 error_messages.append(_("Exception while renaming the Data Folder"))
                 logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -626,8 +626,8 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType: ...
 
-    @classmethod
-    def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:
+    @staticmethod
+    def check_project_name_is_available(name: str, directory: str) -> ProjectNameResult:
         """Check if the provided project name is available for use.
 
         Returns a ProjectNameResult.
@@ -1188,8 +1188,8 @@ class FileProjectStorageSystem(ProjectStorageSystem):
 
         return ProjectNameResult(error_messages, self.__project_path)
 
-    @classmethod
-    def check_project_name_is_available(cls, name: str, directory: str) -> ProjectNameResult:
+    @staticmethod
+    def check_project_name_is_available(name: str, directory: str) -> ProjectNameResult:
         """Check if the provided project name is available for use.
 
         Checks that no project file or data folder exist in the directory that already use the name provided.

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1163,9 +1163,16 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
         If undoing the renaming of the project file fails then the project file's name will have changed, but there will still be an error message.
         """
+        self.load_properties()
+        if self.__project_data_path is None:
+            # The project data path may not be up to date and is None even though there is a data folder on disk
+            data_path = self.__project_path.parent / f"{self.project_path.name} Data"  # Default path of the data folder
+            if data_path.exists():  # Only save the data folder when it exists on disk
+                self.__project_data_path = data_path
+
         old_data_path = self.__project_data_path
         old_project_path = self.__project_path
-        new_project_path = old_project_path.with_name(f"{name}.nsproj")
+        new_project_path = old_project_path.parent / f"{name}.nsproj"
         try:
             self.__project_path = old_project_path.rename(new_project_path)
         except Exception as e:
@@ -1174,7 +1181,8 @@ class FileProjectStorageSystem(ProjectStorageSystem):
 
         error_messages = []
         try:
-            if old_data_path is not None:
+            # The directory must be checked to exist because load_properties will set the data path to the default even when the directory does not exist
+            if old_data_path is not None and old_data_path.is_dir():
                 self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
         except Exception as e:
             error_messages.append(_("Exception while renaming the Data Folder"))
@@ -1186,6 +1194,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                 error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
                 logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
 
+        self._write_properties()  # Trigger the writing of the project_data_folders in the project file
         return ProjectNameResult(error_messages, self.__project_path)
 
     @staticmethod

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1194,11 +1194,10 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         If undoing the renaming of the project file fails then the project file's name will have changed, but there will still be an error message.
         """
         self.load_properties()
-        if self.__project_data_path is None:
-            # The project data path may not be up to date and is None even though there is a data folder on disk
-            data_path = self.__project_path.parent / f"{self.project_path.name} Data"  # Default path of the data folder
-            if data_path.exists():  # Only save the data folder when it exists on disk
-                self.__project_data_path = data_path
+        self.normalize_project_data_path()
+        # normalize_project_data_path can set the data path to a non-existent directory instead of None, so if it doesn't exist we set it to None
+        if self.__project_data_path is None or not self.__project_data_path.is_dir():
+            self.__project_data_path = None
 
         old_data_path = self.__project_data_path
         old_project_path = self.__project_path
@@ -1212,7 +1211,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         error_messages = []
         try:
             # The directory must be checked to exist because load_properties will set the data path to the default even when the directory does not exist
-            if old_data_path is not None and old_data_path.is_dir():
+            if old_data_path is not None:
                 self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
         except Exception as e:
             error_messages.append(_("Exception while renaming the Data Folder"))
@@ -1224,7 +1223,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                 error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
                 logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
 
-        self._write_properties()  # Trigger the writing of the project_data_folders in the project file
+        self._write_untransformed_properties(self._untransform_properties(self.get_properties()))  # Trigger the writing of the project_data_folders in the project file
         return ProjectNameResult(error_messages, self.__project_path)
 
     @staticmethod

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -644,7 +644,7 @@ class Profile(Persistence.PersistentObject):
         Returns the newly loaded project reference and the rename result as a tuple to be unpacked.
         """
         project = project_reference.project
-        project_path = project_reference.path
+
         if project is None:
             project_storage_system = project_reference.make_storage(self.profile_context)
         else:
@@ -656,7 +656,9 @@ class Profile(Persistence.PersistentObject):
         self.remove_project_reference(project_reference)
 
         rename_result = project_storage_system.rename_project(name)
-        if rename_result.project_path is not None:  # The project file name changed, so update the project reference to point to the new path.
+
+        project_path = project_reference.path  # Load the old path unless the returned project path exists
+        if rename_result.project_path is not None and rename_result.project_path.exists():
             project_path = rename_result.project_path
 
         # Open project creates and adds the project to the profile, but does not read/load the project.

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -638,6 +638,33 @@ class Profile(Persistence.PersistentObject):
             return self.add_project_index(path, load=False)
         return None
 
+    def rename_project(self, project_reference: ProjectReference, name: str) -> tuple[ProjectReference, FileStorageSystem.ProjectRenameResult]:
+        """Rename the project, managing the loading and unloading of the project and calling the ProjectStorageSystem rename_project function.
+
+        Returns the newly loaded project reference and the rename result as a tuple to be unpacked.
+        """
+        project = project_reference.project
+        project_path = project_reference.path
+        if project is None:
+            project_storage_system = project_reference.make_storage(self.profile_context)
+        else:
+            project_storage_system = project.project_storage_system
+        assert project_storage_system is not None
+
+        if project_reference.project_state == "loaded":
+            project_reference.unload_project()  # Defensively ensure the project is unloaded to avoid a traceback when removing the project reference
+        self.remove_project_reference(project_reference)
+
+        rename_result = project_storage_system.rename_project(name)
+        if rename_result.project_path is not None:  # The project file name changed, so update the project reference to point to the new path.
+            project_path = rename_result.project_path
+
+        # Open project creates and adds the project to the profile, but does not read/load the project.
+        # The project reference should be added even when the renaming fails
+        new_project_reference = self.open_project(project_path)
+        assert new_project_reference is not None
+        return new_project_reference, rename_result
+
     def get_project_reference(self, uuid_: uuid.UUID) -> typing.Optional[ProjectReference]:
         for project_reference in self.project_references:
             if project_reference.uuid == uuid_:

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -638,7 +638,7 @@ class Profile(Persistence.PersistentObject):
             return self.add_project_index(path, load=False)
         return None
 
-    def rename_project(self, project_reference: ProjectReference, name: str) -> tuple[ProjectReference, FileStorageSystem.ProjectRenameResult]:
+    def rename_project(self, project_reference: ProjectReference, name: str) -> tuple[ProjectReference, FileStorageSystem.ProjectNameResult]:
         """Rename the project, managing the loading and unloading of the project and calling the ProjectStorageSystem rename_project function.
 
         Returns the newly loaded project reference and the rename result as a tuple to be unpacked.

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -23,6 +23,10 @@
                 "items": []
             },
             {
+                "type": "item",
+                "action_id": "project.rename_current_project"
+            },
+            {
                 "type": "separator"
             },
             {

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -89,15 +89,11 @@ class TestProjectClass(unittest.TestCase):
             reference_path = project_reference.path
             base_directory = reference_path.parent
 
-            def mock_get_project_reference_by_path(_path: pathlib.Path) -> Profile.ProjectReference | None:
-                return project_reference
-
             def mock_check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
                 return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
 
-            with unittest.mock.patch.object(profile, 'get_project_reference_by_path', mock_get_project_reference_by_path):
-                with unittest.mock.patch.object(FileStorageSystem.ProjectStorageSystem, 'check_project_name_is_available', mock_check_project_name_is_available):
-                    viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, FileStorageSystem.ProjectStorageSystem)
-                    viewmodel.update_project_status_label(project_reference.title)
-                    self.assertFalse(viewmodel.accept_button_enabled.value)
-                    self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")
+            with unittest.mock.patch.object(FileStorageSystem.ProjectStorageSystem, 'check_project_name_is_available', mock_check_project_name_is_available):
+                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, FileStorageSystem.ProjectStorageSystem)
+                viewmodel.update_project_status_label(project_reference.title)
+                self.assertFalse(viewmodel.accept_button_enabled.value)
+                self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -1,8 +1,10 @@
 # standard libraries
 import contextlib
 import copy
+import pathlib
 import typing
 import unittest
+import unittest.mock
 
 # third party libraries
 import numpy
@@ -10,9 +12,7 @@ import numpy
 # local libraries
 from nion.swift import Application
 from nion.swift import Facade
-from nion.swift.model import Connection
 from nion.swift.model import DataItem
-from nion.swift.model import DisplayItem
 from nion.swift.model import Profile
 from nion.swift.test import TestContext
 from nion.ui import TestUI
@@ -82,3 +82,74 @@ class TestProjectClass(unittest.TestCase):
                 project_reference.close()
 
     # do not import same project (by uuid) twice
+
+    def test_verify_project_name_is_invalid_with_existing_project(self) -> None:
+        original_exists = pathlib.Path.exists
+
+        def mock_exists(self_path: pathlib.Path) -> bool:
+            if str(self_path).endswith("ExistingProject.nsproj"):
+                return True
+            return original_exists(self_path)
+
+        with TestContext.MemoryProfileContext() as profile_context:
+            with unittest.mock.patch.object(pathlib.Path, 'exists', mock_exists):
+                current_working_directory = str(pathlib.Path.cwd())
+                viewmodel = Application.NameProjectViewModel("ExistingProject", current_working_directory, profile_context.create_profile())
+                viewmodel.update_project_status_label("ExistingProject")
+                self.assertFalse(viewmodel.accept_button_enabled.value)
+                self.assertEqual(viewmodel.project_name_status_label.value, "Project Name \"ExistingProject.nsproj\" already exists")
+
+    def test_name_project_viewmodel_is_invalid_with_existing_data(self) -> None:
+        original_is_dir = pathlib.Path.is_dir
+
+        def mock_is_dir(self_path: pathlib.Path) -> bool:
+            if str(self_path).endswith("ExistingProject Data"):
+                return True
+            return original_is_dir(self_path)
+
+        with TestContext.MemoryProfileContext() as profile_context:
+            with unittest.mock.patch.object(pathlib.Path, 'is_dir', mock_is_dir):
+                current_working_directory = str(pathlib.Path.cwd())
+                viewmodel = Application.NameProjectViewModel("ExistingProject", current_working_directory, profile_context.create_profile())
+                viewmodel.update_project_status_label("ExistingProject")
+                self.assertFalse(viewmodel.accept_button_enabled.value)
+                self.assertEqual(viewmodel.project_name_status_label.value, "Data Folder \"ExistingProject Data\" already exists")
+
+    def test_verify_project_name_is_invalid_with_existing_reference(self) -> None:
+        with TestContext.MemoryProfileContext() as profile_context:
+            profile = profile_context.create_profile()
+            project_reference = profile.project_references[0]
+
+            def mock_get_project_reference_by_path(_path: pathlib.Path) -> Profile.ProjectReference | None:
+                return project_reference
+
+            with unittest.mock.patch.object(profile, 'get_project_reference_by_path', mock_get_project_reference_by_path):
+                reference_path = project_reference.path
+                base_directory = reference_path.parent
+                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile)
+                viewmodel.update_project_status_label(project_reference.title)
+                self.assertFalse(viewmodel.accept_button_enabled.value)
+                self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")
+
+    def test_name_project_dialog_button_validity_updates(self) -> None:
+        with create_memory_profile_context() as profile_context:
+            profile = profile_context.create_profile()
+            profile.read_profile()
+            app = profile_context.create_application()
+            app._set_profile_for_test(profile)
+            document_controller = app.open_project_window(profile.project_references[0])
+            try:
+                current_working_directory = str(pathlib.Path.cwd())
+                dialog = Application.NameProjectDialog(app.ui, document_controller, app, current_working_directory, "",
+                                                       accept_fn=lambda _name, _dir: False, dialog_name="Rename Project", choose_directory_visible=False)
+
+                # Check the button starts off as disabled
+                self.assertEqual(dialog._accept_button.tool_tip, "Project name cannot be empty")
+                self.assertFalse(dialog._accept_button.enabled)
+
+                # Check that the rename button becomes enabled when the name becomes valid
+                dialog.handle_project_name_changed(app.ui.create_line_edit_widget(), "NewProjectName")
+                self.assertTrue(dialog._accept_button.enabled)
+            finally:
+                # clean up
+                document_controller.request_close()

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -148,7 +148,8 @@ class TestProjectClass(unittest.TestCase):
                 self.assertFalse(dialog._accept_button.enabled)
 
                 # Check that the rename button becomes enabled when the name becomes valid
-                dialog.handle_project_name_changed(app.ui.create_line_edit_widget(), "NewProjectName")
+
+                dialog.handle_project_name_changed(_widget=app.ui.create_line_edit_widget(), text="NewProjectName")
                 self.assertTrue(dialog._accept_button.enabled)
             finally:
                 # clean up

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -12,8 +12,9 @@ import numpy
 # local libraries
 from nion.swift import Application
 from nion.swift import Facade
-from nion.swift.model import DataItem
+from nion.swift.model import DataItem, FileStorageSystem
 from nion.swift.model import Profile
+from nion.swift.model.FileStorageSystem import FileProjectStorageSystem
 from nion.swift.test import TestContext
 from nion.ui import TestUI
 
@@ -87,14 +88,17 @@ class TestProjectClass(unittest.TestCase):
         with TestContext.MemoryProfileContext() as profile_context:
             profile = profile_context.create_profile()
             project_reference = profile.project_references[0]
+            reference_path = project_reference.path
+            base_directory = reference_path.parent
 
             def mock_get_project_reference_by_path(_path: pathlib.Path) -> Profile.ProjectReference | None:
                 return project_reference
 
+            def mock_check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
+                return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
+
             with unittest.mock.patch.object(profile, 'get_project_reference_by_path', mock_get_project_reference_by_path):
-                reference_path = project_reference.path
-                base_directory = reference_path.parent
-                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile)
+                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, mock_check_project_name_is_available)
                 viewmodel.update_project_status_label(project_reference.title)
                 self.assertFalse(viewmodel.accept_button_enabled.value)
                 self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -83,39 +83,7 @@ class TestProjectClass(unittest.TestCase):
 
     # do not import same project (by uuid) twice
 
-    def test_verify_project_name_is_invalid_with_existing_project(self) -> None:
-        original_exists = pathlib.Path.exists
-
-        def mock_exists(self_path: pathlib.Path) -> bool:
-            if str(self_path).endswith("ExistingProject.nsproj"):
-                return True
-            return original_exists(self_path)
-
-        with TestContext.MemoryProfileContext() as profile_context:
-            with unittest.mock.patch.object(pathlib.Path, 'exists', mock_exists):
-                current_working_directory = str(pathlib.Path.cwd())
-                viewmodel = Application.NameProjectViewModel("ExistingProject", current_working_directory, profile_context.create_profile())
-                viewmodel.update_project_status_label("ExistingProject")
-                self.assertFalse(viewmodel.accept_button_enabled.value)
-                self.assertEqual(viewmodel.project_name_status_label.value, "Project Name \"ExistingProject.nsproj\" already exists")
-
-    def test_name_project_viewmodel_is_invalid_with_existing_data(self) -> None:
-        original_is_dir = pathlib.Path.is_dir
-
-        def mock_is_dir(self_path: pathlib.Path) -> bool:
-            if str(self_path).endswith("ExistingProject Data"):
-                return True
-            return original_is_dir(self_path)
-
-        with TestContext.MemoryProfileContext() as profile_context:
-            with unittest.mock.patch.object(pathlib.Path, 'is_dir', mock_is_dir):
-                current_working_directory = str(pathlib.Path.cwd())
-                viewmodel = Application.NameProjectViewModel("ExistingProject", current_working_directory, profile_context.create_profile())
-                viewmodel.update_project_status_label("ExistingProject")
-                self.assertFalse(viewmodel.accept_button_enabled.value)
-                self.assertEqual(viewmodel.project_name_status_label.value, "Data Folder \"ExistingProject Data\" already exists")
-
-    def test_verify_project_name_is_invalid_with_existing_reference(self) -> None:
+    def test_project_name_viewmodel_is_invalid_with_existing_reference(self) -> None:
         with TestContext.MemoryProfileContext() as profile_context:
             profile = profile_context.create_profile()
             project_reference = profile.project_references[0]
@@ -140,17 +108,17 @@ class TestProjectClass(unittest.TestCase):
             document_controller = app.open_project_window(profile.project_references[0])
             try:
                 current_working_directory = str(pathlib.Path.cwd())
-                dialog = Application.NameProjectDialog(app.ui, document_controller, app, current_working_directory, "",
-                                                       accept_fn=lambda _name, _dir: False, dialog_name="Rename Project", choose_directory_visible=False)
+                name_project_dialog = Application.NameProjectDialog(app.ui, document_controller, app, current_working_directory, "",
+                                                                    accept_fn=lambda _name, _dir: False, dialog_name="Rename Project", choose_directory_visible=False)
 
                 # Check the button starts off as disabled
-                self.assertEqual(dialog._accept_button.tool_tip, "Project name cannot be empty")
-                self.assertFalse(dialog._accept_button.enabled)
+                self.assertEqual(name_project_dialog._accept_button.tool_tip, "Project name cannot be empty")
+                self.assertFalse(name_project_dialog._accept_button.enabled)
 
                 # Check that the rename button becomes enabled when the name becomes valid
-
-                dialog.handle_project_name_changed(_widget=app.ui.create_line_edit_widget(), text="NewProjectName")
-                self.assertTrue(dialog._accept_button.enabled)
+                assert name_project_dialog._project_name_line_edit is not None
+                name_project_dialog.handle_project_name_changed(_widget=name_project_dialog._project_name_line_edit, text="NewProjectName")
+                self.assertTrue(name_project_dialog._accept_button.enabled)
             finally:
                 # clean up
                 document_controller.request_close()

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -1,6 +1,5 @@
 # standard libraries
 import contextlib
-import copy
 import pathlib
 import typing
 import unittest
@@ -12,11 +11,10 @@ import numpy
 # local libraries
 from nion.swift import Application
 from nion.swift import Facade
-from nion.swift.model import DataItem, FileStorageSystem
+from nion.swift.model import DataItem
+from nion.swift.model import FileStorageSystem
 from nion.swift.model import Profile
-from nion.swift.model.FileStorageSystem import FileProjectStorageSystem
 from nion.swift.test import TestContext
-from nion.ui import TestUI
 
 
 Facade.initialize()
@@ -98,31 +96,8 @@ class TestProjectClass(unittest.TestCase):
                 return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
 
             with unittest.mock.patch.object(profile, 'get_project_reference_by_path', mock_get_project_reference_by_path):
-                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, mock_check_project_name_is_available)
-                viewmodel.update_project_status_label(project_reference.title)
-                self.assertFalse(viewmodel.accept_button_enabled.value)
-                self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")
-
-    def test_name_project_dialog_button_validity_updates(self) -> None:
-        with create_memory_profile_context() as profile_context:
-            profile = profile_context.create_profile()
-            profile.read_profile()
-            app = profile_context.create_application()
-            app._set_profile_for_test(profile)
-            document_controller = app.open_project_window(profile.project_references[0])
-            try:
-                current_working_directory = str(pathlib.Path.cwd())
-                name_project_dialog = Application.NameProjectDialog(app.ui, document_controller, app, current_working_directory, "",
-                                                                    accept_fn=lambda _name, _dir: False, dialog_name="Rename Project", choose_directory_visible=False)
-
-                # Check the button starts off as disabled
-                self.assertEqual(name_project_dialog._accept_button.tool_tip, "Project name cannot be empty")
-                self.assertFalse(name_project_dialog._accept_button.enabled)
-
-                # Check that the rename button becomes enabled when the name becomes valid
-                assert name_project_dialog._project_name_line_edit is not None
-                name_project_dialog.handle_project_name_changed(_widget=name_project_dialog._project_name_line_edit, text="NewProjectName")
-                self.assertTrue(name_project_dialog._accept_button.enabled)
-            finally:
-                # clean up
-                document_controller.request_close()
+                with unittest.mock.patch.object(FileStorageSystem.ProjectStorageSystem, 'check_project_name_is_available', mock_check_project_name_is_available):
+                    viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, FileStorageSystem.ProjectStorageSystem)
+                    viewmodel.update_project_status_label(project_reference.title)
+                    self.assertFalse(viewmodel.accept_button_enabled.value)
+                    self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -89,7 +89,11 @@ class TestProjectClass(unittest.TestCase):
             reference_path = project_reference.path
             base_directory = reference_path.parent
 
-            viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, None)
+            # In order to get to the test path the check available function just returns a success with a path to the existing reference
+            def check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
+                return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
+
+            viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, check_project_name_is_available)
             viewmodel.update_project_status_label(project_reference.title)
             self.assertFalse(viewmodel.accept_button_enabled.value)
             self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -89,11 +89,7 @@ class TestProjectClass(unittest.TestCase):
             reference_path = project_reference.path
             base_directory = reference_path.parent
 
-            def mock_check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
-                return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
-
-            with unittest.mock.patch.object(FileStorageSystem.ProjectStorageSystem, 'check_project_name_is_available', mock_check_project_name_is_available):
-                viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, FileStorageSystem.ProjectStorageSystem)
-                viewmodel.update_project_status_label(project_reference.title)
-                self.assertFalse(viewmodel.accept_button_enabled.value)
-                self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")
+            viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, None)
+            viewmodel.update_project_status_label(project_reference.title)
+            self.assertFalse(viewmodel.accept_button_enabled.value)
+            self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4645,6 +4645,131 @@ class TestStorageClass(unittest.TestCase):
         memory_usage = memory_usage_resource() - memory_start
         self.assertTrue(memory_usage < 0.2)
 
+    def test_rename_current_project_with_no_items_works(self):
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                app.rename_project(project_reference, "new_name")
+                project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+
+                self.assertIsNotNone(project_reference.project)  # Check the project reopened
+                self.assertEqual("new_name", project_reference.project.title)  # Check the title was updated
+                self.assertEqual("loaded", project_reference.project_state)  # Check the project was reloaded
+                self.assertEqual("new_name", project_reference.project_path.stem)
+                self.assertEqual("new_name", project_reference.path.stem)
+                self.assertTrue((profile_context.projects_dir / "new_name.nsproj").exists())
+                self.assertFalse((profile_context.projects_dir / "new_name Data").is_dir())  # No data folder should exist since there are no data exists
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_data_item(self):
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6)))
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+                self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())  # Check the data folder has been renamed
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_large_format_data_item(self):
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6, 5)), large_format=True)
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+                self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())  # Check the data folder has been renamed
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_workspace(self):
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                workspace_controller = document_controller.workspace_controller
+                assert workspace_controller is not None
+
+                display_panel = workspace_controller.display_panels[0]
+                document_controller.selected_display_panel = display_panel
+                document_controller.perform_action("workspace.split_horizontal")
+                old_workspace_layout = copy.deepcopy(document_controller.workspace_controller._workspace_layout)
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+                self.assertEqual(old_workspace_layout, document_controller.workspace_controller._workspace_layout)
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4783,18 +4783,20 @@ class TestStorageClass(unittest.TestCase):
                     document_controller.request_close()
 
     def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_project(self) -> None:
-        with unittest.mock.patch.object(pathlib.Path, 'exists', lambda _self: True):
+        with open("ExistingProject.nsproj", "w"):
             current_working_directory = pathlib.Path.cwd()
             check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
             self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
             self.assertEqual(check_name_result.error_messages, ["Project Name \"ExistingProject.nsproj\" already exists"])
+        os.remove("ExistingProject.nsproj")
 
     def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_data_folder(self) -> None:
-        with unittest.mock.patch.object(pathlib.Path, 'is_dir', lambda _self: True):
-            current_working_directory = pathlib.Path.cwd()
-            check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
-            self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
-            self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
+        os.mkdir("ExistingProject Data")
+        current_working_directory = pathlib.Path.cwd()
+        check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+        self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+        self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
+        os.rmdir("ExistingProject Data")
 
     def test_file_project_storage_system_renames_project_file(self) -> None:
         """Test that the FileProjectStorageSystem rename_project renames the project file.

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -12,6 +12,7 @@ import shutil
 import threading
 import typing
 import unittest
+import unittest.mock
 import uuid
 
 # third party libraries
@@ -4645,27 +4646,28 @@ class TestStorageClass(unittest.TestCase):
         memory_usage = memory_usage_resource() - memory_start
         self.assertTrue(memory_usage < 0.2)
 
-    def test_rename_current_project_with_no_items_works(self) -> None:
+    def test_rename_current_project_with_no_items(self) -> None:
+        """Test the application's rename_project works for the simplest case of no data items.
+
+        This is ProjectStorageSystem independent, testing the project reference is updated and the project is reloaded.
+        """
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
             app = Application.Application(ui, set_global=False)
             app._set_profile_for_test(profile)
-            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            project_reference = profile.project_references[0]
             document_controller = app.open_project_window(project_reference)
             app._set_document_model(document_controller.document_model)
             app.initialize(load_plug_ins=False)
             try:
                 app.rename_project(project_reference, "new_name")
-                project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+                project_reference = profile.project_references[0]
 
                 self.assertIsNotNone(project_reference.project)  # Check the project reopened
                 self.assertEqual("new_name", project_reference.project.title)  # Check the title was updated
                 self.assertEqual("loaded", project_reference.project_state)  # Check the project was reloaded
-                self.assertEqual("new_name", project_reference.project_path.stem)
                 self.assertEqual("new_name", project_reference.path.stem)
-                self.assertTrue((profile_context.projects_dir / "new_name.nsproj").exists())
-                self.assertFalse((profile_context.projects_dir / "new_name Data").is_dir())  # No data folder should exist since there are no data exists
             finally:
                 app._set_profile_for_test(None)
                 app.exit()
@@ -4674,24 +4676,27 @@ class TestStorageClass(unittest.TestCase):
                     document_controller.request_close()
 
     def test_rename_current_project_preserves_data_item(self) -> None:
+        """Test the application's rename_project works with a basic data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
             app = Application.Application(ui, set_global=False)
             app._set_profile_for_test(profile)
-            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            project_reference = profile.project_references[0]
             document_controller = app.open_project_window(project_reference)
             app._set_document_model(document_controller.document_model)
             app.initialize(load_plug_ins=False)
             try:
                 document_model = app.document_model
-                data_item = DataItem.DataItem(numpy.zeros((6, 6)))
+                data_item = DataItem.DataItem(numpy.zeros((6, 6)), large_format=False)
                 document_model.append_data_item(data_item)
                 original_snapshot = data_item.snapshot()
 
                 app.rename_project(project_reference, "new_name")
                 document_controller = app.document_controllers[0]
-                self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())  # Check the data folder has been renamed
 
                 self.assertEqual(1, len(document_controller.document_model.data_items))
                 self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
@@ -4708,12 +4713,16 @@ class TestStorageClass(unittest.TestCase):
                     document_controller.request_close()
 
     def test_rename_current_project_preserves_large_format_data_item(self) -> None:
+        """Test the application's rename_project works with a h5 backed data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
             app = Application.Application(ui, set_global=False)
             app._set_profile_for_test(profile)
-            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            project_reference = profile.project_references[0]
             document_controller = app.open_project_window(project_reference)
             app._set_document_model(document_controller.document_model)
             app.initialize(load_plug_ins=False)
@@ -4725,7 +4734,6 @@ class TestStorageClass(unittest.TestCase):
 
                 app.rename_project(project_reference, "new_name")
                 document_controller = app.document_controllers[0]
-                self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())  # Check the data folder has been renamed
 
                 self.assertEqual(1, len(document_controller.document_model.data_items))
                 self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
@@ -4742,12 +4750,16 @@ class TestStorageClass(unittest.TestCase):
                     document_controller.request_close()
 
     def test_rename_current_project_preserves_workspace(self) -> None:
+        """Test the application's rename_project works with a workspace.
+
+        This is ProjectStorageSystem independent, only testing that the workspace layout was preserved.
+        """
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
             app = Application.Application(ui, set_global=False)
             app._set_profile_for_test(profile)
-            project_reference = typing.cast(Profile.IndexProjectReference, profile.project_references[0])
+            project_reference = profile.project_references[0]
             document_controller = app.open_project_window(project_reference)
             app._set_document_model(document_controller.document_model)
             app.initialize(load_plug_ins=False)
@@ -4769,6 +4781,53 @@ class TestStorageClass(unittest.TestCase):
                 app.deinitialize()
                 if document_controller.count > 0:
                     document_controller.request_close()
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_project(self) -> None:
+        with unittest.mock.patch.object(pathlib.Path, 'exists', lambda _self: True):
+            current_working_directory = pathlib.Path.cwd()
+            check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+            self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+            self.assertEqual(check_name_result.error_messages, ["Project Name \"ExistingProject.nsproj\" already exists"])
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_data_folder(self) -> None:
+        with unittest.mock.patch.object(pathlib.Path, 'is_dir', lambda _self: True):
+            current_working_directory = pathlib.Path.cwd()
+            check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+            self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+            self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
+
+    def test_file_project_storage_system_renames_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the project file.
+
+        This creates the project file manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": []})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name.nsproj").exists())
+
+    def test_file_project_storage_system_renames_data_folder(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder.
+
+        This creates the project file and data folder manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4645,7 +4645,7 @@ class TestStorageClass(unittest.TestCase):
         memory_usage = memory_usage_resource() - memory_start
         self.assertTrue(memory_usage < 0.2)
 
-    def test_rename_current_project_with_no_items_works(self):
+    def test_rename_current_project_with_no_items_works(self) -> None:
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
@@ -4673,7 +4673,7 @@ class TestStorageClass(unittest.TestCase):
                 if document_controller.count > 0:
                     document_controller.request_close()
 
-    def test_rename_current_project_preserves_data_item(self):
+    def test_rename_current_project_preserves_data_item(self) -> None:
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
@@ -4704,10 +4704,10 @@ class TestStorageClass(unittest.TestCase):
                 app._set_profile_for_test(None)
                 app.exit()
                 app.deinitialize()
-                if document_controller.count > 0:
+                if document_controller.count > 0:  # If the test fails the document controller may have not been closed by renaming so close it here
                     document_controller.request_close()
 
-    def test_rename_current_project_preserves_large_format_data_item(self):
+    def test_rename_current_project_preserves_large_format_data_item(self) -> None:
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()
@@ -4741,7 +4741,7 @@ class TestStorageClass(unittest.TestCase):
                 if document_controller.count > 0:
                     document_controller.request_close()
 
-    def test_rename_current_project_preserves_workspace(self):
+    def test_rename_current_project_preserves_workspace(self) -> None:
         with create_temp_profile_context() as profile_context:
             profile = profile_context.create_profile(project_name="Project")
             ui = TestUI.UserInterface()

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4831,6 +4831,23 @@ class TestStorageClass(unittest.TestCase):
             storage_system.rename_project("new_name")
             self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())
 
+    def test_file_project_storage_system_renames_data_folder_in_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder in the project file project_data_folders property."""
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            new_project_path = profile_context.projects_dir / "new_name.nsproj"
+            with new_project_path.open("r") as fp:
+                properties = json.load(fp)
+                self.assertEqual(["new_name Data"], properties["project_data_folders"])
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes #504. Adds the ability to rename the currently open project via the File menu, as well as rename other projects through the Choose Project menu.
When current open project is renamed it is closed, then renamed then opened. 
Similar to the opening of projects, if the user renames a project while computations, acquisitions or other live updates, there will be problems caused.
