### PR TITLE
Remove redundant cast to fix mypy

### DIFF
--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -362,7 +362,7 @@ def adjustment_factory(adjustment_d: Persistence.PersistentDictType) -> typing.O
                 self.__gamma = gamma
 
             def transform(self, data: _ImageDataType, display_limits: typing.Tuple[float, float]) -> _ImageDataType:
-                return typing.cast(_ImageDataType, numpy.power(numpy.clip(data, 0.0, 1.0), self.__gamma, dtype=numpy.float32))
+                return numpy.power(numpy.clip(data, 0.0, 1.0), self.__gamma, dtype=numpy.float32)
 
         return AdjustGamma(adjustment_d.get("gamma", 1.0))
     elif adjustment_d.get("type", None) == "log":


### PR DESCRIPTION
The newest numpy version has broken some of the type checks see also https://github.com/nion-software/nion-alignment/pull/266.