### PR TITLE
Text background color and visibility properties

### DIFF
--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -659,16 +659,16 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
                     drawing_context.font = self.font
-                    if region.middle_text and region.style != "tag" and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("width"), region_selected):
-                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.get_text_background_color_fn("width") or self.text_background_color)
+                    if region.middle_text and region.style != "tag" and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("width_text"), region_selected):
+                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.get_text_background_color_fn("width_text") or self.text_background_color)
                     drawing_context.fill_style = region_color
-                    if region.left_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("left"), region_selected):
-                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.get_text_background_color_fn("left") or self.text_background_color)
-                    if region.right_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("right"), region_selected):
-                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.get_text_background_color_fn("right") or self.text_background_color)
+                    if region.left_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("left_text"), region_selected):
+                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.get_text_background_color_fn("left_text") or self.text_background_color)
+                    if region.right_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("right_text"), region_selected):
+                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.get_text_background_color_fn("right_text") or self.text_background_color)
                     label = region.label
-                    if label and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("label"), region_selected):
-                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.get_text_background_color_fn("label") or self.text_background_color)
+                    if label and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("label_text"), region_selected):
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.get_text_background_color_fn("label_text") or self.text_background_color)
                     drawing_context.close_path()
 
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -659,16 +659,16 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
                     drawing_context.font = self.font
-                    if region.middle_text and region.style != "tag" and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("width_text"), region_selected):
-                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.get_text_background_color_fn("width_text") or self.text_background_color)
+                    if region.middle_text and region.style != "tag" and Graphics.GraphicRenderer.is_label_visible(Graphics.Graphic.resolve_used_property(region.used_text_visibility_map, "width_text"), region_selected):
+                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", Graphics.Graphic.resolve_used_property(region.used_text_background_color_map, "width_text") or self.text_background_color)
                     drawing_context.fill_style = region_color
-                    if region.left_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("left_text"), region_selected):
-                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.get_text_background_color_fn("left_text") or self.text_background_color)
-                    if region.right_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("right_text"), region_selected):
-                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.get_text_background_color_fn("right_text") or self.text_background_color)
+                    if region.left_text and Graphics.GraphicRenderer.is_label_visible(Graphics.Graphic.resolve_used_property(region.used_text_visibility_map, "left_text"), region_selected):
+                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", Graphics.Graphic.resolve_used_property(region.used_text_background_color_map, "left_text") or self.text_background_color)
+                    if region.right_text and Graphics.GraphicRenderer.is_label_visible(Graphics.Graphic.resolve_used_property(region.used_text_visibility_map, "right_text"), region_selected):
+                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", Graphics.Graphic.resolve_used_property(region.used_text_background_color_map, "right_text") or self.text_background_color)
                     label = region.label
-                    if label and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("label_text"), region_selected):
-                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.get_text_background_color_fn("label_text") or self.text_background_color)
+                    if label and Graphics.GraphicRenderer.is_label_visible(Graphics.Graphic.resolve_used_property(region.used_text_visibility_map, "label_text"), region_selected):
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", Graphics.Graphic.resolve_used_property(region.used_text_background_color_map, "label_text") or self.text_background_color)
                     drawing_context.close_path()
 
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -29,6 +29,7 @@ from nion.swift import MimeTypes
 from nion.swift import Undo
 from nion.swift.model import DisplayItem
 from nion.swift.model import DocumentModel
+from nion.swift.model import Graphics
 from nion.swift.model import LinePlotDisplay
 from nion.swift.model import UISettings
 from nion.swift.model import Utility
@@ -595,11 +596,11 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
                 return Geometry.FloatRect.from_tlhw(rect_top, rect_left, height, width)
 
-            def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str) -> None:
+            def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str, background_color: str) -> None:
                 with drawing_context.saver():
                     drawing_context.text_baseline = text_baseline
                     drawing_context.text_align = text_align
