### PR TITLE
Use the verify filename utility function in the export dialog

### DIFF
--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -81,11 +81,12 @@ class ExportDialogViewModel:
             non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
             if prefix_enabled and non_prefix_options_enabled:
                 # The prefix will only be part of the filename so only check that it is made up of valid characters
-                illegal_chars = re.findall(Utility.ILLEGAL_FILENAME_CHARS_REGEX, prefix_str)
-                if len(illegal_chars) == 1:
-                    invalid_reasons.append(_("Prefix contains illegal character") + f" \"{illegal_chars[0]}\"")
-                elif len(illegal_chars) > 1:
-                    invalid_reasons.append(_("Prefix contains illegal characters") + f" {illegal_chars}")
+                matches = re.findall(Utility.ILLEGAL_FILENAME_CHARS_REGEX, prefix_str)
+                matches = sorted(set(matches))
+                if len(matches) == 1:
+                    invalid_reasons.append(_("Prefix contains illegal character") + f" {matches[0]}")
+                elif len(matches) > 1:
+                    invalid_reasons.append(_("Prefix contains illegal characters {characters}").format(characters="".join(matches)))
             elif prefix_enabled and not non_prefix_options_enabled:
                 # The prefix is the full filename so check it is allowed using the verify filename utility
                 is_valid, errors = Utility.verify_filename_is_legal(prefix_str)

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -70,53 +70,6 @@ class ExportDialogViewModel:
         if not self.is_directory_valid:
             self.directory.value = None  # Clear the initial directory if it was invalid
 
-        def compute_export_options_validity(prefix_value: str | None, include_title: bool | None,
-                                            include_date: bool | None, include_dimensions: bool | None,
-                                            include_sequence: bool | None, is_directory_valid: bool | None) -> ExportOptionsValidity:
-            """Use the combined values of the export filename options and the directory validity to get a list of invalid reasons."""
-            invalid_reasons: list[str] = []
-
-            prefix_str = prefix_value or str()
-            prefix_enabled = prefix_str != str()
-            non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
-            if prefix_enabled and non_prefix_options_enabled:
-                # The prefix will only be part of the filename so only check that it is made up of valid characters
-                matches = re.findall(Utility.ILLEGAL_FILENAME_CHARS_REGEX, prefix_str)
-                matches = sorted(set(matches))
-                if len(matches) == 1:
-                    invalid_reasons.append(_("Prefix contains illegal character") + f" {matches[0]}")
-                elif len(matches) > 1:
-                    invalid_reasons.append(_("Prefix contains illegal characters {characters}").format(characters="".join(matches)))
-            elif prefix_enabled and not non_prefix_options_enabled:
-                # The prefix is the full filename so check it is allowed using the verify filename utility
-                is_valid, errors = Utility.verify_filename_is_legal(prefix_str)
-                if not is_valid and errors is not None:
-                    invalid_reasons.append(_("Prefix was not a valid filename:"))
-                    invalid_reasons.extend(errors)
-            elif not prefix_enabled and not non_prefix_options_enabled:
-                # There must be at least one option enabled otherwise the filenames will be empty
-                invalid_reasons.append(_("Filename requires at least one option to be selected"))
-
-            if not is_directory_valid:
-                invalid_reasons.append(_("Directory does not exist"))
-
-            return ExportOptionsValidity(bool(is_directory_valid), tuple(invalid_reasons))
-
-        def handle_export_options_validity_changed(export_validity: ExportOptionsValidity | None) -> None:
-            """Update the export button's enabled state and tooltip based on the computed invalid reasons and directory validity."""
-            export_validity = export_validity or ExportOptionsValidity(False, tuple())
-            if not export_validity.is_directory_valid:
-                self.directory.value = None  # Clear the directory if it is invalid
-
-            if export_validity.invalid_reasons:
-                self.export_button_enabled.value = False
-                self.export_button_tool_tip.value = ", ".join(export_validity.invalid_reasons)
-                self.directory_warning.value = "\n".join(export_validity.invalid_reasons)
-            else:
-                self.export_button_enabled.value = True
-                self.export_button_tool_tip.value = None
-                self.directory_warning.value = str()
-
         export_filename_option_streams: typing.Sequence[Stream.PropertyChangedEventStream[str | bool]] = [
             # Update the button when one of the options changes
             Stream.PropertyChangedEventStream(self.prefix, "value"),
@@ -129,13 +82,64 @@ class ExportDialogViewModel:
         ]
 
         self.__export_button_update_action = Stream.ValueStreamAction(
-            Stream.CombineLatestStream(export_filename_option_streams, compute_export_options_validity),
-            handle_export_options_validity_changed
+            Stream.CombineLatestStream(export_filename_option_streams, self.__compute_export_options_validity),
+            self.__handle_export_options_validity_changed
         )
