### PR TITLE
Dragging to split panel from selection

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -314,9 +314,7 @@ class DataPanel(Panel.Panel):
                 return mime_data.has_file_paths
 
             def drop_mime_data(self, mime_data: UserInterface.MimeData, action: str, drop_index: int | None) -> str:
-                display_items = document_controller.receive_files(mime_data.file_paths)
-                if set(display_items).intersection(set(document_controller.filtered_display_items_model.display_items)):
-                    document_controller.select_display_items_in_data_panel(display_items)
+                document_controller.receive_files(mime_data.file_paths)
                 return "accept"
 
             def _get_mime_data_and_thumbnail_data(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> typing.Tuple[typing.Optional[UserInterface.MimeData], typing.Optional[_NDArray]]:

--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -334,11 +334,14 @@ class DataPanel(Panel.Panel):
                             Image.scaled(Image.get_rgba_view_from_rgba_data(thumbnail_data),
                                          tuple(Geometry.IntSize(w=80, h=80))))
                 elif len(display_items) > 1:
+                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
+                    if display_item is None and self.__selection.anchor_index is not None:
+                        display_item = self.__data_panel.document_controller.display_items_model.items[self.__selection.anchor_index]
+                    else:
+                        display_item = display_items[0]
                     mime_data = document_controller.ui.create_mime_data()
                     MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    anchor_index = self.__selection.anchor_index or 0
-                    thumbnail_display_item = display_items[anchor_index]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, thumbnail_display_item)
+                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, display_item)
                     thumbnail_data = thumbnail_source.thumbnail_data
                 return mime_data, thumbnail_data
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2140,11 +2140,14 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                         thumbnail_data = Image.get_rgba_data_from_rgba(
                             Image.scaled(Image.get_rgba_view_from_rgba_data(thumbnail_data), tuple(Geometry.IntSize(w=80, h=80))))
                 elif len(display_items) > 1:
+                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
+                    if display_item is None and self.__selection.anchor_index is not None:
+                        display_item = document_controller.display_items_model.items[self.__selection.anchor_index]
+                    else:
+                        display_item = display_items[0]
                     mime_data = document_controller.ui.create_mime_data()
                     MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    anchor_index = self.__selection.anchor_index or 0
-                    thumbnail_display_item = display_items[anchor_index]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, thumbnail_display_item)
+                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, display_item)
                     thumbnail_data = thumbnail_source.thumbnail_data
                 return mime_data, thumbnail_data
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -30,6 +30,7 @@ from nion.swift import MimeTypes
 from nion.swift import Panel
 from nion.swift import Thumbnails
 from nion.swift import Undo
+from nion.swift import Workspace
 from nion.swift.model import Changes
 from nion.swift.model import DataItem
 from nion.swift.model import DisplayInfo
@@ -148,7 +149,8 @@ class DisplayPanelOverlayCanvasItemComposer(CanvasItem.BaseComposer):
                  selected_style: str,
                  line_dash: typing.Optional[int],
                  selection_number: typing.Optional[int],
-                 get_font_metrics_fn: typing.Callable[[str, str], UISettings.FontMetrics]) -> None:
+                 get_font_metrics_fn: typing.Callable[[str, str], UISettings.FontMetrics],
+                 drag_items_split: tuple[int, int] | None = None) -> None:
         super().__init__(canvas_item, layout_sizing, cache)
         self.__drop_regions_map = drop_regions_map
         self.__drop_region = drop_region
@@ -159,6 +161,7 @@ class DisplayPanelOverlayCanvasItemComposer(CanvasItem.BaseComposer):
         self.__line_dash = line_dash
         self.__selection_number = selection_number
         self.__get_font_metrics_fn = get_font_metrics_fn
+        self.__drag_items_split = drag_items_split
 
     def _repaint(self, drawing_context: DrawingContext.DrawingContext, canvas_bounds: Geometry.IntRect, composer_cache: CanvasItem.ComposerCache) -> None:
         drop_regions_map = self.__drop_regions_map