-                    drawing_context.fill_style = self.text_background_color
+                    drawing_context.fill_style = background_color
                     label_rect = _get_text_rectangle(label_text, label_x, label_y, text_baseline, text_align)
 
                     # Draw the text background
@@ -653,25 +654,22 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.close_path()  # A new path is needed for the label to have a transparency in the background
                     drawing_context.line_dash = 0
                     drawing_context.begin_path()
+                    labels_visible = Graphics.GraphicRenderer.is_label_visible(region.text_visibility, region_selected, self.__is_focused)
                     if region_selected:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), fill=selection_color, stroke=selection_color)
-                        drawing_context.font = self.font
-                        left_text = region.left_text
-                        right_text = region.right_text
-                        middle_text = region.middle_text
-                        if middle_text and region.style != "tag":
-                            _draw_label_with_background(middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom")
-                        drawing_context.fill_style = region_color
-                        if left_text:
-                            _draw_label_with_background(left_text, left - 5, level, "right", "middle")
-                        if right_text:
-                            _draw_label_with_background(right_text, right + 5, level, "left", "middle")
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
-
+                    drawing_context.font = self.font
+                    if region.middle_text and region.style != "tag" and labels_visible:
+                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.background_color or self.text_background_color)
+                    drawing_context.fill_style = region_color
+                    if region.left_text and labels_visible:
+                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.background_color or self.text_background_color)
+                    if region.right_text and labels_visible:
+                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.background_color or self.text_background_color)
                     label = region.label
-                    if label:
-                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top")
+                    if label and labels_visible:
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.background_color or self.text_background_color)
                     drawing_context.close_path()
 
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -654,22 +654,21 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.close_path()  # A new path is needed for the label to have a transparency in the background
                     drawing_context.line_dash = 0
                     drawing_context.begin_path()
-                    labels_visible = Graphics.GraphicRenderer.is_label_visible(region.text_visibility, region_selected, self.__is_focused)
                     if region_selected:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), fill=selection_color, stroke=selection_color)
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
                     drawing_context.font = self.font
-                    if region.middle_text and region.style != "tag" and labels_visible:
-                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.background_color or self.text_background_color)
+                    if region.middle_text and region.style != "tag" and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("width"), region_selected):
+                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", region.get_text_background_color_fn("width") or self.text_background_color)
                     drawing_context.fill_style = region_color
-                    if region.left_text and labels_visible:
-                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.background_color or self.text_background_color)
-                    if region.right_text and labels_visible:
-                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.background_color or self.text_background_color)
+                    if region.left_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("left"), region_selected):
+                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", region.get_text_background_color_fn("left") or self.text_background_color)
+                    if region.right_text and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("right"), region_selected):
+                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", region.get_text_background_color_fn("right") or self.text_background_color)
                     label = region.label
-                    if label and labels_visible:
-                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.background_color or self.text_background_color)
+                    if label and Graphics.GraphicRenderer.is_label_visible(region.get_text_visibility_fn("label"), region_selected):
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", region.get_text_background_color_fn("label") or self.text_background_color)
                     drawing_context.close_path()
 
 

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -927,11 +927,19 @@ class Graphic(Persistence.PersistentObject):
     def used_stroke_width(self) -> float:
         return self.stroke_width if self.stroke_width is not None else 1.0
 
-    def used_text_visibility(self, part: str) -> str:
-        return "always"
+    @property
+    def used_text_visibility_map(self) -> dict[str, str]:
+        return {"default": "always"}
 
-    def used_text_background_color(self, part: str) -> str:
-        return "rgba(255, 255, 255, 0.6)"
+    @property
+    def used_text_background_color_map(self) -> dict[str, str]:
+        return {"default": "rgba(255, 255, 255, 0.6)"}
+
+    @staticmethod
+    def resolve_used_property(prop: dict[str, str], part: str) -> str:
+        if part not in prop:
+            return prop["default"]
+        return prop[part]
 
     @property
     def color(self) -> typing.Optional[str]:
