### PR TITLE
Make calls to auto-legend more explicit. Fixes SVG export issue.

### DIFF
--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2218,7 +2218,7 @@ class DisplayItem(Persistence.PersistentObject):
         self.define_property("session_id", hidden=True, changed=self.__property_changed)
         self.define_property("calibration_style_id", "calibrated", hidden=True, changed=self.__property_changed)
         self.define_property("intensity_calibration_style_id", "calibrated", hidden=True, changed=self.__property_changed)
-        self.define_property("display_properties", dict(), hidden=True, copy_on_read=True, changed=self.__display_properties_changed)
+        self.define_property("display_properties", dict(), hidden=True, copy_on_read=True, changed=self.__property_changed)
         self.define_relationship("graphics", Graphics.factory, insert=self.__insert_graphic, remove=self.__remove_graphic, hidden=True)
         self.define_relationship("display_layers", typing.cast(Persistence._PersistentObjectFactoryFn, display_layer_factory), insert=self.__insert_display_layer, remove=self.__remove_display_layer, hidden=True)
         self.define_relationship("display_data_channels", display_data_channel_factory, insert=self.__insert_display_data_channel, remove=self.__remove_display_data_channel, hidden=True)
@@ -2537,9 +2537,6 @@ class DisplayItem(Persistence.PersistentObject):
             self.__specified_title_stream.value = value
             self.notify_property_changed("displayed_title")
 
-    def __display_properties_changed(self, name: str, value: typing.Any) -> None:
-        self.notify_property_changed(name)
-
     def clone(self) -> DisplayItem:
         display_item = self.__class__()
         display_item.uuid = self.uuid
@@ -2662,13 +2659,11 @@ class DisplayItem(Persistence.PersistentObject):
     def __insert_display_layer(self, name: str, before_index: int, display_layer: DisplayLayer) -> None:
         self.__display_layer_changed_event_listeners.insert(before_index, display_layer.property_changed_event.listen(self.__display_layer_changed))
         self.notify_insert_item("display_layers", display_layer, before_index)
-        self.auto_display_legend()
 
     def __remove_display_layer(self, name: str, index: int, display_layer: DisplayLayer) -> None:
         self.__display_layer_changed_event_listeners[index].close()
         del self.__display_layer_changed_event_listeners[index]
         self.notify_remove_item("display_layers", display_layer, index)
-        self.auto_display_legend()
 
     def __display_layer_changed(self, name: str) -> None:
         self.display_changed_event.fire()

--- a/nion/swift/test/DisplayItem_test.py
+++ b/nion/swift/test/DisplayItem_test.py
@@ -91,6 +91,20 @@ class TestDisplayItemClass(unittest.TestCase):
                 self.assertEqual(1, snapshot_display_item.display_data_channels[0].sequence_index)
                 self.assertEqual((1, 2, 0), snapshot_display_item.display_data_channels[0].collection_index)
 
+    def test_display_item_snapshot_and_preserves_legend(self):
+        with TestContext.create_memory_context() as test_context:
+            document_model = test_context.create_document_model()
+            data_item1 = DataItem.DataItem(numpy.zeros((8,), numpy.uint32))
+            document_model.append_data_item(data_item1)
+            data_item2 = DataItem.DataItem(numpy.zeros((8,), numpy.uint32))
+            document_model.append_data_item(data_item2)
+            display_item = document_model.get_display_item_for_data_item(data_item1)
+            display_item.append_display_data_channel_for_data_item(data_item2)
+            self.assertEqual("top-right", display_item.get_display_property("legend_position"))
+            display_item.set_display_property("legend_position", "top-left")
+            with contextlib.closing(display_item.snapshot()) as snapshot_display_item:
+                self.assertEqual("top-left", snapshot_display_item.get_display_property("legend_position"))
+
     def test_appending_display_data_channel_does_nothing_if_display_data_channel_already_exists(self):
         with TestContext.create_memory_context() as test_context:
             document_model = test_context.create_document_model()
@@ -134,6 +148,7 @@ class TestDisplayItemClass(unittest.TestCase):
             display_item.append_display_data_channel_for_data_item(data_item2)
             self.assertEqual(2, len(display_item.display_data_channels))
             display_item.remove_display_data_channel(display_item.display_data_channels[-1]).close()
+            display_item.auto_display_legend()
             self.assertEqual(1, len(display_item.display_data_channels))
             self.assertEqual(1, len(display_item.display_layers))
             self.assertEqual(data_item1, display_item.display_data_channel.data_item)
@@ -327,10 +342,12 @@ class TestDisplayItemClass(unittest.TestCase):
             self.assertIsNone(display_item.get_display_property("legend_position"))
             # check that legend is automatically enabled for 2nd layer
             display_item.append_display_data_channel_for_data_item(data_item2)
+            display_item.auto_display_legend()
             self.assertEqual("top-right", display_item.get_display_property("legend_position"))
             # check that legend is not automatically enabled for 3rd layer
             display_item.set_display_property("legend_position", None)
             display_item.append_display_data_channel_for_data_item(data_item3)
+            display_item.auto_display_legend()
             self.assertIsNone(display_item.get_display_property("legend_position"))
 
     def test_closing_display_does_not_trigger_computation_binding(self):


### PR DESCRIPTION
Fixes #1776

The legend gets enabled/disabled automatically when a line plot display goes from one item to two or two to one.
This change makes that more explicit and adds a test. This wasn't a good solution in the first place and this is
only a band-aid on top of that original solution. This fixes the issue with the legend reverting to top-right
when exporting to SVG. In that case, the legend got reset during snapshot. Moving the 'auto_legend' call out of
the low level fixes that issue. Snapshot was probably also failing in the same way SVG was failing, too.