@@ -197,6 +200,16 @@ class DisplayPanelOverlayCanvasItemComposer(CanvasItem.BaseComposer):
                         drawing_context.rect(0, 0, canvas_bounds.width, int(canvas_bounds.height * 0.10))
                     elif drop_region == "bottom":
                         drawing_context.rect(0, int(canvas_bounds.height * 0.90), canvas_bounds.width, int(canvas_bounds.height - canvas_bounds.height * 0.90))
+                    elif self.__drag_items_split and self.__drag_items_split != (1, 1):
+                        # Draw a grid of panels to preview what the split will look like
+                        gap = 4  # Each panel is separated by a gap of 4px
+                        horizontal, vertical = self.__drag_items_split
+                        # The panel width and height can be calculated as: n + 1 gaps + n panel widths equals the total canvas size which is rearranged to get the panel width/height
+                        panel_width = (canvas_bounds.width - (gap * (1 + horizontal))) / horizontal
+                        panel_height = (canvas_bounds.height - (gap * (1 + vertical))) / vertical
+                        for h in range(0, horizontal):
+                            for v in range(0, vertical):
+                                drawing_context.rect(gap + h * (gap + panel_width), gap + v * (gap + panel_height), panel_width, panel_height)
                     else:
                         drawing_context.rect(0, 0, canvas_bounds.width, canvas_bounds.height)
                     drawing_context.fill_style = "rgba(255, 0, 0, 0.10)"
@@ -244,6 +257,7 @@ class DisplayPanelOverlayCanvasItem(CanvasItem.AbstractCanvasItem):
         self.__line_dash: typing.Optional[int] = None
         self.__selection_number: typing.Optional[int] = None
         self.__get_font_metrics_fn = get_font_metrics_fn
+        self.__drag_items_split: tuple[int, int] | None = None
 
     @property
     def drop_regions_map(self) -> _DropRegionsMapType:
@@ -326,13 +340,23 @@ class DisplayPanelOverlayCanvasItem(CanvasItem.AbstractCanvasItem):
             self.__selection_number = value
             self.update()
 
+    @property
+    def drag_items_split(self) -> tuple[int, int] | None:
+        return self.__drag_items_split
+
+    @drag_items_split.setter
+    def drag_items_split(self, value: tuple[int, int] | None) -> None:
+        if self.__drag_items_split != value:
+            self.__drag_items_split = value
+            self.update()
+
     def _get_composer(self, composer_cache: CanvasItem.ComposerCache) -> typing.Optional[CanvasItem.BaseComposer]:
         return DisplayPanelOverlayCanvasItemComposer(self, self.layout_sizing, composer_cache,
                                                      self.__drop_regions_map, self.__drop_region,
                                                      self.__is_focused, self.__is_selected,
                                                      self.__focused_style, self.__selected_style,
                                                      self.__line_dash, self.__selection_number,
-                                                     self.__get_font_metrics_fn)
+                                                     self.__get_font_metrics_fn, self.__drag_items_split)
 
 
 class DisplayPanelOverlayCanvasItemComposition(CanvasItem.CanvasItemComposition):
@@ -443,6 +467,15 @@ class DisplayPanelOverlayCanvasItemComposition(CanvasItem.CanvasItemComposition)
 
     def _set_drop_region(self, drop_region: str) -> None:
         self.__set_drop_region(drop_region)
+
+    @property
+    def drag_items_split(self) -> tuple[int, int] | None:
+        return self.__display_panel_overlay_canvas_item.drag_items_split
+
+    @drag_items_split.setter
+    def drag_items_split(self, value: tuple[int, int] | None) -> None:
+        if self.__display_panel_overlay_canvas_item.drag_items_split != value:
+            self.__display_panel_overlay_canvas_item.drag_items_split = value
 
     def mouse_clicked(self, x: int, y: int, modifiers: UserInterface.KeyboardModifiers) -> bool:
         if super().mouse_clicked(x, y, modifiers):
@@ -1986,6 +2019,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             else:
                 self.__content_canvas_item.drop_regions_map = dict()
             if workspace_controller:
+                self.__content_canvas_item.drag_items_split = workspace_controller.get_split_for_selection(MimeTypes.mime_get_number_of_items(mime_data))
                 return workspace_controller.handle_drag_enter(self, mime_data)
             return "ignore"
 