@@ -1037,8 +1045,8 @@ class GraphicRenderer:
         self.is_position_locked = graphic.is_position_locked
         self.is_shape_locked = graphic.is_shape_locked
         self.is_rotation_locked = graphic.is_rotation_locked
-        self.used_text_visibility_fn = graphic.used_text_visibility
-        self.used_text_background_color_fn = graphic.used_text_background_color
+        self.used_text_visibility_map = graphic.used_text_visibility_map
+        self.used_text_background_color_map = graphic.used_text_background_color_map
 
     def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
         raise NotImplementedError()
@@ -1060,7 +1068,7 @@ class GraphicRenderer:
 
     def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool) -> None:
         label = self.label
-        if label and self.is_label_visible(self.used_text_visibility_fn("label_text"), is_selected):
+        if label and self.is_label_visible(Graphic.resolve_used_property(self.used_text_visibility_map, "label_text"), is_selected):
             padding = self.label_padding
             font = self.label_font
             font_metrics = ui_settings.get_font_metrics(font, label)
@@ -1077,7 +1085,7 @@ class GraphicRenderer:
                     ctx.line_to(text_pos.x - font_metrics.width * 0.5 - padding,
                                 text_pos.y + font_metrics.height * 0.5 + padding)
                     ctx.close_path()
-                    ctx.fill_style = self.used_text_background_color_fn("label_text")
+                    ctx.fill_style = Graphic.resolve_used_property(self.used_text_background_color_map, "label_text")
                     ctx.fill()
                     ctx.stroke_style = self.used_stroke_style
                     ctx.stroke()
@@ -2090,19 +2098,29 @@ class IntervalGraphic(Graphic):
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
         self._default_drag_part = "end"
 
-    def used_text_background_color(self, part: str) -> str:
-        if self.used_role == "measurement" and part == "width_text":
-            return "white"
+    @property
+    def used_text_background_color_map(self) -> dict[str, str]:
+        """Get the background color property dictionary.
+        
+        For intervals the default text background is slight transparent white.
+        For width text when the interval is a measurement where it should be white.
+        """
+        if self.used_role == "measurement":
+            return {"default": "#99ffffff", "width_text": "white"}
         else:
-            return "#99ffffff"
+            return {"default": "#99ffffff"}
 
-    def used_text_visibility(self, part: str) -> str:
-        if part == "label":
-            return "always"
-        if self.used_role == "measurement" and part == "width_text":
-            return "always"
+    @property
+    def used_text_visibility_map(self) -> dict[str, str]:
+        """Get the background color property dictionary.
+
+        For intervals the default text visibility is always.
+        When the interval is a measurement the width text should always show but the others should only show when the interval is selected.
+        """
+        if self.used_role == "measurement":
+            return {"default": "selection", "width_text": "always"}
         else:
-            return "selection"
+            return {"default": "always"}
 
     @property
     def interval(self) -> typing.Tuple[float, float]:

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -718,8 +718,6 @@ class Graphic(Persistence.PersistentObject):
         self.define_property("is_rotation_locked", False, changed=self._property_changed, validate=to_bool, hidden=True)
         self.define_property("is_bounds_constrained", False, changed=self._property_changed, validate=to_bool, hidden=True)
         self.define_property("role", None, changed=self._property_changed, validate=to_str, hidden=True)
-        self.define_property("text_visibility", "always", changed=self._property_changed, validate=to_str, hidden=True)
-        self.define_property("text_background_color", "#00000000", changed=self._property_changed, validate=to_str, hidden=True)  # Default to transparent
         self.label_padding = 4
         self.label_font = "normal 11px serif"
         self.__source_reference = self.create_item_reference()
@@ -930,10 +928,10 @@ class Graphic(Persistence.PersistentObject):
         return self.stroke_width if self.stroke_width is not None else 1.0
 
     def used_text_visibility(self, part: str) -> str:
-        return self.text_visibility if self.text_visibility is not None else "always"
+        return "always"
 
     def used_text_background_color(self, part: str) -> str:
-        return self.text_background_color if self.text_background_color is not None else "rgba(255, 255, 255, 0.6)"
+        return "rgba(255, 255, 255, 0.6)"
 
     @property
     def color(self) -> typing.Optional[str]:
@@ -942,22 +940,6 @@ class Graphic(Persistence.PersistentObject):
     @color.setter
     def color(self, value: typing.Optional[str]) -> None:
         self.stroke_color = value
-
-    @property
-    def text_background_color(self) -> str | None:
-        return typing.cast(str, self._get_persistent_property_value("text_background_color"))
-
-    @text_background_color.setter
-    def text_background_color(self, value: str | None) -> None:
-        self._set_persistent_property_value("text_background_color", value)
-
-    @property
-    def text_visibility(self) -> str | None:
-        return typing.cast(str, self._get_persistent_property_value("text_visibility"))
-
-    @text_visibility.setter
-    def text_visibility(self, value: str | None) -> None:
-        self._set_persistent_property_value("text_visibility", value)
 
     @property
     def _constraints(self) -> typing.Set[str]:
@@ -1078,7 +1060,7 @@ class GraphicRenderer:
 
     def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool) -> None:
         label = self.label
-        if label and self.is_label_visible(self.used_text_visibility_fn("label"), is_selected):
+        if label and self.is_label_visible(self.used_text_visibility_fn("label_text"), is_selected):
             padding = self.label_padding
             font = self.label_font
             font_metrics = ui_settings.get_font_metrics(font, label)
@@ -1095,7 +1077,7 @@ class GraphicRenderer:
                     ctx.line_to(text_pos.x - font_metrics.width * 0.5 - padding,
                                 text_pos.y + font_metrics.height * 0.5 + padding)
                     ctx.close_path()
-                    ctx.fill_style = self.used_text_background_color_fn("label")
+                    ctx.fill_style = self.used_text_background_color_fn("label_text")
                     ctx.fill()
                     ctx.stroke_style = self.used_stroke_style
                     ctx.stroke()
@@ -2107,23 +2089,17 @@ class IntervalGraphic(Graphic):
         # interval is stored in image normalized coordinates
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
         self._default_drag_part = "end"
-        self.text_visibility = None
-        self.text_background_color = None
 
     def used_text_background_color(self, part: str) -> str:
-        if self.text_background_color:
-            return self.text_background_color
-        if self.used_role == "measurement" and part == "width":
+        if self.used_role == "measurement" and part == "width_text":
             return "white"
         else:
             return "#99ffffff"
 
     def used_text_visibility(self, part: str) -> str:
-        if self.text_visibility:
-            return self.text_visibility
         if part == "label":
             return "always"
-        if self.used_role == "measurement" and part == "width":
+        if self.used_role == "measurement" and part == "width_text":
             return "always"
         else:
             return "selection"

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -821,8 +821,6 @@ class Graphic(Persistence.PersistentObject):
         self._set_persistent_property_value("role", value)
         self.notify_property_changed("used_stroke_style")
         self.notify_property_changed("used_fill_style")
-        self.notify_property_changed("used_text_visibility")
-        self.notify_property_changed("used_text_background_color")
 
     @property
     def project(self) -> typing.Optional[Project.Project]:

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -823,6 +823,8 @@ class Graphic(Persistence.PersistentObject):
         self._set_persistent_property_value("role", value)
         self.notify_property_changed("used_stroke_style")
         self.notify_property_changed("used_fill_style")
+        self.notify_property_changed("used_text_visibility")
+        self.notify_property_changed("used_text_background_color")
 
     @property
     def project(self) -> typing.Optional[Project.Project]:
@@ -927,6 +929,12 @@ class Graphic(Persistence.PersistentObject):
     def used_stroke_width(self) -> float:
         return self.stroke_width if self.stroke_width is not None else 1.0
 
+    def used_text_visibility(self, part: str) -> str:
+        return self.text_visibility if self.text_visibility is not None else "always"
+
+    def used_text_background_color(self, part: str) -> str:
+        return self.text_background_color if self.text_background_color is not None else "rgba(255, 255, 255, 0.6)"
+
     @property
     def color(self) -> typing.Optional[str]:
         return self.used_stroke_style
@@ -936,19 +944,19 @@ class Graphic(Persistence.PersistentObject):
         self.stroke_color = value
 
     @property
-    def text_background_color(self) -> str:
+    def text_background_color(self) -> str | None:
         return typing.cast(str, self._get_persistent_property_value("text_background_color"))
 
     @text_background_color.setter
-    def text_background_color(self, value: str) -> None:
+    def text_background_color(self, value: str | None) -> None:
         self._set_persistent_property_value("text_background_color", value)
 
     @property
-    def text_visibility(self) -> str:
+    def text_visibility(self) -> str | None:
         return typing.cast(str, self._get_persistent_property_value("text_visibility"))
 
     @text_visibility.setter
-    def text_visibility(self, value: str) -> None:
+    def text_visibility(self, value: str | None) -> None:
         self._set_persistent_property_value("text_visibility", value)
 
     @property
@@ -1047,8 +1055,8 @@ class GraphicRenderer:
         self.is_position_locked = graphic.is_position_locked
         self.is_shape_locked = graphic.is_shape_locked
         self.is_rotation_locked = graphic.is_rotation_locked
-        self.text_visibility = graphic.text_visibility
-        self.text_background_color = graphic.text_background_color
+        self.used_text_visibility_fn = graphic.used_text_visibility
+        self.used_text_background_color_fn = graphic.used_text_background_color
 
     def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
         raise NotImplementedError()
@@ -1056,19 +1064,21 @@ class GraphicRenderer:
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         return None
 
-    @classmethod
-    def is_label_visible(cls, text_visibility: str, is_selected: bool, is_focused: bool) -> bool:
+    @staticmethod
+    def is_label_visible(text_visibility: str | None, is_selected: bool) -> bool:
+        """Return whether the label is visible based on the text visibility setting and if it is selected.
+
+        If the visibility is always then return true, if it is selection return the value of is_selected, otherwise return false.
+        """
         if text_visibility == "always":
             return True
         elif text_visibility == "selection":
             return is_selected
-        elif text_visibility == "focus":
-            return is_focused
         return False
 
-    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool) -> None:
         label = self.label
-        if label and self.is_label_visible(self.text_visibility, is_selected, is_focused):
+        if label and self.is_label_visible(self.used_text_visibility_fn("label"), is_selected):
             padding = self.label_padding
             font = self.label_font
             font_metrics = ui_settings.get_font_metrics(font, label)
@@ -1085,7 +1095,7 @@ class GraphicRenderer:
                     ctx.line_to(text_pos.x - font_metrics.width * 0.5 - padding,
                                 text_pos.y + font_metrics.height * 0.5 + padding)
                     ctx.close_path()
-                    ctx.fill_style = "rgba(255, 255, 255, 0.6)"
+                    ctx.fill_style = self.used_text_background_color_fn("label")
                     ctx.fill()
                     ctx.stroke_style = self.used_stroke_style
                     ctx.stroke()
@@ -1390,7 +1400,7 @@ class RectangleGraphicRenderer(RectangleTypeGraphicRenderer):
                 ctx.stroke_style = used_stroke_style
                 ctx.stroke()
                 draw_circular_marker(ctx, rotation_point, is_focused, is_rotation_locked)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = Geometry.FloatRect.make(self.bounds)
