### PR TITLE
stylesheet for label visibility

### DIFF
--- a/nion/swift/ImageCanvasItem.py
+++ b/nion/swift/ImageCanvasItem.py
@@ -179,7 +179,16 @@ class GraphicsCanvasItemComposer(CanvasItem.BaseComposer):
                 drawing_context.translate(canvas_bounds.left, canvas_bounds.top)
                 for graphic_index, graphic_renderer in enumerate(graphic_renderers):
                     try:
-                        graphic_renderer.draw(drawing_context, ui_settings, widget_mapping, graphic_selection.contains(graphic_index), is_focused)
+                        graphic_state = Graphics.GraphicInteractionState(
+                            graphic_selection.contains(graphic_index),
+                            is_focused,
+                        )
+                        graphic_attributes = Graphics.GraphicAttributes(
+                            position_locked=graphic_renderer.is_position_locked,
+                            shape_locked=graphic_renderer.is_shape_locked,
+                            rotation_locked=graphic_renderer.is_rotation_locked,
+                        )
+                        graphic_renderer.draw(drawing_context, ui_settings, widget_mapping, graphic_state, graphic_attributes)
                     except Exception as e:
                         import traceback
                         logging.debug("Graphic Repaint Error: %s", e)

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -596,11 +596,11 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
                 return Geometry.FloatRect.from_tlhw(rect_top, rect_left, height, width)
 
-            def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str) -> None:
+            def _draw_label_with_background(label_text: str, label_x: float, label_y: float, text_align: str, text_baseline: str, background_color: str) -> None:
                 with drawing_context.saver():
                     drawing_context.text_baseline = text_baseline
                     drawing_context.text_align = text_align
-                    drawing_context.fill_style = self.text_background_color
+                    drawing_context.fill_style = background_color
                     label_rect = _get_text_rectangle(label_text, label_x, label_y, text_baseline, text_align)
 
                     # Draw the text background
@@ -656,23 +656,40 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
                     drawing_context.begin_path()
                     if region_selected:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), fill=selection_color, stroke=selection_color)
-                        drawing_context.font = self.font
-                        left_text = region.left_text
-                        right_text = region.right_text
-                        middle_text = region.middle_text
-                        if middle_text and region.style != "tag":
-                            _draw_label_with_background(middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom")
-                        drawing_context.fill_style = region_color
-                        if left_text:
-                            _draw_label_with_background(left_text, left - 5, level, "right", "middle")
-                        if right_text:
-                            _draw_label_with_background(right_text, right + 5, level, "left", "middle")
                     else:
                         draw_marker(drawing_context, Geometry.FloatPoint(level, mid_x), stroke=selection_color)
+                    drawing_context.font = self.font
+                    graphic_stylesheet = region.graphic_stylesheet
+                    graphic_type = region.graphic_type
+                    graphic_used_role = region.graphic_used_role
+                    graphic_state = region.graphic_state
+                    graphic_attributes = region.graphic_attributes
 
+                    label_visibility = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label"}, Graphics.PROP_VISIBILITY, graphic_state, graphic_attributes)
+                    width_label_visibility = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "width"}, Graphics.PROP_VISIBILITY, graphic_state, graphic_attributes)
+                    left_label_visibility = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "left"}, Graphics.PROP_VISIBILITY, graphic_state, graphic_attributes)
+                    right_label_visibility = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "right"}, Graphics.PROP_VISIBILITY, graphic_state, graphic_attributes)
+
+                    is_label_visible = Graphics.GraphicRenderer.is_label_visible(label_visibility, graphic_state.selected)
+                    is_width_label_visible = Graphics.GraphicRenderer.is_label_visible(width_label_visibility, graphic_state.selected)
+                    is_left_label_visible = Graphics.GraphicRenderer.is_label_visible(left_label_visibility, graphic_state.selected)
+                    is_right_label_visible = Graphics.GraphicRenderer.is_label_visible(right_label_visibility, graphic_state.selected)
+
+                    label_background_color = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label"}, Graphics.PROP_LABEL_BACKGROUND_COLOR, graphic_state, graphic_attributes) or self.text_background_color
+                    width_label_background_color = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "width"}, Graphics.PROP_LABEL_BACKGROUND_COLOR, graphic_state, graphic_attributes) or label_background_color
+                    left_label_background_color = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "left"}, Graphics.PROP_LABEL_BACKGROUND_COLOR, graphic_state, graphic_attributes) or label_background_color
+                    right_label_background_color = graphic_stylesheet.resolve(graphic_type, graphic_used_role, {"part": "label", "category": "details", "type": "right"}, Graphics.PROP_LABEL_BACKGROUND_COLOR, graphic_state, graphic_attributes) or label_background_color
+
+                    if region.middle_text and region.style != "tag" and is_width_label_visible:
+                        _draw_label_with_background(region.middle_text, mid_x, level - self.font_size_metric.height, "center", "bottom", width_label_background_color)
+                    drawing_context.fill_style = region_color
+                    if region.left_text and is_left_label_visible:
+                        _draw_label_with_background(region.left_text, left - 5, level, "right", "middle", left_label_background_color)
+                    if region.right_text and is_right_label_visible:
+                        _draw_label_with_background(region.right_text, right + 5, level, "left", "middle", right_label_background_color)
                     label = region.label
-                    if label:
-                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top")
+                    if label and is_label_visible:
+                        _draw_label_with_background(label, mid_x, level + self.font_size_metric.height, "center", "top", label_background_color)
                     drawing_context.close_path()
 
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -29,6 +29,7 @@ from nion.swift import MimeTypes
 from nion.swift import Undo
 from nion.swift.model import DisplayItem
 from nion.swift.model import DocumentModel
+from nion.swift.model import Graphics
 from nion.swift.model import LinePlotDisplay
 from nion.swift.model import UISettings
 from nion.swift.model import Utility
@@ -615,7 +616,7 @@ class LineGraphRegionsCanvasItemComposer(CanvasItem.BaseComposer):
 
             for region in regions:
                 left_channel, right_channel = region.channels
-                region_selected = region.selected
+                region_selected = region.graphic_state.selected
                 index = region.index
                 level = canvas_size.height - canvas_size.height * 0.8 + index * 8
                 with drawing_context.saver():

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -946,9 +946,14 @@ class Graphic(Persistence.PersistentObject):
             constraints.add("bounds")
         return constraints
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState) -> None:
         if not self._closed:
-            self.get_renderer().draw(ctx, ui_settings, mapping, is_selected, is_focused)
+            graphic_attributes = GraphicAttributes(
+                position_locked=self.is_position_locked,
+                shape_locked=self.is_shape_locked,
+                rotation_locked=self.is_rotation_locked,
+            )
+            self.get_renderer().draw(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def get_renderer(self) -> GraphicRenderer:
         raise NotImplementedError()
@@ -1265,26 +1270,53 @@ class GraphicRenderer:
     """
 
     def __init__(self, graphic: Graphic) -> None:
+        self.graphic_type = graphic.type
         self.graphic_uuid = graphic.uuid
         self.modified_count = graphic.modified_count
         self.stroke_color = graphic.stroke_color
-        self.used_stroke_style = graphic.used_stroke_style
-        self.used_stroke_width = graphic.used_stroke_width
-        self.used_fill_style = graphic.used_fill_style
+        self.stroke_width = graphic.stroke_width
+        self.fill_color = graphic.fill_color
+        self.used_role = graphic.used_role
+        self.is_shape_locked = graphic.is_shape_locked
+        self.is_position_locked = graphic.is_position_locked
+        self.is_rotation_locked = graphic.is_rotation_locked
         self.label = graphic.label
         self.label_padding = graphic.label_padding
         self.label_font = graphic.label_font
-        self.is_position_locked = graphic.is_position_locked
-        self.is_shape_locked = graphic.is_shape_locked
-        self.is_rotation_locked = graphic.is_rotation_locked
+        self.graphic_stylesheet = GraphicStylesheet.default()
+        default_interaction_state = GraphicInteractionState.default()
+        default_graphic_attributes = GraphicAttributes(
+            position_locked=self.is_position_locked,
+            shape_locked=self.is_shape_locked,
+            rotation_locked=self.is_rotation_locked,
+        )
+        # Keep these values for legacy call sites that do not pass style context.
+        self.used_stroke_style = self.resolve_shape_stroke_color(default_interaction_state, default_graphic_attributes)
+        self.used_stroke_width = self.resolve_shape_stroke_width(default_interaction_state, default_graphic_attributes)
+        self.used_fill_style = self.resolve_shape_fill_color(default_interaction_state, default_graphic_attributes)
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         raise NotImplementedError()
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         return None
 
-    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike) -> None:
+    def resolve_shape_stroke_color(self, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> str:
+        if self.stroke_color is not None:
+            return self.stroke_color
+        return self.graphic_stylesheet.resolve(self.graphic_type, self.used_role, {"part": "shape"}, PROP_STROKE_COLOR, graphic_state, graphic_attributes)
+
+    def resolve_shape_fill_color(self, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> str:
+        if self.fill_color is not None:
+            return self.fill_color
+        return self.graphic_stylesheet.resolve(self.graphic_type, self.used_role, {"part": "shape"}, PROP_FILL_COLOR, graphic_state, graphic_attributes)
+
+    def resolve_shape_stroke_width(self, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> float:
+        if self.stroke_width is not None:
+            return self.stroke_width
+        return self.graphic_stylesheet.resolve(self.graphic_type, self.used_role, {"part": "shape"}, PROP_STROKE_WIDTH, graphic_state, graphic_attributes)
+
+    def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         label = self.label
         if label:
             padding = self.label_padding
@@ -1305,7 +1337,7 @@ class GraphicRenderer:
                     ctx.close_path()
                     ctx.fill_style = "rgba(255, 255, 255, 0.6)"
                     ctx.fill()
-                    ctx.stroke_style = self.used_stroke_style
+                    ctx.stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
                     ctx.stroke()
                     ctx.font = font
                     ctx.text_baseline = "middle"
@@ -1328,7 +1360,7 @@ class MissingGraphic(Graphic):
 
 class MissingGraphicRenderer(GraphicRenderer):
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         pass
 
 
@@ -1557,15 +1589,17 @@ class RectangleGraphic(RectangleTypeGraphic):
 
 class RectangleGraphicRenderer(RectangleTypeGraphicRenderer):
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         bounds = self.bounds
         rotation = self.rotation
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        used_fill_style = self.used_fill_style
-        is_shape_locked = self.is_shape_locked
-        is_position_locked = self.is_position_locked
-        is_rotation_locked = self.is_rotation_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
+        is_position_locked = graphic_attributes.position_locked
+        is_rotation_locked = graphic_attributes.rotation_locked
         # origin is top left
         origin = mapping.map_point_image_norm_to_widget(bounds.origin)
         size = mapping.map_size_image_norm_to_widget(bounds.size)
@@ -1608,7 +1642,7 @@ class RectangleGraphicRenderer(RectangleTypeGraphicRenderer):
                 ctx.stroke_style = used_stroke_style
                 ctx.stroke()
                 draw_circular_marker(ctx, rotation_point, is_focused, is_rotation_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = Geometry.FloatRect.make(self.bounds)
@@ -1647,20 +1681,22 @@ class EllipseGraphic(RectangleTypeGraphic):
 
 class EllipseGraphicRenderer(RectangleTypeGraphicRenderer):
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         bounds = self.bounds
         rotation = self.rotation
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        used_fill_style = self.used_fill_style
-        is_shape_locked = self.is_shape_locked
-        is_position_locked = self.is_position_locked
-        is_rotation_locked = self.is_rotation_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
+        is_position_locked = graphic_attributes.position_locked
+        is_rotation_locked = graphic_attributes.rotation_locked
         # origin is top left
         center = mapping.map_point_image_norm_to_widget(bounds.center)
         size = mapping.map_size_image_norm_to_widget(bounds.size)
         draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style,  used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         bounds = self.bounds
@@ -1991,14 +2027,16 @@ class LineGraphic(LineTypeGraphic):
 
 class LineGraphicRenderer(LineTypeGraphicRenderer):
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         start = self.start
         end = self.end
         start_arrow_enabled = self.start_arrow_enabled
         end_arrow_enabled = self.end_arrow_enabled
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        is_shape_locked = self.is_shape_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
         p1 = mapping.map_point_image_norm_to_widget(start)
         p2 = mapping.map_point_image_norm_to_widget(end)
         with ctx.saver():
@@ -2015,7 +2053,7 @@ class LineGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
 
 class LineProfileGraphic(LineTypeGraphic):
@@ -2068,7 +2106,7 @@ class LineProfileGraphicRenderer(LineTypeGraphicRenderer):
         self.width = graphic.width
         self.interval_descriptors = copy.deepcopy(graphic.interval_descriptors)
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         start = self.start
         end = self.end
         start_arrow_enabled = self.start_arrow_enabled
@@ -2076,9 +2114,11 @@ class LineProfileGraphicRenderer(LineTypeGraphicRenderer):
         width = self.width
         interval_descriptors = self.interval_descriptors
         stroke_color = self.stroke_color
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        is_shape_locked = self.is_shape_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
         p1 = mapping.map_point_image_norm_to_widget(start)
         p2 = mapping.map_point_image_norm_to_widget(end)
         w = mapping.map_size_image_to_widget(Geometry.FloatSize(width=width)).width
@@ -2128,7 +2168,7 @@ class LineProfileGraphicRenderer(LineTypeGraphicRenderer):
         if is_selected:
             draw_marker(ctx, p1, is_focused, is_shape_locked)
             draw_marker(ctx, p2, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
 
 class PointTypeGraphic(Graphic):
@@ -2253,11 +2293,13 @@ class PointGraphicRenderer(PointTypeGraphicRenderer):
         super().__init__(graphic)
         self.cross_hair_size = graphic.cross_hair_size
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         position = self.position
         cross_hair_size = self.cross_hair_size
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
         p = mapping.map_point_image_norm_to_widget(position)
         with ctx.saver():
             ctx.begin_path()
@@ -2272,9 +2314,9 @@ class PointGraphicRenderer(PointTypeGraphicRenderer):
             ctx.line_to(p.x, p.y + cross_hair_size)
             ctx.line_width = used_stroke_width
             ctx.stroke_style = used_stroke_style
-            ctx.stroke_style = self.used_stroke_style
+            ctx.stroke_style = used_stroke_style
             ctx.stroke()
-            self.draw_label(ctx, ui_settings, mapping)
+            self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
         if is_selected:
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, cross_hair_size), is_focused, False)
             draw_marker(ctx, p + Geometry.FloatPoint(cross_hair_size, -cross_hair_size), is_focused, False)
@@ -2440,7 +2482,7 @@ class IntervalGraphicRenderer(GraphicRenderer):
         self.start = graphic.start
         self.end = graphic.end
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         pass
 
 
@@ -2451,6 +2493,7 @@ class ChannelGraphic(Graphic):
 
     def __init__(self) -> None:
         super().__init__("channel-graphic")
+        self._default_stroke_color = "#F00"
         self.title = _("Channel")
         # channel is stored in image normalized coordinates
         self.define_property("position", 0.5, changed=self._property_changed, validate=lambda value: float(value), hidden=True)
@@ -2524,7 +2567,7 @@ class ChannelGraphicRenderer(GraphicRenderer):
         super().__init__(graphic)
         self.position = graphic.position
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         pass
 
 
@@ -2725,15 +2768,17 @@ class SpotGraphicRenderer(GraphicRenderer):
         self.center = graphic.center
         self.size = graphic.size
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         bounds = self.bounds
         rotation = self.rotation
-        used_stroke_style = self.used_stroke_style
-        used_stroke_width = self.used_stroke_width
-        used_fill_style = self.used_fill_style
-        is_shape_locked = self.is_shape_locked
-        is_position_locked = self.is_position_locked
-        is_rotation_locked = self.is_rotation_locked
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
+        is_position_locked = graphic_attributes.position_locked
+        is_rotation_locked = graphic_attributes.rotation_locked
         # origin is top left
         origin = mapping.calibrated_origin_widget
         center = origin + mapping.map_size_image_norm_to_widget(bounds.center.as_size())
@@ -2744,7 +2789,7 @@ class SpotGraphicRenderer(GraphicRenderer):
             ctx.rotate(math.pi)
             ctx.translate(-origin.x, -origin.y)
             draw_ellipse_graphic(ctx, center, size, rotation, is_selected, is_focused, is_shape_locked, is_position_locked, is_rotation_locked, used_stroke_style, used_stroke_width, used_fill_style)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         center_widget = mapping.calibrated_origin_widget
@@ -2933,13 +2978,15 @@ class WedgeGraphicRenderer(GraphicRenderer):
         self.start_angle = graphic.start_angle
         self.end_angle = graphic.end_angle
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         start_angle = self.start_angle
         end_angle = self.end_angle
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        used_fill_style = self.used_fill_style
-        is_shape_locked = self.is_shape_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
         center = mapping.calibrated_origin_widget
         size = mapping.map_size_image_norm_to_widget(Geometry.FloatSize(1.0, 1.0))
         bounds = Geometry.FloatRect(Geometry.FloatPoint(), size) + mapping.map_point_image_norm_to_widget(Geometry.FloatPoint())
@@ -2985,7 +3032,7 @@ class WedgeGraphicRenderer(GraphicRenderer):
 
         if is_selected:
             draw_marker(ctx, center, is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -3137,14 +3184,16 @@ class RingGraphicRenderer(GraphicRenderer):
         self.radius_2 = graphic.radius_2
         self.mode = graphic.mode
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         radius_1 = self.radius_1
         radius_2 = self.radius_2
         mode = self.mode
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        used_fill_style = self.used_fill_style
-        is_shape_locked = self.is_shape_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
         # origin is top left
         center = mapping.calibrated_origin_widget
         bounds0 = mapping.map_point_image_norm_to_widget(Geometry.FloatPoint(0.0, 0.0))
@@ -3224,7 +3273,7 @@ class RingGraphicRenderer(GraphicRenderer):
                         ctx.line_to(x, y)
                 ctx.close_path()
                 ctx.fill()
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget
@@ -3477,15 +3526,17 @@ class LatticeGraphicRenderer(GraphicRenderer):
         self.v_pos = graphic.v_pos
         self.radius = graphic.radius
 
-    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, is_selected: bool, is_focused: bool) -> None:
+    def draw(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         u_pos = self.u_pos
         v_pos = self.v_pos
         radius = self.radius
-        used_stroke_width = self.used_stroke_width
-        used_stroke_style = self.used_stroke_style
-        used_fill_style = self.used_fill_style
-        is_position_locked = self.is_position_locked
-        is_shape_locked = self.is_shape_locked
+        used_stroke_width = self.resolve_shape_stroke_width(graphic_state, graphic_attributes)
+        used_stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
+        used_fill_style = self.resolve_shape_fill_color(graphic_state, graphic_attributes)
+        is_selected = graphic_state.selected
+        is_focused = graphic_state.focused
+        is_shape_locked = graphic_attributes.shape_locked
+        is_position_locked = graphic_attributes.position_locked
         start = mapping.calibrated_origin_image_norm
         u_pos = Geometry.FloatSize.make(u_pos)
         v_pos = Geometry.FloatSize.make(v_pos)
@@ -3542,7 +3593,7 @@ class LatticeGraphicRenderer(GraphicRenderer):
             draw_marker(ctx, v_pos_widget, is_focused, is_position_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(u_pos_widget, size_widget), is_focused, is_shape_locked)
             draw_rect_marker(ctx, Geometry.FloatRect.from_center_and_size(v_pos_widget, size_widget), is_focused, is_shape_locked)
-        self.draw_label(ctx, ui_settings, mapping)
+        self.draw_label(ctx, ui_settings, mapping, graphic_state, graphic_attributes)
 
     def label_position(self, mapping: CoordinateMappingLike, font_metrics: UISettings.FontMetrics, padding: float) -> typing.Optional[Geometry.FloatPoint]:
         p1 = mapping.calibrated_origin_widget

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -1001,6 +1001,254 @@ class Graphic(Persistence.PersistentObject):
         return False
 
 
+T = typing.TypeVar('T')
+
+
+class GraphicInteractionState:
+    """Transient UI state used while resolving style rules."""
+
+    def __init__(self, selected: bool = False, focused: bool = False) -> None:
+        self.selected = selected
+        self.focused = focused
+
+    @staticmethod
+    def default() -> GraphicInteractionState:
+        """Return the default interaction state (not selected and not focused)."""
+        return GraphicInteractionState(selected=False, focused=False)
+
+
+class GraphicAttributes:
+    """Persistent graphic attributes used while resolving style rules."""
+
+    def __init__(self, position_locked: bool = False, shape_locked: bool = False, rotation_locked: bool = False) -> None:
+        self.position_locked = position_locked
+        self.shape_locked = shape_locked
+        self.rotation_locked = rotation_locked
+
+    @staticmethod
+    def default() -> GraphicAttributes:
+        """Return the default attributes (no locks enabled)."""
+        return GraphicAttributes(position_locked=False, shape_locked=False, rotation_locked=False)
+
+
+class GraphicInteractionStateSelector:
+    """Selector constraints for GraphicInteractionState.
+
+    A field set to None is a wildcard and matches either True or False.
+    """
+
+    def __init__(self, selected: bool | None = None, focused: bool | None = None) -> None:
+        self.selected = selected
+        self.focused = focused
+
+    @staticmethod
+    def wildcard() -> GraphicInteractionStateSelector:
+        """Return a selector with no interaction-state constraints."""
+        return GraphicInteractionStateSelector()
+
+    def matches(self, graphic_state: GraphicInteractionState) -> bool:
+        """Return True if this selector matches the given interaction state."""
+        if self.selected is not None and self.selected != graphic_state.selected:
+            return False
+        if self.focused is not None and self.focused != graphic_state.focused:
+            return False
+        return True
+
+
+class GraphicAttributesSelector:
+    """Selector constraints for GraphicAttributes.
+
+    A field set to None is a wildcard and matches either True or False.
+    """
+
+    def __init__(self, position_locked: bool | None = None, shape_locked: bool | None = None, rotation_locked: bool | None = None) -> None:
+        self.position_locked = position_locked
+        self.shape_locked = shape_locked
+        self.rotation_locked = rotation_locked
+
+    @staticmethod
+    def wildcard() -> GraphicAttributesSelector:
+        """Return a selector with no attribute constraints."""
+        return GraphicAttributesSelector()
+
+    def matches(self, graphic_attributes: GraphicAttributes) -> bool:
+        """Return True if this selector matches the given graphic attributes."""
+        if self.position_locked is not None and self.position_locked != graphic_attributes.position_locked:
+            return False
+        if self.shape_locked is not None and self.shape_locked != graphic_attributes.shape_locked:
+            return False
+        if self.rotation_locked is not None and self.rotation_locked != graphic_attributes.rotation_locked:
+            return False
+        return True
+
+
+class GraphicStylePropertyKey(typing.Generic[T]):
+    def __init__(self, name: str, value_type: typing.Type[T], default: T):
+        self.name = name
+        self.value_type = value_type
+        self.default = default
+
+
+class GraphicStyleProperties:
+    """A type-safe bundle of graphical properties."""
+
+    def __init__(self) -> None:
+        self.__storage: dict[str, typing.Any] = {}
+
+    def has(self, key: GraphicStylePropertyKey[T]) -> bool:
+        return key.name in self.__storage
+
+    def get(self, key: GraphicStylePropertyKey[T]) -> T:
+        return typing.cast(T, self.__storage.get(key.name, key.default))
+
+    def set(self, key: GraphicStylePropertyKey[T], value: T) -> None:
+        if not isinstance(value, key.value_type):
+            raise TypeError(
+                f"Graphic property '{key.name}' requires type {key.value_type.__name__}, "
+                f"but received {type(value).__name__}."
+            )
+        self.__storage[key.name] = value
+
+
+# Built-in property keys. Stylesheet identifiers use dashes; Python names use underscores.
+PROP_STROKE_COLOR: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("stroke-color", str, "#F80")
+PROP_FILL_COLOR: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("fill-color", str, "")  # empty string = no fill
+PROP_STROKE_WIDTH: GraphicStylePropertyKey[float] = GraphicStylePropertyKey("stroke-width", float, 1.0)
+
+
+class GraphicStyleSelector:
+    """Matches a resolution context (graphic_type, role, part, interaction state, attributes).
+
+    Fields graphic_type, role, and part use None as a wildcard.
+    """
+
+    def __init__(
+        self,
+        graphic_type: str | None = None,
+        role: str | None = None,
+        part: str | None = None,
+        axes: dict[str, str] | None = None,
+        state_selector: GraphicInteractionStateSelector | None = None,
+        attributes_selector: GraphicAttributesSelector | None = None,
+    ) -> None:
+        self.graphic_type = graphic_type
+        self.role = role
+        self.part = part
+        self.axes = axes if axes is not None else dict()
+        self.state_selector = state_selector if state_selector is not None else GraphicInteractionStateSelector.wildcard()
+        self.attributes_selector = attributes_selector if attributes_selector is not None else GraphicAttributesSelector.wildcard()
+
+    def matches(self, graphic_type: str, role: str | None, part: str | None, state: GraphicInteractionState,
+                attributes: GraphicAttributes, axes: dict[str, str] | None = None) -> bool:
+        if self.graphic_type is not None and self.graphic_type != graphic_type:
+            return False
+        if self.role is not None and self.role != role:
+            return False
+        if self.part is not None and self.part != part:
+            return False
+        resolved_axes = axes if axes is not None else dict()
+        for axis_name, axis_value in self.axes.items():
+            if resolved_axes.get(axis_name) != axis_value:
+                return False
+        return self.state_selector.matches(state) and self.attributes_selector.matches(attributes)
+
+
+class GraphicStyleRule:
+    """A selector paired with a declaration (set of properties) and a source order."""
+
+    def __init__(self, selector: GraphicStyleSelector, declaration: GraphicStyleProperties, order: int = 0) -> None:
+        self.selector = selector
+        self.declaration = declaration
+        self.order = order
+
+
+class GraphicStylesheet:
+    """A list of style rules resolved against a graphic context.
+
+    Use ``resolve(graphic_type, role, part, key, state, attributes)`` to retrieve a typed property
+    value, where ``state`` is a ``GraphicInteractionState`` object capturing transient UI state
+    and ``attributes`` is a ``GraphicAttributes`` object capturing persistent lock attributes.
+
+    State and attributes are selector inputs that styling can react to,
+    but rules cannot set them. Source order controls precedence: last matching rule wins.
+
+    ``GraphicStylesheet.default()`` returns a stylesheet whose rules reproduce
+    the current hard-coded visibility and color behaviour.
+    """
+
+    def __init__(self, rules: list[GraphicStyleRule] | None = None) -> None:
+        self._rules: list[GraphicStyleRule] = rules if rules is not None else []
+
+    def resolve(
+        self,
+        graphic_type: str,
+        role: str | None,
+        selector_fragment: dict[str, str | None],
+        key: GraphicStylePropertyKey[T],
+        state: GraphicInteractionState,
+        attributes: GraphicAttributes,
+    ) -> T:
+        """Resolve *key* against a selector fragment.
+
+        Axes inside the fragment are unordered constraints.
+        """
+        result = key.default
+        fragment_part = selector_fragment.get("part")
+        fragment_axes = {k: v for k, v in selector_fragment.items() if k != "part" and v is not None}
+        for rule in self._rules:
+            if rule.selector.matches(graphic_type, role, fragment_part, state, attributes, fragment_axes) and rule.declaration.has(key):
+                result = rule.declaration.get(key)
+        return result
+
+    @staticmethod
+    def default() -> GraphicStylesheet:
+        """Return a stylesheet that encodes the current built-in defaults as explicit rules.
+
+        Rule mapping (reproduces existing hard-coded logic, last match wins):
+          graphic                                                        { visibility: always }
+          graphic                                                        { stroke-color: #F80; stroke-width: 1.0 }
+          interval-graphic::part(shape)                                  { stroke-color: #F00 }
+          channel-graphic::part(shape)                                   { stroke-color: #F00 }
+          graphic[role="mask"]::part(shape)                              { stroke-color: #00F; fill-color: rgba(0,0,255,0.1) }
+          graphic[role="fourier_mask"]::part(shape)                      { stroke-color: #F08; fill-color: rgba(255,0,127,0.1) }
+        """
+        rules: list[GraphicStyleRule] = []
+
+        # base default: all graphics, all parts are always visible
+        base_properties = GraphicStyleProperties()
+        rules.append(GraphicStyleRule(GraphicStyleSelector(), base_properties, order=1))
+
+        # base stroke/width defaults (matches Graphic._default_stroke_color and used_stroke_width)
+        base_shape_properties = GraphicStyleProperties()
+        base_shape_properties.set(PROP_STROKE_COLOR, "#F80")
+        base_shape_properties.set(PROP_STROKE_WIDTH, 1.0)
+        rules.append(GraphicStyleRule(GraphicStyleSelector(), base_shape_properties, order=1))
+
+        # interval-graphic shape default stroke color
+        interval_shape_properties = GraphicStyleProperties()
+        interval_shape_properties.set(PROP_STROKE_COLOR, "#F00")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(graphic_type="interval-graphic", part="shape"), interval_shape_properties, order=2))
+
+        # channel-graphic shape default stroke color
+        channel_shape_properties = GraphicStyleProperties()
+        channel_shape_properties.set(PROP_STROKE_COLOR, "#F00")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(graphic_type="channel-graphic", part="shape"), channel_shape_properties, order=2))
+
+        # mask role: blue stroke and semi-transparent fill
+        mask_shape_properties = GraphicStyleProperties()
+        mask_shape_properties.set(PROP_STROKE_COLOR, "#00F")
+        mask_shape_properties.set(PROP_FILL_COLOR, "rgba(0, 0, 255, 0.1)")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(role="mask", part="shape"), mask_shape_properties, order=2))
+
+        # fourier_mask role: magenta stroke and semi-transparent fill
+        fourier_mask_shape_properties = GraphicStyleProperties()
+        fourier_mask_shape_properties.set(PROP_STROKE_COLOR, "#F08")
+        fourier_mask_shape_properties.set(PROP_FILL_COLOR, "rgba(255, 0, 127, 0.1)")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(role="fourier_mask", part="shape"), fourier_mask_shape_properties, order=2))
+
+        return GraphicStylesheet(rules)
+
+
 class GraphicRenderer:
     """Drawing state for rendering a Graphic.
 

--- a/nion/swift/model/Graphics.py
+++ b/nion/swift/model/Graphics.py
@@ -1116,6 +1116,8 @@ class GraphicStyleProperties:
 
 
 # Built-in property keys. Stylesheet identifiers use dashes; Python names use underscores.
+PROP_VISIBILITY: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("visibility", str, "selection")
+PROP_LABEL_BACKGROUND_COLOR: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("label-background-color", str, "#99ffffff")
 PROP_STROKE_COLOR: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("stroke-color", str, "#F80")
 PROP_FILL_COLOR: GraphicStylePropertyKey[str] = GraphicStylePropertyKey("fill-color", str, "")  # empty string = no fill
 PROP_STROKE_WIDTH: GraphicStylePropertyKey[float] = GraphicStylePropertyKey("stroke-width", float, 1.0)
@@ -1216,11 +1218,16 @@ class GraphicStylesheet:
           channel-graphic::part(shape)                                   { stroke-color: #F00 }
           graphic[role="mask"]::part(shape)                              { stroke-color: #00F; fill-color: rgba(0,0,255,0.1) }
           graphic[role="fourier_mask"]::part(shape)                      { stroke-color: #F08; fill-color: rgba(255,0,127,0.1) }
+          interval-graphic::part(label)                                  { visibility: always; label-background-color: #99ffffff }
+          interval-graphic::part(label)[category="details"]             { visibility: selection }
+          interval-graphic[role="measurement"]::part(label)
+              [category="details"][type="width"]                       { visibility: always; label-background-color: white }
         """
         rules: list[GraphicStyleRule] = []
 
         # base default: all graphics, all parts are always visible
         base_properties = GraphicStyleProperties()
+        base_properties.set(PROP_VISIBILITY, "always")
         rules.append(GraphicStyleRule(GraphicStyleSelector(), base_properties, order=1))
 
         # base stroke/width defaults (matches Graphic._default_stroke_color and used_stroke_width)
@@ -1250,6 +1257,46 @@ class GraphicStylesheet:
         fourier_mask_shape_properties.set(PROP_STROKE_COLOR, "#F08")
         fourier_mask_shape_properties.set(PROP_FILL_COLOR, "rgba(255, 0, 127, 0.1)")
         rules.append(GraphicStyleRule(GraphicStyleSelector(role="fourier_mask", part="shape"), fourier_mask_shape_properties, order=2))
+
+        # interval-graphic base label defaults.
+        label_properties = GraphicStyleProperties()
+        label_properties.set(PROP_VISIBILITY, "always")
+        label_properties.set(PROP_LABEL_BACKGROUND_COLOR, "#99ffffff")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(graphic_type="interval-graphic", part="label"), label_properties, order=2))
+
+        # details labels inherit from label and default to selection visibility.
+        details_label_properties = GraphicStyleProperties()
+        details_label_properties.set(PROP_VISIBILITY, "selection")
+        rules.append(GraphicStyleRule(
+            GraphicStyleSelector(graphic_type="interval-graphic", part="label", axes={"category": "details"}),
+            details_label_properties,
+            order=3,
+        ))
+
+        # measurement role overrides details width labels: always visible, white.
+        measurement_properties = GraphicStyleProperties()
+        measurement_properties.set(PROP_VISIBILITY, "always")
+        measurement_properties.set(PROP_LABEL_BACKGROUND_COLOR, "white")
+        rules.append(GraphicStyleRule(
+            GraphicStyleSelector(
+                graphic_type="interval-graphic",
+                role="measurement",
+                part="label",
+                axes={"category": "details", "type": "width"},
+            ),
+            measurement_properties,
+            order=4,
+        ))
+
+        # interval-graphic shape default stroke color
+        measurement_interval_shape_properties = GraphicStyleProperties()
+        measurement_interval_shape_properties.set(PROP_STROKE_COLOR, "#8C5E00")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(graphic_type="interval-graphic", role="measurement", part="shape"), measurement_interval_shape_properties, order=4))
+
+        # interval-graphic shape default stroke color
+        measurement_interval_shape_properties = GraphicStyleProperties()
+        measurement_interval_shape_properties.set(PROP_STROKE_COLOR, "#8C5E00")
+        rules.append(GraphicStyleRule(GraphicStyleSelector(graphic_type="interval-graphic", role="measurement", part="shape"), measurement_interval_shape_properties, order=4))
 
         return GraphicStylesheet(rules)
 
@@ -1316,14 +1363,42 @@ class GraphicRenderer:
             return self.stroke_width
         return self.graphic_stylesheet.resolve(self.graphic_type, self.used_role, {"part": "shape"}, PROP_STROKE_WIDTH, graphic_state, graphic_attributes)
 
+    @staticmethod
+    def is_label_visible(text_visibility: str | None, is_selected: bool) -> bool:
+        """Return whether the label is visible based on the text visibility setting and if it is selected.
+
+        If the visibility is always then return true, if it is selection return the value of is_selected, otherwise return false.
+        """
+        if text_visibility == "always":
+            return True
+        elif text_visibility == "selection":
+            return is_selected
+        return False
+
     def draw_label(self, ctx: DrawingContextLike, ui_settings: UISettings.UISettings, mapping: CoordinateMappingLike, graphic_state: GraphicInteractionState, graphic_attributes: GraphicAttributes) -> None:
         label = self.label
-        if label:
+        label_visibility = self.graphic_stylesheet.resolve(
+            self.graphic_type,
+            self.used_role,
+            {"part": "label"},
+            PROP_VISIBILITY,
+            graphic_state,
+            graphic_attributes,
+        )
+        if label and self.is_label_visible(label_visibility, graphic_state.selected):
             padding = self.label_padding
             font = self.label_font
             font_metrics = ui_settings.get_font_metrics(font, label)
             text_pos = self.label_position(mapping, font_metrics, padding)
             if text_pos:
+                label_background_color = self.graphic_stylesheet.resolve(
+                    self.graphic_type,
+                    self.used_role,
+                    {"part": "label"},
+                    PROP_LABEL_BACKGROUND_COLOR,
+                    graphic_state,
+                    graphic_attributes,
+                )
                 with ctx.saver():
                     ctx.begin_path()
                     ctx.move_to(text_pos.x - font_metrics.width * 0.5 - padding,
@@ -1335,7 +1410,7 @@ class GraphicRenderer:
                     ctx.line_to(text_pos.x - font_metrics.width * 0.5 - padding,
                                 text_pos.y + font_metrics.height * 0.5 + padding)
                     ctx.close_path()
-                    ctx.fill_style = "rgba(255, 255, 255, 0.6)"
+                    ctx.fill_style = label_background_color
                     ctx.fill()
                     ctx.stroke_style = self.resolve_shape_stroke_color(graphic_state, graphic_attributes)
                     ctx.stroke()

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -25,7 +25,6 @@ from nion.utils import Geometry
 @dataclasses.dataclass
 class RegionInfo:
     channels: typing.Tuple[float, float]
-    selected: bool
     index: int
     left_text: str
     right_text: str
@@ -33,6 +32,11 @@ class RegionInfo:
     label: typing.Optional[str]
     style: typing.Optional[str]
     color: typing.Optional[str]
+    graphic_stylesheet: Graphics.GraphicStylesheet
+    graphic_type: str
+    graphic_used_role: str | None
+    graphic_state: Graphics.GraphicInteractionState
+    graphic_attributes: Graphics.GraphicAttributes
 
 
 def nice_label(value: float, precision: int) -> str:
@@ -487,6 +491,20 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                                                                                include_units=False))
 
                 for graphic_index, graphic_renderer in enumerate(graphic_renderers):
+                    graphic_state = Graphics.GraphicInteractionState(graphic_selection.contains(graphic_index), False)
+                    graphic_attributes = Graphics.GraphicAttributes(
+                        position_locked=graphic_renderer.is_position_locked,
+                        shape_locked=graphic_renderer.is_shape_locked,
+                        rotation_locked=graphic_renderer.is_rotation_locked,
+                    )
+                    graphic_color = graphic_renderer.graphic_stylesheet.resolve(
+                        graphic_renderer.graphic_type,
+                        graphic_renderer.used_role,
+                        {"part": "shape"},
+                        Graphics.PROP_STROKE_COLOR,
+                        graphic_state,
+                        graphic_attributes,
+                    )
                     if isinstance(graphic_renderer, Graphics.IntervalGraphicRenderer):
                         graphic_start, graphic_end = graphic_renderer.start, graphic_renderer.end
                         graphic_start, graphic_end = min(graphic_start, graphic_end), max(graphic_start, graphic_end)
@@ -496,9 +514,10 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         right_text = convert_to_calibrated_value_str(right_channel)
                         middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
                         region = RegionInfo((graphic_start, graphic_end),
-                                            graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, None, graphic_renderer.used_stroke_style)
+                                            graphic_renderer.label, None, graphic_color,
+                                            graphic_renderer.graphic_stylesheet, graphic_renderer.graphic_type,
+                                            graphic_renderer.used_role, graphic_state, graphic_attributes)
                         regions.append(region)
                     elif isinstance(graphic_renderer, Graphics.ChannelGraphicRenderer):
                         graphic_start, graphic_end = graphic_renderer.position, graphic_renderer.position
@@ -509,9 +528,10 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                         right_text = convert_to_calibrated_value_str(right_channel)
                         middle_text = convert_to_calibrated_size_str(right_channel - left_channel)
                         region = RegionInfo((graphic_start, graphic_end),
-                                            graphic_selection.contains(graphic_index),
                                             graphic_index, left_text, right_text, middle_text,
-                                            graphic_renderer.label, "tag", graphic_renderer.used_stroke_style)
+                                            graphic_renderer.label, "tag", graphic_color,
+                                            graphic_renderer.graphic_stylesheet, graphic_renderer.graphic_type,
+                                            graphic_renderer.used_role, graphic_state, graphic_attributes)
                         regions.append(region)
             self.__regions = regions
         return self.__regions or list()

--- a/nion/swift/test/Graphics_test.py
+++ b/nion/swift/test/Graphics_test.py
@@ -1764,6 +1764,294 @@ class TestGraphicsClass(unittest.TestCase):
             self.assertEqual(mask[5, 2], 1.0) # inbetween radius
             self.assertEqual(mask[0, 0], 0.0) # outside outer
 
+
+# Focused unit tests for stylesheet rule resolution and typed style properties.
+class TestGraphicStylesheetClass(unittest.TestCase):
+
+    def setUp(self):
+        TestContext.begin_leaks()
+        self._test_setup = TestContext.TestSetup()
+
+    def tearDown(self):
+        self._test_setup = typing.cast(typing.Any, None)
+        TestContext.end_leaks(self)
+
+    def test_style_properties_returns_property_default_when_missing(self):
+        properties = Graphics.GraphicStyleProperties()
+        self.assertEqual(properties.get(Graphics.PROP_STROKE_COLOR), "#F80")
+
+    def test_style_properties_set_get_and_has(self):
+        properties = Graphics.GraphicStyleProperties()
+        properties.set(Graphics.PROP_STROKE_WIDTH, 2.5)
+        self.assertTrue(properties.has(Graphics.PROP_STROKE_WIDTH))
+        self.assertEqual(properties.get(Graphics.PROP_STROKE_WIDTH), 2.5)
+
+    def test_style_properties_set_rejects_wrong_type(self):
+        properties = Graphics.GraphicStyleProperties()
+        with self.assertRaises(TypeError):
+            properties.set(Graphics.PROP_STROKE_WIDTH, "2.5")
+
+    def test_stylesheet_resolve_returns_key_default_when_no_rule_matches(self):
+        stylesheet = Graphics.GraphicStylesheet([])
+        value = stylesheet.resolve(
+            "interval-graphic",
+            "measurement",
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(value, "#F80")
+
+    def test_stylesheet_resolve_last_matching_rule_wins(self):
+        first_properties = Graphics.GraphicStyleProperties()
+        first_properties.set(Graphics.PROP_STROKE_COLOR, "#111")
+        second_properties = Graphics.GraphicStyleProperties()
+        second_properties.set(Graphics.PROP_STROKE_COLOR, "#222")
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="shape"), first_properties),
+            Graphics.GraphicStyleRule(Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="shape"), second_properties),
+        ])
+        value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(value, "#222")
+
+    def test_stylesheet_resolve_applies_state_selector(self):
+        # A rule that only fires when selected=True changes the stroke color.
+        selected_properties = Graphics.GraphicStyleProperties()
+        selected_properties.set(Graphics.PROP_STROKE_COLOR, "#FF0000")
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(
+                    graphic_type="interval-graphic",
+                    part="shape",
+                    state_selector=Graphics.GraphicInteractionStateSelector(selected=True),
+                ),
+                selected_properties,
+            )
+        ])
+        unselected_value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState(selected=False),
+            Graphics.GraphicAttributes.default(),
+        )
+        selected_value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState(selected=True),
+            Graphics.GraphicAttributes.default(),
+        )
+        # Unselected: no rule fires, so key default is returned.
+        self.assertEqual(unselected_value, "#F80")
+        # Selected: matching rule fires.
+        self.assertEqual(selected_value, "#FF0000")
+
+    def test_stylesheet_resolve_applies_attributes_selector(self):
+        locked_properties = Graphics.GraphicStyleProperties()
+        locked_properties.set(Graphics.PROP_STROKE_WIDTH, 3.0)
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(
+                    graphic_type="interval-graphic",
+                    part="shape",
+                    attributes_selector=Graphics.GraphicAttributesSelector(shape_locked=True),
+                ),
+                locked_properties,
+            )
+        ])
+        unlocked_value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_WIDTH,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes(shape_locked=False),
+        )
+        locked_value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_WIDTH,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes(shape_locked=True),
+        )
+        self.assertEqual(unlocked_value, 1.0)
+        self.assertEqual(locked_value, 3.0)
+
+    def test_stylesheet_resolve_uses_ordered_fragments(self):
+        base_properties = Graphics.GraphicStyleProperties()
+        base_properties.set(Graphics.PROP_STROKE_WIDTH, 1.1)
+        details_properties = Graphics.GraphicStyleProperties()
+        details_properties.set(Graphics.PROP_STROKE_WIDTH, 2.2)
+        width_properties = Graphics.GraphicStyleProperties()
+        width_properties.set(Graphics.PROP_STROKE_WIDTH, 3.3)
+        details_width_properties = Graphics.GraphicStyleProperties()
+        details_width_properties.set(Graphics.PROP_STROKE_WIDTH, 4.4)
+
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="label"),
+                base_properties,
+                order=1,
+            ),
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="label", axes={"category": "details"}),
+                details_properties,
+                order=2,
+            ),
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="label", axes={"type": "width"}),
+                width_properties,
+                order=3,
+            ),
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="label", axes={"category": "details", "type": "width"}),
+                details_width_properties,
+                order=4,
+            ),
+        ])
+
+        # Test that the most specific rule matches (category + type)
+        stroke_width = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "label", "category": "details", "type": "width"},
+            Graphics.PROP_STROKE_WIDTH,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(stroke_width, 4.4)
+
+    def test_stylesheet_selector_axes_dict_order_does_not_matter(self):
+        properties = Graphics.GraphicStyleProperties()
+        properties.set(Graphics.PROP_FILL_COLOR, "rgba(171, 205, 239, 0.5)")
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(
+                    graphic_type="interval-graphic",
+                    part="label",
+                    axes={"category": "details", "type": "width"},
+                ),
+                properties,
+            )
+        ])
+        fill_color = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "label", "type": "width", "category": "details"},
+            Graphics.PROP_FILL_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(fill_color, "rgba(171, 205, 239, 0.5)")
+
+    def test_stylesheet_role_specific_shape_stroke_width_uses_fragment_axes(self):
+        base_properties = Graphics.GraphicStyleProperties()
+        base_properties.set(Graphics.PROP_STROKE_WIDTH, 1.5)
+        details_properties = Graphics.GraphicStyleProperties()
+        details_properties.set(Graphics.PROP_STROKE_WIDTH, 2.5)
+        measurement_details_width_properties = Graphics.GraphicStyleProperties()
+        measurement_details_width_properties.set(Graphics.PROP_STROKE_WIDTH, 4.5)
+
+        stylesheet = Graphics.GraphicStylesheet([
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="shape"),
+                base_properties,
+                order=1,
+            ),
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(graphic_type="interval-graphic", part="shape", axes={"category": "details"}),
+                details_properties,
+                order=2,
+            ),
+            Graphics.GraphicStyleRule(
+                Graphics.GraphicStyleSelector(
+                    graphic_type="interval-graphic",
+                    role="measurement",
+                    part="shape",
+                    axes={"category": "details", "type": "width"},
+                ),
+                measurement_details_width_properties,
+                order=3,
+            ),
+        ])
+
+        measurement_stroke_width = stylesheet.resolve(
+            "interval-graphic",
+            "measurement",
+            {"part": "shape", "category": "details", "type": "width"},
+            Graphics.PROP_STROKE_WIDTH,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        non_measurement_stroke_width = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape", "category": "details", "type": "width"},
+            Graphics.PROP_STROKE_WIDTH,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+
+        self.assertEqual(measurement_stroke_width, 4.5)
+        self.assertEqual(non_measurement_stroke_width, 2.5)
+
+    def test_default_stylesheet_interval_shape_overrides_base_stroke_color(self):
+        # A type-specific rule (interval-graphic + shape) overrides the base wildcard rule.
+        stylesheet = Graphics.GraphicStylesheet.default()
+        # Base rule sets #F80; interval-graphic/shape rule overrides to #F00.
+        interval_value = stylesheet.resolve(
+            "interval-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        # A graphic type with no specific rule falls back to the base #F80.
+        other_value = stylesheet.resolve(
+            "rect-graphic",
+            None,
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(interval_value, "#F00")
+        self.assertEqual(other_value, "#F80")
+
+    def test_default_stylesheet_mask_shape_colors(self):
+        stylesheet = Graphics.GraphicStylesheet.default()
+        stroke_color = stylesheet.resolve(
+            "spot-graphic",
+            "mask",
+            {"part": "shape"},
+            Graphics.PROP_STROKE_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        fill_color = stylesheet.resolve(
+            "spot-graphic",
+            "mask",
+            {"part": "shape"},
+            Graphics.PROP_FILL_COLOR,
+            Graphics.GraphicInteractionState.default(),
+            Graphics.GraphicAttributes.default(),
+        )
+        self.assertEqual(stroke_color, "#00F")
+        self.assertEqual(fill_color, "rgba(0, 0, 255, 0.1)")
+
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
- **Introduce GraphicStylesheet, default stylesheet, and tests.**
- **Integrate GraphicStylesheet into graphic rendering.**
- **Add properties for the text background and visibility.**

This PR introduces a stylesheet system for graphics. It is as close to possible to a CSS style system, but customized for use in this application.

How to review:
- The first commit (introduce stylesheet) stands alone and should be reviewed to see the gist of the system.
- The second commit builds on the first commit and uses it in limited cases in the existing code. No functionality change at this point.
- The third commit is https://github.com/nion-software/nionswift/pull/1883 modified to run on top of stylesheets.

The benefit here is an extendible system of styles that can be used for most properties of most graphics. There is a selector system (CSS) that can select based on graphic type, graphic category, part, some graphic properties, and some user state (focused, selected, etc.). The second commit makes the modifications to `draw` methods and similar to make sure the ability to resolve styles is available to rendering/composer code while still being immutable.

I expect the first two commits to be merged with this PR, but the third commit may be merged as part of #1883 if we decide to go this direction.

This PR implements a portion of
- https://github.com/nion-software/nionswift/issues/1673.