@@ -2122,6 +2156,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 display_panel = self.__display_panel_ref()
                 if mime_data and display_panel:
                     display_panel.content_canvas_item.drag(mime_data, thumbnail_data)
+                    display_panel.content_canvas_item.drag_items_split = Workspace.Workspace.get_split_for_selection(MimeTypes.mime_get_number_of_items(mime_data))
                     return True
                 return False
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -204,7 +204,7 @@ class DisplayPanelOverlayCanvasItemComposer(CanvasItem.BaseComposer):
                         # Draw a grid of panels to preview what the split will look like
                         gap = 4  # Each panel is separated by a gap of 4px
                         horizontal, vertical = self.__drag_items_split
-                        # The panel width and height can be calculated as: n + 1 gaps + n panel widths equals the total canvas size which is rearranged to get the panel width/height
+                        # The panel width and height can be calculated as: n - 1 gaps + 2 border gaps + n panel widths equal the total canvas size which is rearranged to get the panel width/height
                         panel_width = (canvas_bounds.width - (gap * (1 + horizontal))) / horizontal
                         panel_height = (canvas_bounds.height - (gap * (1 + vertical))) / vertical
                         for h in range(0, horizontal):

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -2711,15 +2711,18 @@ class DocumentController(Window.Window):
             assert self.__old_workspace_layout is not None
             workspace_controller.reconstruct(self.__old_workspace_layout)
 
-    # receive files into the document model. data_group and index can optionally
-    # be specified. if data_group is specified, the item is added to an arbitrary
-    # position in the document model (the end) and at the group at the position
-    # specified by the index. if the data group is not specified, the item is added
-    # at the index within the document model.
-    def receive_files(self, files: typing.Sequence[str], data_group: typing.Optional[DataGroup.DataGroup] = None, index: int = -1) -> typing.Sequence[DisplayItem.DisplayItem]:
+    def receive_files(self, filepaths: typing.Sequence[str], data_group: typing.Optional[DataGroup.DataGroup] = None, index: int = -1) -> typing.Sequence[DisplayItem.DisplayItem]:
+        """Import files using the provided filepaths and add them to the document model.
+
+        data_group and index can optionally be specified.
+        If data_group is specified, the item is added to an arbitrary position in the document model (the end) and at the group at the position specified by the index.
+        If the data group is not specified, the item is added at the index within the document model.
+        The newly created display items are selected in the data panel.
+        Returns the display items created by importing the files.
+        """
         display_items = list[DisplayItem.DisplayItem]()
-        file_paths = [pathlib.Path(file_path) for file_path in files]
-        for file_index, file_path in enumerate(file_paths):
+        paths = [pathlib.Path(path) for path in filepaths]
+        for file_index, file_path in enumerate(paths):
             try:
                 document_model = self.document_model
                 project = document_model._project
@@ -2742,8 +2745,6 @@ class DocumentController(Window.Window):
                     loaded_data_item = project._load_data_item(data_item_properties)
                     if loaded_data_item:
                         data_items.append(loaded_data_item)
-                # keep a list of display items for bookkeeping.
-                display_items = list[DisplayItem.DisplayItem]()
                 for item_d in import_data.items:
                     if item_d.get("type") == "display_item":
                         # create a new display item and read it from the dictionary.

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -3838,8 +3838,7 @@ class CreateWorkspaceFromSelectionAction(WorkspaceNewAction):
         workspace_controller = window.workspace_controller
         assert workspace_controller is not None
         selection = list(window.selected_display_items)
-        split = Workspace.Workspace.get_split_for_selection(len(selection))
-        command = Workspace.CreateWorkspaceFromSelectionCommand(workspace_controller, text, selection, split)
+        command = Workspace.CreateWorkspaceFromSelectionCommand(workspace_controller, text, selection)
         command.perform()
         window.push_undo_command(command)
         return Window.ActionResult(Window.ActionStatus.FINISHED)

