### PR TITLE
Fix bug with the anchor index of multiple selection

### DIFF
--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -338,9 +338,13 @@ class DataPanel(Panel.Panel):
                 elif len(display_items) > 1:
                     mime_data = document_controller.ui.create_mime_data()
                     MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    anchor_index = self.__selection.anchor_index or 0
-                    thumbnail_display_item = display_items[anchor_index]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, thumbnail_display_item)
+                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
+                    if display_item is None:
+                        if self.__selection.anchor_index is not None:
+                            display_item = self.__data_panel.document_controller.display_items_model.items[self.__selection.anchor_index]
+                        else:
+                            display_item = display_items[0]
+                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, display_item)
                     thumbnail_data = thumbnail_source.thumbnail_data
                 return mime_data, thumbnail_data
 

--- a/nion/swift/DataPanel.py
+++ b/nion/swift/DataPanel.py
@@ -53,6 +53,29 @@ _ = gettext.gettext
 """
 
 
+def get_mime_data_and_thumbnail_data(drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent,
+                                     ui: UserInterface.UserInterface) -> tuple[UserInterface.MimeData | None, _NDArray | None]:
+    display_item = typing.cast(DisplayItem.DisplayItem, drag_started_event.item)
+    assert display_item is not None
+    display_items = tuple(typing.cast(DisplayItem.DisplayItem, item) for item in drag_started_event.selected_items)
+    display_item = typing.cast(DisplayItem.DisplayItem, drag_started_event.item)
+    mime_data = ui.create_mime_data()
+    if len(display_items) <= 1:
+        MimeTypes.mime_data_put_display_item(mime_data, display_item)
+    else:
+        MimeTypes.mime_data_put_display_items(mime_data, display_items)
+
+    # Get and scale thumbnail
+    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(ui, display_item)
+    thumbnail_data = thumbnail_source.thumbnail_data
+
+    if thumbnail_data is not None:
+        scaled_view = Image.scaled(Image.get_rgba_view_from_rgba_data(thumbnail_data), tuple(Geometry.IntSize(w=80, h=80)))
+        thumbnail_data = Image.get_rgba_data_from_rgba(scaled_view)
+
+    return mime_data, thumbnail_data
+
+
 class DataPanelItemBaseCanvasItem(CanvasItem.AbstractCanvasItem):
     """Canvas item to draw a data panel list item.
 
@@ -304,7 +327,7 @@ class DataPanel(Panel.Panel):
                 return True
 
             def drag_started_event(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> bool:
-                mime_data, thumbnail_data = self._get_mime_data_and_thumbnail_data(drag_started_event)
+                mime_data, thumbnail_data = get_mime_data_and_thumbnail_data(drag_started_event, self.__data_panel.ui)
                 if mime_data:
                     self.__data_panel.widget.drag(mime_data, thumbnail_data)
                     return True
@@ -319,34 +342,6 @@ class DataPanel(Panel.Panel):
                     document_controller.select_display_items_in_data_panel(display_items)
                 return "accept"
 
-            def _get_mime_data_and_thumbnail_data(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> typing.Tuple[typing.Optional[UserInterface.MimeData], typing.Optional[_NDArray]]:
-                mime_data = None
-                thumbnail_data = None
-                display_item = typing.cast(DisplayItem.DisplayItem, drag_started_event.item)
-                display_items = tuple(
-                    typing.cast(DisplayItem.DisplayItem, item) for item in drag_started_event.selected_items)
-                if len(display_items) <= 1 and display_item is not None:
-                    mime_data = document_controller.ui.create_mime_data()
-                    MimeTypes.mime_data_put_display_item(mime_data, display_item)
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, display_item)
-                    thumbnail_data = thumbnail_source.thumbnail_data
-                    if thumbnail_data is not None:
-                        # scaling is very slow
-                        thumbnail_data = Image.get_rgba_data_from_rgba(
-                            Image.scaled(Image.get_rgba_view_from_rgba_data(thumbnail_data),
-                                         tuple(Geometry.IntSize(w=80, h=80))))
-                elif len(display_items) > 1:
-                    mime_data = document_controller.ui.create_mime_data()
-                    MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
-                    if display_item is None:
-                        if self.__selection.anchor_index is not None:
-                            display_item = self.__data_panel.document_controller.display_items_model.items[self.__selection.anchor_index]
-                        else:
-                            display_item = display_items[0]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__data_panel.ui, display_item)
-                    thumbnail_data = thumbnail_source.thumbnail_data
-                return mime_data, thumbnail_data
 
         item_delegate = ItemDelegate(self, self.__selection)
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2142,9 +2142,13 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 elif len(display_items) > 1:
                     mime_data = document_controller.ui.create_mime_data()
                     MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    anchor_index = self.__selection.anchor_index or 0