@@ -1442,7 +1452,7 @@ class EllipseGraphicRenderer(RectangleTypeGraphicRenderer):
         center = mapping.map_point_image_norm_to_widget(bounds.center)
         size = mapping.map_size_image_norm_to_widget(bounds.size)
         draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style,  used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = self.bounds
@@ -1797,7 +1807,7 @@ class LineGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
 
 class LineProfileGraphic(LineTypeGraphic):
@@ -1910,7 +1920,7 @@ class LineProfileGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
 
 class PointTypeGraphic(Graphic):
@@ -2056,7 +2066,7 @@ class PointGraphicRenderer(PointTypeGraphicRenderer):
             ctx.stroke_style = used_stroke_style
             ctx.stroke_style = self.used_stroke_style
             ctx.stroke()
-            self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+            self.draw_label(ctx, ui_settings, mapping, is_selected)
         if is_selected:
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, cross_hair_size), is_focused, False)
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, -cross_hair_size), is_focused, False)
@@ -2097,8 +2107,26 @@ class IntervalGraphic(Graphic):
         # interval is stored in image normalized coordinates
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
         self._default_drag_part = "end"
-        self.text_visibility = "selection"
-        self.text_background_color = "#99ffffff"
+        self.text_visibility = None
+        self.text_background_color = None
+
+    def used_text_background_color(self, part: str) -> str:
+        if self.text_background_color:
+            return self.text_background_color
+        if self.used_role == "measurement" and part == "width":
+            return "white"
+        else:
+            return "#99ffffff"
+
+    def used_text_visibility(self, part: str) -> str:
+        if self.text_visibility:
+            return self.text_visibility
+        if part == "label":
+            return "always"
+        if self.used_role == "measurement" and part == "width":
+            return "always"
+        else:
+            return "selection"
 
     @property
     def interval(self) -> typing.Tuple[float, float]:
@@ -2528,7 +2556,7 @@ class SpotGraphicRenderer(GraphicRenderer):
             ctx.rotate(math.pi)
             ctx.translate(-origin.x, -origin.y)
             draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style, used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         center_widget = mapping.calibrated_origin_widget