--- a/nion/swift/MimeTypes.py
+++ b/nion/swift/MimeTypes.py
@@ -145,3 +145,15 @@ def mime_data_put_panel(mime_data: UserInterface.MimeData, display_item: typing.
         d = dict(d)
         d["display_item_specifier"] = Persistence.write_persistent_specifier(display_item.uuid)
     mime_data.set_data_as_string(DISPLAY_PANEL_MIME_TYPE, json.dumps(d))
+
+
+def mime_get_number_of_items(mime_data: UserInterface.MimeData) -> int:
+    number_of_items = 0
+    if mime_data.has_format(DISPLAY_ITEMS_MIME_TYPE):
+        data_sources_mime_data = json.loads(mime_data.data_as_string(DISPLAY_ITEMS_MIME_TYPE))
+        number_of_items += len(data_sources_mime_data)
+    if mime_data.has_format(DISPLAY_ITEM_MIME_TYPE):
+        number_of_items += 1
+    if mime_data.file_paths:
+        number_of_items += len(mime_data.file_paths)
+    return number_of_items

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -86,23 +86,17 @@ class CreateWorkspaceCommand(Undo.UndoableCommand):
 class CreateWorkspaceFromSelectionCommand(CreateWorkspaceCommand):
     """Create a workspace, then split the panels and insert the selected display items."""
     def __init__(self, workspace_controller: Workspace, name: str,
-                 selection: list[DisplayItem.DisplayItem], layout_shape: tuple[int, int]) -> None:
+                 selection: list[DisplayItem.DisplayItem]) -> None:
         super().__init__(workspace_controller, name)
         self.__selection = selection
-        self.__layout_shape = layout_shape
         self.__workspace_controller = workspace_controller
 
     def _perform(self) -> None:
         super()._perform()
-        horizontal, vertical = self.__layout_shape
         # The newly created workspace will have one display panel which is the selected one
         selected_display_panel = self.__workspace_controller.document_controller.selected_display_panel
         assert selected_display_panel
-        # apply_layouts mutates the workspace_controller.display_panels so directly using it would cause recursion
-        display_panels = [selected_display_panel]
-        display_panels = self.__workspace_controller.apply_layouts(selected_display_panel, display_panels, horizontal, vertical)
-        for display_item, display_panel in zip(self.__selection, display_panels):  # Populate the display panels with the items
-            display_panel.set_display_item(display_item)
+        self.__workspace_controller.split_panel_and_insert_display_items(selected_display_panel, self.__selection)
 
 
 class RemoveWorkspaceCommand(Undo.UndoableCommand):