-                    thumbnail_display_item = display_items[anchor_index]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, thumbnail_display_item)
+                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
+                    if display_item is None:
+                        if self.__selection.anchor_index is not None:
+                            display_item = document_controller.display_items_model.items[self.__selection.anchor_index]
+                        else:
+                            display_item = display_items[0]
+                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, display_item)
                     thumbnail_data = thumbnail_source.thumbnail_data
                 return mime_data, thumbnail_data
 

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2118,39 +2118,13 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 return True
 
             def drag_started_event(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> bool:
-                mime_data, thumbnail_data = self._get_mime_data_and_thumbnail_data(drag_started_event)
+                mime_data, thumbnail_data = DataPanel.get_mime_data_and_thumbnail_data(drag_started_event, self.__ui)
                 display_panel = self.__display_panel_ref()
                 if mime_data and display_panel:
                     display_panel.content_canvas_item.drag(mime_data, thumbnail_data)
                     return True
                 return False
 
-            def _get_mime_data_and_thumbnail_data(self, drag_started_event: GridFlowCanvasItem.GridFlowCanvasItemDragStartedEvent) -> typing.Tuple[typing.Optional[UserInterface.MimeData], typing.Optional[_NDArray]]:
-                mime_data = None
-                thumbnail_data = None
-                display_item = typing.cast(DisplayItem.DisplayItem, drag_started_event.item)
-                display_items = tuple(typing.cast(DisplayItem.DisplayItem, item) for item in drag_started_event.selected_items)
-                if len(display_items) <= 1 and display_item is not None:
-                    mime_data = document_controller.ui.create_mime_data()
-                    MimeTypes.mime_data_put_display_item(mime_data, display_item)
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, display_item)
-                    thumbnail_data = thumbnail_source.thumbnail_data
-                    if thumbnail_data is not None:
-                        # scaling is very slow
-                        thumbnail_data = Image.get_rgba_data_from_rgba(
-                            Image.scaled(Image.get_rgba_view_from_rgba_data(thumbnail_data), tuple(Geometry.IntSize(w=80, h=80))))
-                elif len(display_items) > 1:
-                    mime_data = document_controller.ui.create_mime_data()
-                    MimeTypes.mime_data_put_display_items(mime_data, display_items)
-                    # Thumbnail preference order: The display item the drag started from, then the anchor item, then the first display item in the list
-                    if display_item is None:
-                        if self.__selection.anchor_index is not None:
-                            display_item = document_controller.display_items_model.items[self.__selection.anchor_index]
-                        else:
-                            display_item = display_items[0]
-                    thumbnail_source = Thumbnails.ThumbnailManager().thumbnail_source_for_display_item(self.__ui, display_item)
-                    thumbnail_data = thumbnail_source.thumbnail_data
-                return mime_data, thumbnail_data
 
             def key_pressed_event(self, key_event: GridFlowCanvasItem.GridFlowCanvasItemKeyPressedEvent) -> bool:
                 return key_pressed(key_event.key)

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -802,6 +802,40 @@ class TestDataPanelClass(unittest.TestCase):
             mime_data, thumbnail = data_panel._list_canvas_item._delegate._get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(display_item, [display_item], Geometry.IntPoint(), CanvasItem.KeyboardModifiers()))
             self.assertTrue(mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE))
 