@@ -2769,7 +2797,7 @@ class WedgeGraphicRenderer(GraphicRenderer):
 
         if is_selected:
             draw_marker(ctx, center, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -3008,7 +3036,7 @@ class RingGraphicRenderer(GraphicRenderer):
                         ctx.line_to(x, y)
                 ctx.close_path()
                 ctx.fill()
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -3326,7 +3354,7 @@ class LatticeGraphicRenderer(GraphicRenderer):
             draw_marker(ctx, v_pos_widget, is_focused, is_position_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(u_pos_widget, size_widget), is_focused, is_shape_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(v_pos_widget, size_widget), is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
+        self.draw_label(ctx, ui_settings, mapping, is_selected)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -718,6 +718,8 @@ class Graphic(Persistence.PersistentObject):
         self.define_property("is_rotation_locked", False, changed=self._property_changed, validate=to_bool, hidden=True)
         self.define_property("is_bounds_constrained", False, changed=self._property_changed, validate=to_bool, hidden=True)
         self.define_property("role", None, changed=self._property_changed, validate=to_str, hidden=True)
+        self.define_property("text_visibility", "always", changed=self._property_changed, validate=to_str, hidden=True)
+        self.define_property("text_background_color", "#00000000", changed=self._property_changed, validate=to_str, hidden=True)  # Default to transparent
         self.label_padding = 4
         self.label_font = "normal 11px serif"
         self.__source_reference = self.create_item_reference()
@@ -934,6 +936,22 @@ class Graphic(Persistence.PersistentObject):
         self.stroke_color = value
 
     @property
+    def text_background_color(self) -> str:
+        return typing.cast(str, self._get_persistent_property_value("text_background_color"))
+
+    @text_background_color.setter
+    def text_background_color(self, value: str) -> None:
+        self._set_persistent_property_value("text_background_color", value)
+
+    @property
+    def text_visibility(self) -> str:
+        return typing.cast(str, self._get_persistent_property_value("text_visibility"))
+
+    @text_visibility.setter
+    def text_visibility(self, value: str) -> None:
+        self._set_persistent_property_value("text_visibility", value)
+
+    @property
     def _constraints(self) -> typing.Set[str]:
         constraints: typing.Set[str] = set()
         if self.is_position_locked:
@@ -1029,6 +1047,8 @@ class GraphicRenderer:
         self.is_position_locked = graphic.is_position_locked
         self.is_shape_locked = graphic.is_shape_locked
         self.is_rotation_locked = graphic.is_rotation_locked
+        self.text_visibility = graphic.text_visibility
+        self.text_background_color = graphic.text_background_color
 
     def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
         raise NotImplementedError()
@@ -1036,9 +1056,19 @@ class GraphicRenderer:
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         return None
 
-    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike) -> None:
+    @classmethod
+    def is_label_visible(cls, text_visibility: str, is_selected: bool, is_focused: bool) -> bool:
+        if text_visibility == "always":
+            return True
+        elif text_visibility == "selection":
+            return is_selected
+        elif text_visibility == "focus":
+            return is_focused
+        return False
+
+    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
         label = self.label
-        if label:
+        if label and self.is_label_visible(self.text_visibility, is_selected, is_focused):
             padding = self.label_padding
             font = self.label_font
             font_metrics = ui_settings.get_font_metrics(font, label)
@@ -1360,7 +1390,7 @@ class RectangleGraphicRenderer(RectangleTypeGraphicRenderer):
                 ctx.stroke_style = used_stroke_style
                 ctx.stroke()
                 draw_circular_marker(ctx, rotation_point, is_focused, is_rotation_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = Geometry.FloatRect.make(self.bounds)
@@ -1412,7 +1442,7 @@ class EllipseGraphicRenderer(RectangleTypeGraphicRenderer):
         center = mapping.map_point_image_norm_to_widget(bounds.center)
         size = mapping.map_size_image_norm_to_widget(bounds.size)
         draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style,  used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = self.bounds
@@ -1767,7 +1797,7 @@ class LineGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
 
 class LineProfileGraphic(LineTypeGraphic):
@@ -1880,7 +1910,7 @@ class LineProfileGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
 
 class PointTypeGraphic(Graphic):
@@ -2026,7 +2056,7 @@ class PointGraphicRenderer(PointTypeGraphicRenderer):
             ctx.stroke_style = used_stroke_style
             ctx.stroke_style = self.used_stroke_style
             ctx.stroke()
-            self.draw_label(ctx, ui_settings, mapping)
+            self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
         if is_selected:
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, cross_hair_size), is_focused, False)
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, -cross_hair_size), is_focused, False)
@@ -2067,6 +2097,8 @@ class IntervalGraphic(Graphic):
         # interval is stored in image normalized coordinates
         self.define_property("interval", (0.0, 1.0), changed=self.__interval_changed, reader=read_interval, writer=write_interval, validate=validate_interval, hidden=True)
         self._default_drag_part = "end"
+        self.text_visibility = "selection"
+        self.text_background_color = "#99ffffff"
 
     @property
     def interval(self) -> typing.Tuple[float, float]:
@@ -2496,7 +2528,7 @@ class SpotGraphicRenderer(GraphicRenderer):
             ctx.rotate(math.pi)
             ctx.translate(-origin.x, -origin.y)
             draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style, used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         center_widget = mapping.calibrated_origin_widget