@@ -1051,7 +1045,7 @@ class Workspace:
         Depending on if the division of columns have ceil and floor applied first will affect the final split.
         Both are calculated and the one that will have the least unused panels is returned.
         """
-        if selection_count == 0:
+        if selection_count <= 1:
             return 1, 1
 
         ratio = 0.6
@@ -1070,6 +1064,14 @@ class Workspace:
             return columns_floor, rows_floor
 
         return columns_ceil, rows_ceil
+
+    def split_panel_and_insert_display_items(self, display_panel: DisplayPanel.DisplayPanel, display_items: typing.Sequence[DisplayItem.DisplayItem]) -> None:
+        """Split the display panel into a grid that fits the display items, then populate the new panels with the display items."""
+        horizontal, vertical = self.get_split_for_selection(len(display_items))
+        # apply_layouts mutates the workspace_controller.display_panels so directly using it would cause recursion
+        display_panels = self.apply_layouts(display_panel, [display_panel], horizontal, vertical)
+        for display_item, display_panel in zip(display_items, display_panels):  # Populate the display panels with the items
+            display_panel.set_display_item(display_item)
 
 
 class WorkspaceManager(metaclass=Utility.Singleton):

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -794,39 +794,40 @@ class Workspace:
         source_details: dict[str, typing.Any] | None = None
         source_display_item: DisplayItem.DisplayItem | None = None
         source_display_items: list[DisplayItem.DisplayItem] = list()
-        return_type = "copy"
+        return_type = "ignore"
         if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):
             source_display_item, source_details = MimeTypes.mime_data_get_panel(mime_data, self.document_model)
             return_type = "move"
         elif mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE):
             source_display_items = MimeTypes.mime_data_get_display_items(mime_data, self.document_model)
+            return_type = "copy"
         elif mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE):
             source_display_item = MimeTypes.mime_data_get_display_item(mime_data, self.document_model)
+            return_type = "copy"
         elif mime_data.has_format("text/uri-list"):
             index = len(self.document_model.data_items)
             display_items = self.document_controller.receive_files(list(reversed(mime_data.file_paths)), None, index)
             if len(display_items) == 1:
                 source_display_item = display_items[0]
+                return_type = "copy"
             elif len(display_items) > 1:
                 source_display_items = list(display_items)
+                return_type = "copy"
 
-        if source_display_item:
-            if destination_display_panel.handle_drop_display_item(region, source_display_item):
-                pass  # If handle_drop_display_item returns true then the drop was handled by the function
-            elif region == "right" or region == "left" or region == "top" or region == "bottom":
-                display_item = source_display_item if not source_details else None  # Prefer using the details over the display_item in the case of a panel drop
-                command = self.insert_display_panel(destination_display_panel, region, display_item, source_details)
-                self.document_controller.push_undo_command(command)
-            else:
-                command = self.__replace_displayed_display_item(destination_display_panel, source_display_item)
-                self.document_controller.push_undo_command(command)
-            return return_type
-        elif source_display_items:
-            command = ChangeWorkspaceContentsCommand(self, _("Split Display Panel"))
+        if source_display_items:
+            command: Undo.UndoableCommand = ChangeWorkspaceContentsCommand(self, _("Split Display Panel"))
             self.split_panel_and_insert_display_items(destination_display_panel, source_display_items)
             self.document_controller.push_undo_command(command)
-            return return_type
-        return "ignore"
+        elif source_display_item and destination_display_panel.handle_drop_display_item(region, source_display_item):
+            pass  # If handle_drop_display_item returns true then the drop was handled by the function
+        elif region == "right" or region == "left" or region == "top" or region == "bottom":
+            display_item = source_display_item if not source_details else None  # Prefer using the details over the display_item in the case of a panel drop
+            command = self.insert_display_panel(destination_display_panel, region, display_item, source_details)
+            self.document_controller.push_undo_command(command)
+        else:
+            command = self.__replace_displayed_display_item(destination_display_panel, source_display_item)
+            self.document_controller.push_undo_command(command)
+        return return_type
 
     def _replace_displayed_display_item(self, display_panel: DisplayPanel.DisplayPanel,
                                         display_item: typing.Optional[DisplayItem.DisplayItem],

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -761,6 +761,8 @@ class Workspace:
             return "copy"
         if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):
             return "copy"
+        if mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE):
+            return "copy"
         return "ignore"
 
     def handle_drag_leave(self, display_panel: DisplayPanel.DisplayPanel) -> str:
@@ -773,10 +775,12 @@ class Workspace:
             return "copy"
         if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):
             return "copy"
+        if mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE):
+            return "copy"
         return "ignore"
 
     def should_handle_drag_for_mime_data(self, mime_data: UserInterface.MimeData) -> bool:
-        return mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE) or mime_data.has_format("text/uri-list") or mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE)
+        return mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE) or mime_data.has_format("text/uri-list") or mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE) or mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE)
 
     def handle_drop(self, destination_display_panel: DisplayPanel.DisplayPanel, mime_data: UserInterface.MimeData, region: str, x: int, y: int) -> str:
         """Handle dropping a display panel, display item, or external file on a region of a display panel.