+    def test_multi_drag_from_data_panel_has_correct_items_in_mime_data(self):
+        """Test that a drag started in the data panel with multiple selected items has all the expected items in the mime data.
+
+        The anchor index will be 2 for this configuration ensuring that _get_mime_data_and_thumbnail_data does not index into the selected_display_items list with the anchor index which would produce an index out of range.
+        """
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item_1 = DataItem.DataItem(numpy.zeros((4, 4)))
+            data_item_2 = DataItem.DataItem(numpy.zeros((4, 4)))
+            data_item_3 = DataItem.DataItem(numpy.zeros((4, 4)))
+            document_model.append_data_item(data_item_1)
+            document_model.append_data_item(data_item_2)
+            document_model.append_data_item(data_item_3)
+
+            data_panel = document_controller.find_dock_panel("data-panel")
+            project_panel = document_controller.find_dock_panel("collections-panel")
+
+            display_item_3 = document_model.get_display_item_for_data_item(data_item_3)
+            display_item_2 = document_model.get_display_item_for_data_item(data_item_2)
+            display_item_1 = document_model.get_display_item_for_data_item(data_item_1)
+            # The order of the display items means display_item_1 is index 2
+            self.assertEqual(document_controller.display_items_model.items, [display_item_3, display_item_2, display_item_1])
+            selected_display_items = [display_item_1, display_item_2]
+            # index, parent_row, parent_id
+            project_panel._collection_selection.set(1)
+            document_controller.periodic()
+            # display_item_1 is passed in first so the anchor index will be 2, which is greater than the number of items in the selection, if _get_mime_data_and_thumbnail_data indexed into the selection itself there would be an error
+            document_controller.select_display_items_in_data_panel(selected_display_items)
+            mime_data, thumbnail = data_panel._list_canvas_item._delegate._get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(None, selected_display_items, Geometry.IntPoint(), CanvasItem.KeyboardModifiers()))
+            self.assertTrue(mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE))
+            mime_data_display_items = MimeTypes.mime_data_get_display_items(mime_data, document_model)
+            self.assertEqual(mime_data_display_items, selected_display_items)
+
     def test_changing_filter_validates_data_browser_selection(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -818,6 +818,7 @@ class TestDataPanelClass(unittest.TestCase):
             document_model.append_data_item(data_item_3)
 
             data_panel = document_controller.find_dock_panel("data-panel")
+            assert data_panel is not None
             project_panel = document_controller.find_dock_panel("collections-panel")
 
             display_item_3 = document_model.get_display_item_for_data_item(data_item_3)
@@ -831,7 +832,7 @@ class TestDataPanelClass(unittest.TestCase):
             document_controller.periodic()
             # display_item_1 is passed in first so the anchor index will be 2, which is greater than the number of items in the selection, if _get_mime_data_and_thumbnail_data indexed into the selection itself there would be an error
             document_controller.select_display_items_in_data_panel(selected_display_items)
-            mime_data, thumbnail = data_panel._list_canvas_item._delegate._get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(None, selected_display_items, Geometry.IntPoint(), CanvasItem.KeyboardModifiers()))
+            mime_data, thumbnail = DataPanel.get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(selected_display_items[0], selected_display_items, Geometry.IntPoint(), CanvasItem.KeyboardModifiers()), data_panel.ui)
             self.assertTrue(mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE))
             mime_data_display_items = MimeTypes.mime_data_get_display_items(mime_data, document_model)
             self.assertEqual(mime_data_display_items, selected_display_items)

--- a/nion/swift/test/DataPanel_test.py
+++ b/nion/swift/test/DataPanel_test.py
@@ -799,13 +799,13 @@ class TestDataPanelClass(unittest.TestCase):
             project_panel._collection_selection.set(1)
             document_controller.periodic()
             document_controller.selected_display_panel.set_display_panel_display_item(display_item)
-            mime_data, thumbnail = data_panel._list_canvas_item._delegate._get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(display_item, [display_item], Geometry.IntPoint(), CanvasItem.KeyboardModifiers()))
+            mime_data, thumbnail = DataPanel.get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(display_item, [display_item], Geometry.IntPoint(), CanvasItem.KeyboardModifiers()), data_panel.ui)
             self.assertTrue(mime_data.has_format(MimeTypes.DISPLAY_ITEM_MIME_TYPE))
 
     def test_multi_drag_from_data_panel_has_correct_items_in_mime_data(self):
         """Test that a drag started in the data panel with multiple selected items has all the expected items in the mime data.
 
-        The anchor index will be 2 for this configuration ensuring that _get_mime_data_and_thumbnail_data does not index into the selected_display_items list with the anchor index which would produce an index out of range.
+        The anchor index will be 2 for this configuration ensuring that get_mime_data_and_thumbnail_data does not index into the selected_display_items list with the anchor index which would produce an index out of range.
         """
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()
@@ -830,7 +830,7 @@ class TestDataPanelClass(unittest.TestCase):
             # index, parent_row, parent_id
             project_panel._collection_selection.set(1)
             document_controller.periodic()
-            # display_item_1 is passed in first so the anchor index will be 2, which is greater than the number of items in the selection, if _get_mime_data_and_thumbnail_data indexed into the selection itself there would be an error
+            # display_item_1 is passed in first so the anchor index will be 2, which is greater than the number of items in the selection, if get_mime_data_and_thumbnail_data indexed into the selection itself there would be an error
             document_controller.select_display_items_in_data_panel(selected_display_items)
             mime_data, thumbnail = DataPanel.get_mime_data_and_thumbnail_data(ListCanvasItem.ListCanvasItem2DragStartedEvent(selected_display_items[0], selected_display_items, Geometry.IntPoint(), CanvasItem.KeyboardModifiers()), data_panel.ui)
             self.assertTrue(mime_data.has_format(MimeTypes.DISPLAY_ITEMS_MIME_TYPE))


### PR DESCRIPTION
Fixes #1891. The anchor index was being used as an index to the display items list but said list was not the list of all display items which meant that certain cases would cause it to be greater than the number of items. 