+        self.update_options()
 
-        handle_export_options_validity_changed(compute_export_options_validity(self.prefix.value, self.include_title.value,
-                                                                               self.include_date.value, self.include_dimensions.value,
-                                                                               self.include_sequence.value, self.__is_directory_valid.value))
+    @staticmethod
+    def __compute_export_options_validity(prefix_value: str | None, include_title: bool | None,
+                                        include_date: bool | None, include_dimensions: bool | None,
+                                        include_sequence: bool | None, is_directory_valid: bool | None) -> ExportOptionsValidity:
+        """Use the combined values of the export filename options and the directory validity to get a list of invalid reasons."""
+        invalid_reasons: list[str] = []
+
+        prefix_str = prefix_value or str()
+        prefix_enabled = prefix_str != str()
+        non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
+        if prefix_enabled and non_prefix_options_enabled:
+            # The prefix will only be part of the filename so only check that it is made up of valid characters
+            is_valid, error = Utility.verify_filename_has_no_illegal_characters(prefix_str)
+            if not is_valid and error is not None:
+                invalid_reasons.append(_("Prefix ") + error[0].lower() + error[1:])
+        elif prefix_enabled and not non_prefix_options_enabled:
+            # The prefix is the full filename so check it is allowed using the verify filename utility
+            is_valid, errors = Utility.verify_filename_is_legal(prefix_str)
+            if not is_valid and errors is not None:
+                invalid_reasons.append(_("Prefix was not a valid filename:"))
+                invalid_reasons.extend(errors)
+        elif not prefix_enabled and not non_prefix_options_enabled:
+            # There must be at least one option enabled otherwise the filenames will be empty
+            invalid_reasons.append(_("Filename requires at least one option to be selected"))
+
+        if not is_directory_valid:
+            invalid_reasons.append(_("Directory does not exist"))
+
+        return ExportOptionsValidity(bool(is_directory_valid), tuple(invalid_reasons))
+
+    def __handle_export_options_validity_changed(self, export_validity: ExportOptionsValidity | None) -> None:
+        """Update the export button's enabled state and tooltip based on the computed invalid reasons and directory validity."""
+        export_validity = export_validity or ExportOptionsValidity(False, tuple())
+        if not export_validity.is_directory_valid:
+            self.directory.value = None  # Clear the directory if it is invalid
+
+        if export_validity.invalid_reasons:
+            self.export_button_enabled.value = False
+            self.export_button_tool_tip.value = ", ".join(export_validity.invalid_reasons)
+            self.directory_warning.value = "\n".join(export_validity.invalid_reasons)
+        else:
+            self.export_button_enabled.value = True
+            self.export_button_tool_tip.value = None
+            self.directory_warning.value = str()
+
+    def update_options(self, prefix_value: str | None = None) -> None:
+        """Directly refresh the validity of the export button's enabled state and tooltip."""
+        self.__handle_export_options_validity_changed(
+            self.__compute_export_options_validity(
+                prefix_value or self.prefix.value, self.include_title.value, self.include_date.value,
+                self.include_dimensions.value, self.include_sequence.value, self.__is_directory_valid.value
+            )
+        )
 
     @property
     def directory_path_object(self) -> pathlib.Path:
@@ -268,6 +272,9 @@ class ExportDialog(Declarative.Handler):
         writer = self.__writers[current_index]
         self.viewmodel.writer.value = writer
 
+    def handle_prefix_edited(self, widget: UserInterface.LineEditWidget, text: str) -> None:
+        self.viewmodel.update_options(text)
+
     def __build_ui(self, u: Declarative.DeclarativeUI) -> None:
         """Build the UI and store it in self.ui_view. This is called from __init__."""
 