@@ -787,41 +791,41 @@ class Workspace:
         The replaced_display_panel_content is set on the "move" which will clear the source panel after the drop.
         Returns "move" on success when dragging a display panel, or "copy" on success when dragging a display item or an external file, or "ignore" if the drop was not handled.
         """
-        document_model = self.document_model
-        if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):  # Dragging a display panel
-            source_display_item, source_panel_details = MimeTypes.mime_data_get_panel(mime_data, self.document_model)
-            if source_display_item and destination_display_panel.handle_drop_display_item(region, source_display_item):  # See if the display panel handles dragging onto a layer
-                pass  # handle_drop_display_item already successfully handled the drop
-            elif region == "right" or region == "left" or region == "top" or region == "bottom":
-                command = self.insert_display_panel(destination_display_panel, region, None, source_panel_details)
-                self.document_controller.push_undo_command(command)
-            else:
-                command = self.__replace_displayed_display_item(destination_display_panel, None, source_panel_details)
-                self.document_controller.push_undo_command(command)
-            return "move"
-        source_display_item = MimeTypes.mime_data_get_display_item(mime_data, document_model)
-        if source_display_item:  # Dragging a display item
+        source_details: dict[str, typing.Any] | None = None
+        source_display_item: DisplayItem.DisplayItem | None = None
+        source_display_items: list[DisplayItem.DisplayItem] = list()
+        return_type = "copy"
+        if mime_data.has_format(MimeTypes.DISPLAY_PANEL_MIME_TYPE):
+            source_display_item, source_details = MimeTypes.mime_data_get_panel(mime_data, self.document_model)
+            return_type = "move"
+        elif mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE):
+            source_display_items = MimeTypes.mime_data_get_display_items(mime_data, self.document_model)
+        elif mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE):
+            source_display_item = MimeTypes.mime_data_get_display_item(mime_data, self.document_model)
+        elif mime_data.has_format("text/uri-list"):
+            index = len(self.document_model.data_items)
+            display_items = self.document_controller.receive_files(list(reversed(mime_data.file_paths)), None, index)
+            if len(display_items) == 1:
+                source_display_item = display_items[0]
+            elif len(display_items) > 1:
+                source_display_items = list(display_items)
+
+        if source_display_item:
             if destination_display_panel.handle_drop_display_item(region, source_display_item):
-                pass  # already handled
+                pass  # If handle_drop_display_item returns true then the drop was handled by the function
             elif region == "right" or region == "left" or region == "top" or region == "bottom":
-                command = self.insert_display_panel(destination_display_panel, region, source_display_item)
+                display_item = source_display_item if not source_details else None  # Prefer using the details over the display_item in the case of a panel drop
+                command = self.insert_display_panel(destination_display_panel, region, display_item, source_details)
                 self.document_controller.push_undo_command(command)
             else:
                 command = self.__replace_displayed_display_item(destination_display_panel, source_display_item)
                 self.document_controller.push_undo_command(command)
-            return "copy"
-        if mime_data.has_format("text/uri-list"):
-            index = len(document_model.data_items)
-            display_items = self.document_controller.receive_files(mime_data.file_paths, None, index)
-            display_item = display_items[0] if len(display_items) > 0 else None
-            if display_item:
-                if region == "right" or region == "left" or region == "top" or region == "bottom":
-                    command = self.insert_display_panel(destination_display_panel, region, display_item)
-                    self.document_controller.push_undo_command(command)
-                else:
-                    command = self.__replace_displayed_display_item(destination_display_panel, display_item)
-                    self.document_controller.push_undo_command(command)
-            return "copy"
+            return return_type
+        elif source_display_items:
+            command = ChangeWorkspaceContentsCommand(self, _("Split Display Panel"))
+            self.split_panel_and_insert_display_items(destination_display_panel, source_display_items)
+            self.document_controller.push_undo_command(command)
+            return return_type
         return "ignore"
 
     def _replace_displayed_display_item(self, display_panel: DisplayPanel.DisplayPanel,

--- a/nion/swift/Workspace.py
+++ b/nion/swift/Workspace.py
@@ -806,7 +806,7 @@ class Workspace:
             return_type = "copy"
         elif mime_data.has_format("text/uri-list"):
             index = len(self.document_model.data_items)
-            display_items = self.document_controller.receive_files(list(reversed(mime_data.file_paths)), None, index)
+            display_items = self.document_controller.receive_files(mime_data.file_paths, None, index)
             if len(display_items) == 1:
                 source_display_item = display_items[0]
                 return_type = "copy"


### PR DESCRIPTION
Fixes https://github.com/nion-software/nion-internal/issues/312. 
Requires https://github.com/nion-software/nionui/pull/137.
Adds the ability to split a display panel by dragging a selection of multiple items. This PR can be summarized in three parts: 
1. Fix the multi-drag code. 
2. Add a function in the workspace to split and insert items into a workspace adding this to the drag handler.
3. Add UI to draw a grid preview to show the user what the display panel split will look like after the split action.