@@ -2737,7 +2769,7 @@ class WedgeGraphicRenderer(GraphicRenderer):
 
         if is_selected:
             draw_marker(ctx, center, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -2976,7 +3008,7 @@ class RingGraphicRenderer(GraphicRenderer):
                         ctx.line_to(x, y)
                 ctx.close_path()
                 ctx.fill()
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -3294,7 +3326,7 @@ class LatticeGraphicRenderer(GraphicRenderer):
             draw_marker(ctx, v_pos_widget, is_focused, is_position_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(u_pos_widget, size_widget), is_focused, is_shape_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(v_pos_widget, size_widget), is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, is_selected, is_focused)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -33,8 +33,8 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
-    get_text_visibility_fn: typing.Callable[[str], str | None]  # Returns the visibility of the passed in text part
-    get_text_background_color_fn: typing.Callable[[str], str | None]  # Returns the background color of the passed in text part
+    used_text_visibility_map: dict[str, str]  # Returns the visibility of the passed in text part
+    used_text_background_color_map: dict[str, str]  # Returns the background color of the passed in text part
 
 
 def nice_label(value: float, precision: int) -> str:
@@ -500,7 +500,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_fn, graphic_renderer.used_text_background_color_fn)
+                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_map, graphic_renderer.used_text_background_color_map)
                         regions.append(region)
                     elif isinstance(graphic_renderer, Graphics.ChannelGraphicRenderer):
                         graphic_start, graphic_end = graphic_renderer.position, graphic_renderer.position
@@ -513,7 +513,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_fn, graphic_renderer.used_text_background_color_fn)
+                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_map, graphic_renderer.used_text_background_color_map)
                         regions.append(region)
             self.__regions = regions
         return self.__regions or list()

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -33,8 +33,8 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
-    text_visibility: str
-    background_color: str | None = None
+    get_text_visibility_fn: typing.Callable[[str], str | None]  # Returns the visibility of the passed in text part
+    get_text_background_color_fn: typing.Callable[[str], str | None]  # Returns the background color of the passed in text part
 
 
 def nice_label(value: float, precision: int) -> str:
@@ -500,7 +500,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style, graphic_renderer.text_visibility, graphic_renderer.text_background_color)
+                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_fn, graphic_renderer.used_text_background_color_fn)
                         regions.append(region)
                     elif isinstance(graphic_renderer, Graphics.ChannelGraphicRenderer):
                         graphic_start, graphic_end = graphic_renderer.position, graphic_renderer.position
@@ -513,7 +513,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style, graphic_renderer.text_visibility, graphic_renderer.text_background_color)
+                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style, graphic_renderer.used_text_visibility_fn, graphic_renderer.used_text_background_color_fn)
                         regions.append(region)
             self.__regions = regions
         return self.__regions or list()

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -33,6 +33,8 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
+    text_visibility: str
+    background_color: str | None = None
 
 
 def nice_label(value: float, precision: int) -> str:
@@ -498,7 +500,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style)
+                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style, graphic_renderer.text_visibility, graphic_renderer.text_background_color)
                         regions.append(region)
                     elif isinstance(graphic_renderer, Graphics.ChannelGraphicRenderer):
                         graphic_start, graphic_end = graphic_renderer.position, graphic_renderer.position
@@ -511,7 +513,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         region = RegionInfo((graphic_start, graphic_end),
                                             graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style)
+                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style, graphic_renderer.text_visibility, graphic_renderer.text_background_color)
                         regions.append(region)
             self.__regions = regions
         return self.__regions or list()


### PR DESCRIPTION
Fixes https://github.com/nion-software/nion-internal/issues/304.
Requires #1884 to fix the type check failure introduced by numpy updating.
Adds two properties to the graphics for text background color and text visibility. Text Visibility set to "always" will always show the text, "selection" when the graphic is selected, "focus" when the graphic is in focus. The default is "always" which is overridden by the Interval graphic to "selection" so it only shows the text when the graphic is selected. One issue that was not discussed in the specification is that since the name label and the width, left, and right texts are all driven by the same text visibility the behavior of the name label changes from always showing to only showing on selection. This is a side effect of the implementation that differs from the current behavior and from all other graphics where when there is a name label it will always show.