### PR TITLE
Delay computation writes when inputs are write delayed.

### DIFF
--- a/nion/swift/model/DocumentModel.py
+++ b/nion/swift/model/DocumentModel.py
@@ -167,6 +167,8 @@ class TransactionManager:
                 items.add(item)
                 for dependent in self.__document_model.get_dependent_items(item):
                     self.__get_deep_transaction_item_set(dependent, items)
+                for computation in self.__document_model.get_dependent_computations(item):
+                    self.__get_deep_transaction_item_set(computation, items)
             if isinstance(item, DisplayItem.DisplayItem):
                 for display_data_channel in item.display_data_channels:
                     self.__get_deep_transaction_item_set(display_data_channel, items)
@@ -620,6 +622,7 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         self.__dependency_tree_lock = threading.RLock()
         self.__dependency_tree_source_to_target_map: typing.Dict[typing.Any, typing.List[Persistence.PersistentObject]] = dict()
         self.__dependency_tree_target_to_source_map: typing.Dict[typing.Any, typing.List[Persistence.PersistentObject]] = dict()
+        self.__input_to_computation_map = dict[typing.Any, list[Symbolic.Computation]]()
         self.__computation_changed_listeners: typing.Dict[Symbolic.Computation, Event.EventListener] = dict()
         self.__computation_output_changed_listeners: typing.Dict[Symbolic.Computation, Event.EventListener] = dict()
         self.__computation_changed_delay_list: typing.Optional[typing.List[Symbolic.Computation]] = None
@@ -1420,6 +1423,13 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
             for input in removed_inputs:
                 for output in old_outputs:
                     self.__remove_dependency(input, output)
+                # remove mapping from input to computation
+                input_ref = weakref.ref(input)
+                target_computations = self.__input_to_computation_map.setdefault(input_ref, list())
+                if computation in target_computations:
+                    target_computations.remove(computation)
+                if not target_computations:
+                    self.__input_to_computation_map.pop(input_ref, None)
             for output in removed_outputs:
                 for input in old_inputs:
                     self.__remove_dependency(input, output)
@@ -1428,6 +1438,11 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
             for input in added_inputs:
                 for output in new_outputs:
                     self.__add_dependency(input, output)
+                # add mapping from input to computation
+                input_ref = weakref.ref(input)
+                target_computations = self.__input_to_computation_map.setdefault(input_ref, list())
+                if computation not in target_computations:
+                    target_computations.append(computation)
             for output in added_outputs:
                 for input in same_inputs:
                     self.__add_dependency(input, output)