@@ -303,7 +310,7 @@ class ExportDialog(Declarative.Handler):
 
         # Prefix. Include a messy callback so that prefix gets updated during typing.
         prefix_label = u.create_label(text=_("Prefix:"))
-        prefix_textbox = u.create_line_edit(text="@binding(viewmodel.prefix.value)", placeholder_text=_("None"), width=230)
+        prefix_textbox = u.create_line_edit(text="@binding(viewmodel.prefix.value)", placeholder_text=_("None"), width=230, on_text_edited="handle_prefix_edited")
         prefix_row = u.create_row(prefix_label, prefix_textbox, u.create_stretch(), spacing=10)
 
         # File Type

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -77,10 +77,22 @@ class ExportDialogViewModel:
             invalid_reasons: list[str] = []
 
             prefix_str = prefix_value or str()
-            if prefix_str != Utility.simplify_filename(prefix_str):
-                invalid_reasons.append(_("Prefix contains invalid characters"))
-
-            if not (prefix_str or include_title or include_date or include_dimensions or include_sequence):
+            prefix_enabled = prefix_str != str()
+            non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
+            if prefix_enabled and non_prefix_options_enabled:
+                # The prefix will only be part of the filename so only check that it is made up of valid characters
+                illegal_chars = re.findall(Utility.ILLEGAL_FILENAME_CHARS_REGEX, prefix_str)
+                if len(illegal_chars) == 1:
+                    invalid_reasons.append(_("Prefix contains illegal character") + f" \"{illegal_chars[0]}\"")
+                elif len(illegal_chars) > 1:
+                    invalid_reasons.append(_("Prefix contains illegal characters") + f" {illegal_chars}")
+            elif prefix_enabled and not non_prefix_options_enabled:
+                # The prefix is the full filename so check it is allowed using the verify filename utility
+                is_valid, errors = Utility.verify_filename_is_legal(prefix_str)
+                if not is_valid and errors is not None:
+                    invalid_reasons.append(_("Prefix was not a valid filename:"))
+                    invalid_reasons.extend(errors)
+            elif not prefix_enabled and not non_prefix_options_enabled:
                 # There must be at least one option enabled otherwise the filenames will be empty
                 invalid_reasons.append(_("Filename requires at least one option to be selected"))
 

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -82,20 +82,20 @@ class ExportDialogViewModel:
         ]
 
         self.__export_button_update_action = Stream.ValueStreamAction(
-            Stream.CombineLatestStream(export_filename_option_streams, self.__compute_export_options_validity),
+            Stream.CombineLatestStream(export_filename_option_streams, ExportDialogViewModel.compute_export_options_validity),
             self.__handle_export_options_validity_changed
         )
         self.update_options()
 
     @staticmethod
