### PR TITLE
Drag display panel split moves the content

### DIFF
--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -835,6 +835,8 @@ class Workspace:
                              d: typing.Optional[Persistence.PersistentDictType] = None, new_uuid: typing.Optional[uuid.UUID] = None,
                              new_splits: typing.Optional[typing.List[float]] = None) -> Undo.UndoableCommand:
         assert self.__workspace
+        if self.document_controller.replaced_display_panel_content_flag:
+            self.document_controller.replaced_display_panel_content = {"uuid": display_panel.uuid, "identifier": display_panel.identifier}
         command = ChangeWorkspaceContentsCommand(self, _("Split Display Panel"))
         self._insert_display_panel(display_panel, region, display_item, d, new_uuid, new_splits)
         return command

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -761,28 +761,36 @@ class Workspace:
     def should_handle_drag_for_mime_data(self, mime_data: UserInterface.MimeData) -> bool:
         return mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE) or mime_data.has_format("text/uri-list") or mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE)
 
-    def handle_drop(self, display_panel: DisplayPanel.DisplayPanel, mime_data: UserInterface.MimeData, region: str, x: int, y: int) -> str:
+    def handle_drop(self, destination_display_panel: DisplayPanel.DisplayPanel, mime_data: UserInterface.MimeData, region: str, x: int, y: int) -> str:
+        """Handle dropping a display panel, display item, or external file on a region of a display panel.
+
+        Uses the mime_data to determine the source which can be a display panel, display item or an external file dragged in.
+        The display panel will be split when the region is "left", "right", "top" or "bottom". If the region is "plus" then the display item being dragged is composited.
+        When dragging a display panel the interaction will move the panel contents into the destination, otherwise it will copy the display item into the destination.
+        The replaced_display_panel_content is set on the "move" which will clear the source panel after the drop.
+        Returns "move" on success when dragging a display panel, or "copy" on success when dragging a display item or an external file, or "ignore" if the drop was not handled.
+        """
         document_model = self.document_model
-        if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):
-            display_item, d = MimeTypes.mime_data_get_panel(mime_data, self.document_model)
-            if display_item and display_panel.handle_drop_display_item(region, display_item):
-                pass  # already handled
+        if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):  # Dragging a display panel
+            source_display_item, source_panel_details = MimeTypes.mime_data_get_panel(mime_data, self.document_model)
+            if source_display_item and destination_display_panel.handle_drop_display_item(region, source_display_item):  # See if the display panel handles dragging onto a layer
+                pass  # handle_drop_display_item already successfully handled the drop
             elif region == "right" or region == "left" or region == "top" or region == "bottom":
-                command = self.insert_display_panel(display_panel, region, None, d)
+                command = self.insert_display_panel(destination_display_panel, region, None, source_panel_details)
                 self.document_controller.push_undo_command(command)
             else:
-                command = self.__replace_displayed_display_item(display_panel, None, d)
+                command = self.__replace_displayed_display_item(destination_display_panel, None, source_panel_details)
                 self.document_controller.push_undo_command(command)
             return "move"
-        display_item = MimeTypes.mime_data_get_display_item(mime_data, document_model)
-        if display_item:
-            if display_panel.handle_drop_display_item(region, display_item):
+        source_display_item = MimeTypes.mime_data_get_display_item(mime_data, document_model)
+        if source_display_item:  # Dragging a display item
+            if destination_display_panel.handle_drop_display_item(region, source_display_item):
                 pass  # already handled
             elif region == "right" or region == "left" or region == "top" or region == "bottom":
-                command = self.insert_display_panel(display_panel, region, display_item)
+                command = self.insert_display_panel(destination_display_panel, region, source_display_item)
                 self.document_controller.push_undo_command(command)
             else:
-                command = self.__replace_displayed_display_item(display_panel, display_item)
+                command = self.__replace_displayed_display_item(destination_display_panel, source_display_item)
                 self.document_controller.push_undo_command(command)
             return "copy"
         if mime_data.has_format("text/uri-list"):
@@ -791,10 +799,10 @@ class Workspace:
             display_item = display_items[0] if len(display_items) > 0 else None
             if display_item:
                 if region == "right" or region == "left" or region == "top" or region == "bottom":
-                    command = self.insert_display_panel(display_panel, region, display_item)
+                    command = self.insert_display_panel(destination_display_panel, region, display_item)
                     self.document_controller.push_undo_command(command)
                 else:
-                    command = self.__replace_displayed_display_item(display_panel, display_item)
+                    command = self.__replace_displayed_display_item(destination_display_panel, display_item)
                     self.document_controller.push_undo_command(command)
             return "copy"
         return "ignore"

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1283,6 +1283,28 @@ class TestWorkspaceClass(unittest.TestCase):
             self.assertEqual(document_controller.workspace_controller.display_panels[0].display_item.data_item, data_item2)
             self.assertEqual(document_controller.workspace_controller.display_panels[1].display_item.data_item, data_item1)
 
+    def test_dragging_header_to_split_self_works(self):
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
+            root_canvas_item.layout_immediate(Geometry.IntSize(width=640, height=480))
+            data_item = DataItem.DataItem(numpy.zeros((256), numpy.double))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            document_controller.workspace_controller.display_panels[0].set_display_item(display_item)
+            display_panel = document_controller.workspace_controller.display_panels[0]
+            # Simulate dragging the panel into the right split of the same panel. This should cause a split and the item should only be in the right panel.
+            mime_data = self._test_setup.app.ui.create_mime_data()
+            MimeTypes.mime_data_put_display_item(mime_data, display_item)
+            MimeTypes.mime_data_put_panel(mime_data, display_item, display_panel.save_contents())
+            document_controller.replaced_display_panel_content_flag = True  # This would be set by the drag command
+            action = document_controller.workspace_controller.handle_drop(document_controller.workspace_controller.display_panels[0], mime_data, "right", 160, 240)
+            self.assertEqual(action, "move")  # Ensure the returned action was a move
+            document_controller.workspace_controller.display_panels[0]._drag_finished(document_controller, action)
+            self.assertIsNone(document_controller.workspace_controller.display_panels[0].display_item)  # Ensure the item was removed from the original panel
+            self.assertEqual(document_controller.workspace_controller.display_panels[1].display_item, display_item)  # Ensure the item was moved to the new panel
+
     def test_display_panel_selection_updates_properly_with_data_panel_filter(self):
         # this tests a failure where 2nd processing action would replace the source display item with something else.
         with TestContext.create_memory_context() as test_context:


### PR DESCRIPTION
Fixes #1797. 
Dragging a display panel over a split region now moves the display panels content to the newly created split rather than duplicating the content in both. 
The first commit improves the readability of the code in charge of the dropping handle_drop, which was initially modified although now the changes happen outside that function.