@@ -1446,6 +1461,10 @@ class DocumentModel(Observable.Observable, ReferenceCounting.ReferenceCounted, D
         """Return the list of data items containing data that directly depends on data in this item."""
         with self.__dependency_tree_lock:
             return copy.copy(self.__dependency_tree_source_to_target_map.get(weakref.ref(item), list()))
+
+    def get_dependent_computations(self, item: Persistence.PersistentObject) -> typing.List[Symbolic.Computation]:
+        with self.__dependency_tree_lock:
+            return copy.copy(self.__input_to_computation_map.get(weakref.ref(item), list()))
 
     def __get_deep_dependent_item_set(self, item: Persistence.PersistentObject, item_set: typing.Set[Persistence.PersistentObject]) -> None:
         """Return the list of data items containing data that directly depends on data in this item."""

--- a/nion/swift/model/Symbolic.py
+++ b/nion/swift/model/Symbolic.py
@@ -2049,6 +2049,8 @@ class Computation(Persistence.PersistentObject):
         self.__result_base_item_removed_event_listeners: typing.List[Event.EventListener] = list()
         self.__processor: typing.Optional[ComputationProcessor] = None
         self.last_evaluate_data_time = 0.0
+        self.__in_transaction_state = False
+        self.__write_delay_modified_count = 0
         self.__recompute_enabled = True  # used for disabling recompute machinery while close document
         self.__needs_update = True
         self.computation_mutated_event = Event.Event()
@@ -2099,6 +2101,39 @@ class Computation(Persistence.PersistentObject):
         # for soft delete and flags it to stop.
         self.is_deleted = True
         self.stop()
+
+    @property
+    def in_transaction_state(self) -> bool:
+        return self.__in_transaction_state
+
+    def __enter_write_delay_state(self) -> None:
+        self.__write_delay_modified_count = self.modified_count
+        if self.persistent_object_context:
+            self.enter_write_delay()
+
+    def __exit_write_delay_state(self) -> None:
+        if self.persistent_object_context:
+            self.exit_write_delay()
+            if self.modified_count > self.__write_delay_modified_count:
+                self.rewrite()
+
+    def _transaction_state_entered(self) -> None:
+        self.__in_transaction_state = True
+        # first enter the write delay state.
+        self.__enter_write_delay_state()
+
+    def _transaction_state_exited(self) -> None:
+        self.__in_transaction_state = False
+        # exit the write delay state.
+        self.__exit_write_delay_state()
+
+    def persistent_object_context_changed(self) -> None:
+        # handle case where persistent object context is set on an item that is already under transaction.
+        # this can occur during acquisition. any other cases?
+        super().persistent_object_context_changed()
+
+        if self.__in_transaction_state:
+            self.__enter_write_delay_state()
 
     @property
     def variables(self) -> typing.Sequence[ComputationVariable]:

--- a/nion/swift/test/DocumentModel_test.py
+++ b/nion/swift/test/DocumentModel_test.py
@@ -2512,6 +2512,46 @@ class TestDocumentModelClass(unittest.TestCase):
             # trigger the connection
             display_item.display_data_channel.collection_index = (1, 0)
 
+    def test_transaction_extends_to_computations(self):
+        with TestContext.create_memory_context() as test_context:
+            # create two data items with computations; and then another computation from the first computed item.
+            document_model = test_context.create_document_model()
+            data_item1 = DataItem.DataItem(numpy.zeros((100, )))
+            document_model.append_data_item(data_item1)
+            display_item1 = document_model.get_display_item_for_data_item(data_item1)
+            data_item2 = DataItem.DataItem(numpy.zeros((100, )))
+            document_model.append_data_item(data_item2)
+            display_item2 = document_model.get_display_item_for_data_item(data_item2)
+            computed_data_item1 = document_model.get_invert_new(display_item1, display_item1.data_item)
+            computed_data_item2 = document_model.get_invert_new(display_item2, display_item2.data_item)
+            computed_display_item1 = document_model.get_display_item_for_data_item(computed_data_item1)
+            computed_data_item11 = document_model.get_invert_new(computed_display_item1, computed_display_item1.data_item)
+            # check assumptions
+            self.assertFalse(document_model.computations[0].in_transaction_state)
+            self.assertFalse(document_model.computations[1].in_transaction_state)
+            self.assertFalse(document_model.computations[2].in_transaction_state)
+            # check transaction state
+            with document_model.item_transaction(data_item1):
+                self.assertTrue(document_model.computations[0].in_transaction_state)
+                self.assertFalse(document_model.computations[1].in_transaction_state)
+                self.assertTrue(document_model.computations[2].in_transaction_state)
+            # check return to normal
+            self.assertFalse(document_model.computations[0].in_transaction_state)
+            self.assertFalse(document_model.computations[1].in_transaction_state)
+            self.assertFalse(document_model.computations[2].in_transaction_state)
+            self.assertEqual(0, document_model.transaction_count)
+
+    def test_computation_added_to_data_item_in_transaction(self):
+        with TestContext.create_memory_context() as test_context:
+            document_model = test_context.create_document_model()
+            data_item1 = DataItem.DataItem(numpy.zeros((100, )))
+            document_model.append_data_item(data_item1)
+            display_item1 = document_model.get_display_item_for_data_item(data_item1)
+            with document_model.item_transaction(data_item1):
+                computed_data_item1 = document_model.get_invert_new(display_item1, display_item1.data_item)
+                self.assertTrue(document_model.computations[0].in_transaction_state)
+            self.assertFalse(document_model.computations[0].in_transaction_state)
+
     # solve problem of where to create new elements (same library), generally shouldn't create data items for now?
     # way to configure display for new data items?
     # splitting complex and reconstructing complex does so efficiently (i.e. one recompute for each change at each step)


### PR DESCRIPTION
Fixes #1881

Delay computation writes when inputs are write delayed.

Implements 'transaction state' for computations, which is enabled when
one of their inputs goes into transaction state. This state prevents
writing of the computation and avoids writing to disk when 'needs
recompute' (or any other property) changes during live acquisition.

This was probably a regression when 'needs recompute' was made
persistent.