-    def __compute_export_options_validity(prefix_value: str | None, include_title: bool | None,
+    def compute_export_options_validity(prefix_value: str | None, include_title: bool | None,
                                         include_date: bool | None, include_dimensions: bool | None,
                                         include_sequence: bool | None, is_directory_valid: bool | None) -> ExportOptionsValidity:
         """Use the combined values of the export filename options and the directory validity to get a list of invalid reasons."""
         invalid_reasons: list[str] = []
 
         prefix_str = prefix_value or str()
-        prefix_enabled = prefix_str != str()
+        prefix_enabled = bool(prefix_str)
         non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
         if prefix_enabled and non_prefix_options_enabled:
             # The prefix will only be part of the filename so only check that it is made up of valid characters
@@ -134,12 +134,11 @@ class ExportDialogViewModel:
 
     def update_options(self, prefix_value: str | None = None) -> None:
         """Directly refresh the validity of the export button's enabled state and tooltip."""
-        self.__handle_export_options_validity_changed(
-            self.__compute_export_options_validity(
-                prefix_value or self.prefix.value, self.include_title.value, self.include_date.value,
-                self.include_dimensions.value, self.include_sequence.value, self.__is_directory_valid.value
-            )
+        export_options_validity = ExportDialogViewModel.compute_export_options_validity(
+            prefix_value or self.prefix.value, self.include_title.value, self.include_date.value,
+            self.include_dimensions.value, self.include_sequence.value, self.__is_directory_valid.value
         )
+        self.__handle_export_options_validity_changed(export_options_validity)
 
     @property
     def directory_path_object(self) -> pathlib.Path:

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -99,9 +99,10 @@ class ExportDialogViewModel:
         non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
         if prefix_enabled and non_prefix_options_enabled:
             # The prefix will only be part of the filename so only check that it is made up of valid characters
-            error = Utility.get_filename_illegal_chars_error(prefix_str)
-            if error is not None:
-                invalid_reasons.append(_("Prefix ") + error[0].lower() + error[1:])
+            errors = Utility.get_filename_illegal_chars_error(prefix_str)
+            if errors is not None:
+                invalid_reasons.append(_("Prefix was invalid:"))
+                invalid_reasons.extend(errors)
         elif prefix_enabled and not non_prefix_options_enabled:
             # The prefix is the full filename so check it is allowed using the verify filename utility
             is_valid, errors = Utility.verify_filename_is_legal(prefix_str)

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -99,8 +99,8 @@ class ExportDialogViewModel:
         non_prefix_options_enabled = include_title or include_date or include_dimensions or include_sequence
         if prefix_enabled and non_prefix_options_enabled:
             # The prefix will only be part of the filename so only check that it is made up of valid characters
-            is_valid, error = Utility.verify_filename_has_no_illegal_characters(prefix_str)
-            if not is_valid and error is not None:
+            error = Utility.get_filename_illegal_chars_error(prefix_str)
+            if error is not None:
                 invalid_reasons.append(_("Prefix ") + error[0].lower() + error[1:])
         elif prefix_enabled and not non_prefix_options_enabled:
             # The prefix is the full filename so check it is allowed using the verify filename utility

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -451,7 +451,12 @@ ILLEGAL_FILENAME_CHARS_REGEX = r'[<>:/\\|?*"\0-\31]'  # Capture illegal characte
 ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX = f'^[. ]|{ILLEGAL_FILENAME_CHARS_REGEX}|[. ]$'
 ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
                      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
-
+CONTROL_CHAR_NAMES = {
+    '\t': _("'\\t' (Tab)"),
+    '\r': _("'\\r' (Carriage Return)"),
+    '\n': _("'\\n' (New Line)"),
+    '\\': r"'\'",
+}
 
 def verify_filename_has_no_illegal_characters(filename: str) -> tuple[bool, str | None]:
     """Check if a filename contains illegal characters.
@@ -462,14 +467,10 @@ def verify_filename_has_no_illegal_characters(filename: str) -> tuple[bool, str 
     matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
     illegal_chars = []
     for match in matches:
-        if match == "\\":
-            match = "'\\'"
-        elif match == '\r':
-            match = r"'\r' (Carriage Return)"
-        elif match == '\n':
-            match = r"'\n' (New Line)"
+        if match in CONTROL_CHAR_NAMES:
+            match = CONTROL_CHAR_NAMES[match]
         else:
-            match = repr(match)  # repr ensures the character is printable and has quotations
+            match = repr(match) + " (Control Character)"  # repr ensures the character is printable and has quotations
         if match not in illegal_chars:
             illegal_chars.append(match)
 

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -453,10 +453,38 @@ ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4',
                      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
 
 
+def verify_filename_has_no_illegal_characters(filename: str) -> tuple[bool, str | None]:
+    """Check if a filename contains illegal characters.
+
+    Returns a tuple of a bool indicating if the filename is valid and an error message or None when it is valid.
+    The case of a \r or \n are likely when pasting but using those representations are not clear so use the name of the characters instead.
+    """
+    matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
+    illegal_chars = []
+    for match in matches:
+        if match == "\\":
+            match = "'\\'"
+        elif match == '\r':
+            match = r"'\r' (Carriage Return)"
+        elif match == '\n':
+            match = r"'\n' (New Line)"
+        else:
+            match = repr(match)  # repr ensures the character is printable and has quotations
+        if match not in illegal_chars:
+            illegal_chars.append(match)
+
+    if illegal_chars:
+        if len(illegal_chars) == 1:
+            return False, _("Contains illegal character {character}").format(character=illegal_chars[0])
+        else:
+            return False, _("Contains illegal characters {characters}").format(characters=", ".join(illegal_chars))
+    return True, None
+
+
 def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[bool, typing.Sequence[str] | None]:
     """Check if a filename is allowed on all platforms.
 
-    Returns a tuple with a bool indicating if the path is valid or not, and a list of error messages or None when there are no errors.
+    Returns a tuple with a bool indicating if the filename is valid or not, and a list of error messages or None when there are no errors.
     Checks the filename is not in ILLEGAL_FILENAMES and no matches in the ILLEGAL_FILENAME_CHARS_REGEX.
     Even when the platform can support the filename if it is illegal on any platforms it will not be allowed so there can be cross-platform file compatibility.
     """
@@ -478,27 +506,23 @@ def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[
 
     if filename.upper() in ILLEGAL_FILENAMES:
         errors.append(_("\"{filename}\" is illegal as it is reserved on some platforms").format(filename=filename))
-    matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
-    matches = sorted(set(matches))
-    if matches:
-        if len(matches) == 1:
-            errors.append(_("Contains illegal character '{character}'").format(character=matches[0]))
-        else:
-            errors.append(_("Contains illegal characters {characters}").format(characters=matches))
+
+    is_valid, illegal_chars_error = verify_filename_has_no_illegal_characters(filename)
+    if not is_valid and illegal_chars_error is not None:
+        errors.append(illegal_chars_error)
 
     return len(errors) == 0, errors or None
 
 
 def simplify_filename(filename: str, replacement_char: str = '_', maximum_length: int = 128) -> str:
-    # This function replaces any illegal characters in a file name. Not a full path.
-    # macOS illegal characters = \0 /
-    # linux illegal characters = \0 /
-    # Windows illegal characters = < > : / \ | ? * " ASCII values 0-31 (non-printable chars)
-    # Windows illegal filenames = CON PRN AUX NUL COM1 COM2 COM3 COM4 COM5 COM6 COM7 COM8 COM9
-    #                             LPT1 LPT2 LPT3 LPT4 LPT5 LPT6 LPT7 LPT8 LPT9 COM¹ COM² COM³ LPT¹ LPT² LPT³
-    # those files names are illegal with or without a suffix, upper and lower case
-    # Windows file names cannot start or end with periods or spaces
+    """This function replaces any illegal characters in a file name. Not a full path.
 
+    macOS and linux illegal characters = \\0.
+    Windows illegal characters = < > : / \\ | ? * " ASCII values 0-31 (non-printable chars)
+    Windows illegal filenames = CON PRN AUX NUL COM1 COM2 COM3 COM4 COM5 COM6 COM7 COM8 COM9 LPT1 LPT2 LPT3 LPT4 LPT5 LPT6 LPT7 LPT8 LPT9 COM¹ COM² COM³ LPT¹ LPT² LPT³
+    Those files names are illegal with or without a suffix, upper and lower case.
+    Windows file names cannot start or end with periods or spaces.
+    """
     assert maximum_length > 5
     assert len(replacement_char) == 1
 

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -459,7 +459,7 @@ def get_filename_illegal_chars_error(filename: str)  -> typing.Sequence[str] | N
     """
     matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
     illegal_chars = []
-    errors = []
+    errors: list[str] = []
     for match in matches:
         if not str(match).isprintable():
             if not errors:  # Only add the message once

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -451,35 +451,35 @@ ILLEGAL_FILENAME_CHARS_REGEX = r'[<>:/\\|?*"\0-\31]'  # Capture illegal characte
 ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX = f'^[. ]|{ILLEGAL_FILENAME_CHARS_REGEX}|[. ]$'
 ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
                      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
+# Maps some common control characters to a human-readable name
 CONTROL_CHAR_NAMES = {
-    '\t': _("'\\t' (Tab)"),
-    '\r': _("'\\r' (Carriage Return)"),
-    '\n': _("'\\n' (New Line)"),
-    '\\': r"'\'",
+    '\t': r"'\t' (Tab)",
+    '\r': r"'\r' (Carriage Return)",
+    '\n': r"'\n' (New Line)",
+    '\\': r"'\'"  # Backslash repr is '\\' but we want to show it as '\'
 }
 
-def verify_filename_has_no_illegal_characters(filename: str) -> tuple[bool, str | None]:
+
+def get_filename_illegal_chars_error(filename: str) -> str | None:
     """Check if a filename contains illegal characters.
 
-    Returns a tuple of a bool indicating if the filename is valid and an error message or None when it is valid.
-    The case of a \r or \n are likely when pasting but using those representations are not clear so use the name of the characters instead.
+    Returns an error message if there are illegal chars or None when it is valid.
+    The case of a \r, \t, and \n are likely when pasting but using those representations are not clear so use the name of the characters instead.
     """
     matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
     illegal_chars = []
     for match in matches:
-        if match in CONTROL_CHAR_NAMES:
-            match = CONTROL_CHAR_NAMES[match]
+        # If the character cannot be printed then use a human-readable name
+        if not str(match).isprintable() or match == '\\':
+            match = CONTROL_CHAR_NAMES.get(match, f"{repr(match)} (Control Character)")
         else:
-            match = repr(match) + " (Control Character)"  # repr ensures the character is printable and has quotations
+            match = repr(match)
         if match not in illegal_chars:
             illegal_chars.append(match)
 
     if illegal_chars:
-        if len(illegal_chars) == 1:
-            return False, _("Contains illegal character {character}").format(character=illegal_chars[0])
-        else:
-            return False, _("Contains illegal characters {characters}").format(characters=", ".join(illegal_chars))
-    return True, None
+        return _("Contains illegal character(s) {characters}").format(characters=", ".join(illegal_chars))
+    return None
 
 
 def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[bool, typing.Sequence[str] | None]:
@@ -500,16 +500,14 @@ def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[
     if filename == "":
         errors.append(_("Cannot be empty"))
     if len(filename) > 1:  # A filename can be " " or "." but cannot end with those characters, the "." will be caught by the leading periods check and so shouldn't be duplicated
-        if filename.endswith(" "):
-            errors.append(_("Cannot end with a whitespace"))
         if filename.endswith("."):
             errors.append(_("Cannot end with a period"))
 
     if filename.upper() in ILLEGAL_FILENAMES:
         errors.append(_("\"{filename}\" is illegal as it is reserved on some platforms").format(filename=filename))
 
-    is_valid, illegal_chars_error = verify_filename_has_no_illegal_characters(filename)
-    if not is_valid and illegal_chars_error is not None:
+    illegal_chars_error = get_filename_illegal_chars_error(filename)
+    if illegal_chars_error is not None:
         errors.append(illegal_chars_error)
 
     return len(errors) == 0, errors or None

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -451,35 +451,32 @@ ILLEGAL_FILENAME_CHARS_REGEX = r'[<>:/\\|?*"\0-\31]'  # Capture illegal characte
 ILLEGAL_FILENAME_CHARS_AND_POSITION_REGEX = f'^[. ]|{ILLEGAL_FILENAME_CHARS_REGEX}|[. ]$'
 ILLEGAL_FILENAMES = ['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
                      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³']
-# Maps some common control characters to a human-readable name
-CONTROL_CHAR_NAMES = {
-    '\t': r"'\t' (Tab)",
-    '\r': r"'\r' (Carriage Return)",
-    '\n': r"'\n' (New Line)",
-    '\\': r"'\'"  # Backslash repr is '\\' but we want to show it as '\'
-}
 
-
-def get_filename_illegal_chars_error(filename: str) -> str | None:
+def get_filename_illegal_chars_error(filename: str)  -> typing.Sequence[str] | None:
     """Check if a filename contains illegal characters.
 
-    Returns an error message if there are illegal chars or None when it is valid.
-    The case of a \r, \t, and \n are likely when pasting but using those representations are not clear so use the name of the characters instead.
+    Returns a sequence of error messages if there are illegal chars or None when it is valid.
     """
     matches = re.findall(ILLEGAL_FILENAME_CHARS_REGEX, filename)
     illegal_chars = []
+    errors = []
     for match in matches:
-        # If the character cannot be printed then use a human-readable name
-        if not str(match).isprintable() or match == '\\':
-            match = CONTROL_CHAR_NAMES.get(match, f"{repr(match)} (Control Character)")
+        if not str(match).isprintable():
+            if not errors:  # Only add the message once
+                errors.append(_("Contains non-printable character(s)"))
+            continue
+
+        if match == '\\':  # repr() will return '\\' so we special case it to just return '\'
+            match = r"'\'"
         else:
             match = repr(match)
         if match not in illegal_chars:
             illegal_chars.append(match)
 
     if illegal_chars:
-        return _("Contains illegal character(s) {characters}").format(characters=", ".join(illegal_chars))
-    return None
+        errors.append(_("Contains illegal character(s) {characters}").format(characters=", ".join(illegal_chars)))
+
+    return errors
 
 
 def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[bool, typing.Sequence[str] | None]:
@@ -508,7 +505,7 @@ def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[
 
     illegal_chars_error = get_filename_illegal_chars_error(filename)
     if illegal_chars_error is not None:
-        errors.append(illegal_chars_error)
+        errors.extend(illegal_chars_error)
 
     return len(errors) == 0, errors or None
 

--- a/nion/swift/model/Utility.py
+++ b/nion/swift/model/Utility.py
@@ -476,7 +476,7 @@ def get_filename_illegal_chars_error(filename: str)  -> typing.Sequence[str] | N
     if illegal_chars:
         errors.append(_("Contains illegal character(s) {characters}").format(characters=", ".join(illegal_chars)))
 
-    return errors
+    return errors or None
 
 
 def verify_filename_is_legal(filename: str, maximum_length: int = 128) -> tuple[bool, typing.Sequence[str] | None]:

--- a/nion/swift/test/Utility_test.py
+++ b/nion/swift/test/Utility_test.py
@@ -73,16 +73,25 @@ class TestUtilityClass(unittest.TestCase):
             finally:
                 os.remove(file_path)
 
-    def test_verify_path_is_legal_catches_illegal_names(self) -> None:
+    def test_verify_filename_has_no_illegal_characters(self):
+        test_filenames = [("5>3>2024", "Contains illegal character '>'"),
+                          ("abc\n\rdef\\", r"Contains illegal characters '\n' (New Line), '\r' (Carriage Return), '\'"),
+                          ("\26", r"Contains illegal character '\x16'")]
+
+        for test_input, expected in test_filenames:
+            with self.subTest(test_input=test_input):
+                is_valid, error = Utility.verify_filename_has_no_illegal_characters(test_input)
+                self.assertFalse(is_valid)
+                self.assertEqual(error, expected)
+
+
+    def test_verify_filename_is_legal_catches_illegal_names(self) -> None:
         test_filenames = [("", "Cannot be empty"),
                           ("file.", "Cannot end with a period"),
                           ("file ", "Cannot end with a whitespace"),
                           ("COM¹", "\"COM¹\" is illegal as it is reserved on some platforms"),
-                          ("5>3>2024", "Contains illegal character '>'"),
                           ("1234567890" * 13, "Exceeds the allowed length of 128 characters"),
-                          ("NUL", "\"NUL\" is illegal as it is reserved on some platforms"),
-                          ("abc\n\rdef", "Contains illegal characters ['\\n', '\\r']"),
-                          ("\26", "Contains illegal character '\x16'")]
+                          ("NUL", "\"NUL\" is illegal as it is reserved on some platforms")]
 
         for test_input, expected in test_filenames:
             with self.subTest(test_input=test_input):
@@ -90,9 +99,9 @@ class TestUtilityClass(unittest.TestCase):
                 self.assertFalse(is_valid)
                 self.assertEqual(errors, [expected])
 
-    def test_verify_path_is_legal_returns_multiple_errors(self) -> None:
-        multi_error_filenames = [("/file.", ["Cannot end with a period", "Contains illegal character '/'"]),
-                                 ("*>" + "1234567890" * 13, ["Exceeds the allowed length of 128 characters", r"Contains illegal characters ['*', '>']"])]
+    def test_verify_filename_is_legal_returns_multiple_errors(self) -> None:
+        multi_error_filenames = [("/file.", ["Cannot end with a period", r"Contains illegal character '/'"]),
+                                 ("*>" + "1234567890" * 13, ["Exceeds the allowed length of 128 characters", r"Contains illegal characters '*', '>'"])]
 
         for test_input, expected in multi_error_filenames:
             with self.subTest(test_input=test_input):
@@ -100,7 +109,7 @@ class TestUtilityClass(unittest.TestCase):
                 self.assertFalse(is_valid)
                 self.assertEqual(errors, expected)
 
-    def test_verify_path_is_legal_returns_true_for_valid_names(self) -> None:
+    def test_verify_filename_is_legal_returns_true_for_valid_names(self) -> None:
         valid_filenames = ["file",
                            "file.name",
                            "1234567890" * 12,

--- a/nion/swift/test/Utility_test.py
+++ b/nion/swift/test/Utility_test.py
@@ -74,14 +74,15 @@ class TestUtilityClass(unittest.TestCase):
                 os.remove(file_path)
 
     def test_verify_filename_has_no_illegal_characters(self):
-        test_filenames = [("5>3>2024", "Contains illegal character(s) '>'"),
-                          ("abc\n\rdef\\", r"Contains illegal character(s) '\n' (New Line), '\r' (Carriage Return), '\'"),
-                          ("\26", r"Contains illegal character(s) '\x16' (Control Character)")]
+        test_filenames = [("5>3>2024", ["Contains illegal character(s) '>'"]),
+                          ("abcdef\\", [r"Contains illegal character(s) '\'"]),
+                          ("abcdef\n", [r"Contains non-printable character(s)"]),
+                          ("\26", [r"Contains non-printable character(s)"])]
 
         for test_input, expected in test_filenames:
             with self.subTest(test_input=test_input):
-                error = Utility.get_filename_illegal_chars_error(test_input)
-                self.assertEqual(error, expected)
+                errors = Utility.get_filename_illegal_chars_error(test_input)
+                self.assertEqual(errors, expected)
 
     def test_verify_filename_is_legal_catches_illegal_names(self) -> None:
         test_filenames = [("", "Cannot be empty"),

--- a/nion/swift/test/Utility_test.py
+++ b/nion/swift/test/Utility_test.py
@@ -74,21 +74,18 @@ class TestUtilityClass(unittest.TestCase):
                 os.remove(file_path)
 
     def test_verify_filename_has_no_illegal_characters(self):
-        test_filenames = [("5>3>2024", "Contains illegal character '>'"),
-                          ("abc\n\rdef\\", r"Contains illegal characters '\n' (New Line), '\r' (Carriage Return), '\'"),
-                          ("\26", r"Contains illegal character '\x16'")]
+        test_filenames = [("5>3>2024", "Contains illegal character(s) '>'"),
+                          ("abc\n\rdef\\", r"Contains illegal character(s) '\n' (New Line), '\r' (Carriage Return), '\'"),
+                          ("\26", r"Contains illegal character(s) '\x16' (Control Character)")]
 
         for test_input, expected in test_filenames:
             with self.subTest(test_input=test_input):
-                is_valid, error = Utility.verify_filename_has_no_illegal_characters(test_input)
-                self.assertFalse(is_valid)
+                error = Utility.get_filename_illegal_chars_error(test_input)
                 self.assertEqual(error, expected)
-
 
     def test_verify_filename_is_legal_catches_illegal_names(self) -> None:
         test_filenames = [("", "Cannot be empty"),
                           ("file.", "Cannot end with a period"),
-                          ("file ", "Cannot end with a whitespace"),
                           ("COM¹", "\"COM¹\" is illegal as it is reserved on some platforms"),
                           ("1234567890" * 13, "Exceeds the allowed length of 128 characters"),
                           ("NUL", "\"NUL\" is illegal as it is reserved on some platforms")]
@@ -100,8 +97,8 @@ class TestUtilityClass(unittest.TestCase):
                 self.assertEqual(errors, [expected])
 
     def test_verify_filename_is_legal_returns_multiple_errors(self) -> None:
-        multi_error_filenames = [("/file.", ["Cannot end with a period", r"Contains illegal character '/'"]),
-                                 ("*>" + "1234567890" * 13, ["Exceeds the allowed length of 128 characters", r"Contains illegal characters '*', '>'"])]
+        multi_error_filenames = [("/file.", ["Cannot end with a period", r"Contains illegal character(s) '/'"]),
+                                 ("*>" + "1234567890" * 13, ["Exceeds the allowed length of 128 characters", r"Contains illegal character(s) '*', '>'"])]
 
         for test_input, expected in multi_error_filenames:
             with self.subTest(test_input=test_input):


### PR DESCRIPTION
Fixes #1885.
Changes the check of the prefix to use the verify filename utility function when it is the only option enabled otherwise only the illegal characters are checked.