### PR TITLE
storage system cleanup

### DIFF
--- a/nion/swift/Facade.py
+++ b/nion/swift/Facade.py
@@ -2606,7 +2606,7 @@ class Library(metaclass=SharedInstance):
         data_item_reference = document_model.get_data_item_reference(data_item_reference_key)
         data_item = data_item_reference.data_item
         if data_item is None and create_if_needed:
-            data_item = DataItemModule.DataItem(large_format=large_format)
+            data_item = DataItemModule.DataItem()
             document_model.append_data_item(data_item)
             document_model.setup_channel(data_item_reference_key, data_item)
             data_item.session_id = document_model.session_id

--- a/nion/swift/RecorderPanel.py
+++ b/nion/swift/RecorderPanel.py
@@ -174,7 +174,7 @@ class Recorder:
                 self.__recording_last = current_time
                 # first create an empty data item to hold the recorded data if it doesn't already exist
                 if not self.__recording_data_item:
-                    data_item = DataItem.DataItem(large_format=True)
+                    data_item = DataItem.DataItem()
                     display_item = self.__document_controller.document_model.get_best_display_item_for_data_item(self.__data_item)
                     assert display_item
                     data_item.title = display_item.displayed_title + " (" + _("Recording") + ")"

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -677,11 +677,6 @@ class DataItem(Persistence.PersistentObject):
             self.dynamic_title = dynamic_string
 
     @property
-    def properties(self) -> typing.Optional[Persistence.PersistentDictType]:
-        """ Used for debugging. """
-        return self.get_storage_properties()
-
-    @property
     def is_live(self) -> bool:
         """Return whether this library item represents live acquisition."""
         return self.__is_live

--- a/nion/swift/model/DataItem.py
+++ b/nion/swift/model/DataItem.py
@@ -184,11 +184,9 @@ class DataItem(Persistence.PersistentObject):
     storage_version = 13
     writer_version = 13
 
-    def __init__(self, data: typing.Optional[_ImageDataType] = None, item_uuid: typing.Optional[uuid.UUID] = None,
-                 large_format: bool = False) -> None:
+    def __init__(self, data: typing.Optional[_ImageDataType] = None, item_uuid: typing.Optional[uuid.UUID] = None, large_format: bool = False) -> None:
         super().__init__()
         self.uuid = item_uuid if item_uuid else self.uuid
-        self.large_format = large_format
         self._document_model: typing.Optional[DocumentModel.DocumentModel] = None  # used only for Facade
         self.define_type("data-item")
         self.define_property("created", DateTime.utcnow(), hidden=True, converter=DatetimeToStringConverter(), changed=self.__description_property_changed)
@@ -329,8 +327,6 @@ class DataItem(Persistence.PersistentObject):
     def __deepcopy__(self, memo: typing.Dict[typing.Any, typing.Any]) -> DataItem:
         data_item_copy = self.__class__()
         try:
-            # data format (temporary until moved to buffered data source)
-            data_item_copy.large_format = self.large_format
             # metadata
             data_item_copy.created = self.created
             data_item_copy.timezone = self.timezone
@@ -586,7 +582,6 @@ class DataItem(Persistence.PersistentObject):
         return self.__get_file_path()
 
     def read_from_dict(self, properties: Persistence.PersistentDictType) -> None:
-        self.large_format = properties.get("__large_format", self.large_format)
         # when reading, handle changes specially. first, put everything into a change
         # block; then make sure that no change notifications actually occur. this makes
         # sure things like cached values are preserved after reading.
@@ -1471,7 +1466,7 @@ class DataItem(Persistence.PersistentObject):
 
 def new_data_item(data_and_metadata_in: typing.Optional[DataAndMetadata._DataAndMetadataLike] = None) -> DataItem:
     data_and_metadata = DataAndMetadata.promote_ndarray(data_and_metadata_in) if data_and_metadata_in is not None else None
-    data_item = DataItem(large_format=len(data_and_metadata.dimensional_shape) > 2 if data_and_metadata else False)
+    data_item = DataItem()
     data_item.set_xdata(data_and_metadata)
     return data_item
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -2606,13 +2606,6 @@ class DisplayItem(Persistence.PersistentObject):
             self._get_persistent_property("created").value = timestamp
 
     @property
-    def properties(self) -> typing.Optional[Persistence.PersistentDictType]:
-        """ Used for debugging. """
-        if self.persistent_object_context:
-            return self.get_storage_properties()
-        return dict()
-
-    @property
     def in_transaction_state(self) -> bool:
         return self.__in_transaction_state
 

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -47,12 +47,10 @@ class ReaderInfo:
     def __init__(self,
                  properties: PersistentDictType,
                  changed_ref: typing.List[bool],
-                 large_format: bool,
                  storage_handler: StorageHandler.StorageHandler,
                  identifier: str) -> None:
         self.properties = properties
         self.changed_ref = changed_ref
-        self.large_format = large_format
         self.storage_handler = storage_handler
         self.identifier = identifier
 
@@ -102,8 +100,6 @@ class MigrationReader(typing.Protocol):
 
     def _find_data_items(self, migration_stage: ProjectStorageSystemMigrationStage) -> typing.Sequence[StorageHandler.StorageHandler]: ...
 
-    def _is_storage_handler_large_format(self, storage_handler: StorageHandler.StorageHandler) -> bool: ...
-
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType: ...
 
 
@@ -145,11 +141,10 @@ def migrate_to_latest(source_project_storage_system: MigrationReader,
         preliminary_reader_info_list: typing.List[ReaderInfo] = list()
         for storage_handler in storage_handlers:
             try:
-                large_format = source_project_storage_system._is_storage_handler_large_format(storage_handler)
                 storage_handler_properties = storage_handler.read_properties()
                 assert storage_handler_properties is not None
                 properties = Migration.transform_to_latest(storage_handler_properties)
-                reader_info = ReaderInfo(properties, [False], large_format, storage_handler, storage_handler.reference)
+                reader_info = ReaderInfo(properties, [False], storage_handler, storage_handler.reference)
                 preliminary_reader_info_list.append(reader_info)
             except Exception:
                 storage_handler.close()
@@ -551,7 +546,7 @@ def make_storage_handler_attributes(data_item: DataItem.DataItem, n_bytes_overri
     dimensional_shape = data_item.dimensional_shape
     data_dtype = data_item.data_dtype
     n_bytes = n_bytes_override if n_bytes_override is not None else typing.cast(int, numpy.prod(dimensional_shape, dtype=numpy.int64)) * numpy.dtype(data_dtype).itemsize
-    return StorageHandler.StorageHandlerAttributes(data_item.uuid, data_item.created_local, data_item.session_id, n_bytes, data_item.large_format)
+    return StorageHandler.StorageHandlerAttributes(data_item.uuid, data_item.created_local, data_item.session_id, n_bytes)
 
 
 class ProjectStorageSystem(PersistentStorageSystem):
@@ -594,9 +589,6 @@ class ProjectStorageSystem(PersistentStorageSystem):
 
     @abc.abstractmethod
     def _find_data_items(self, migration_stage: ProjectStorageSystemMigrationStage) -> typing.Sequence[StorageHandler.StorageHandler]: ...
-
-    @abc.abstractmethod
-    def _is_storage_handler_large_format(self, storage_handler: StorageHandler.StorageHandler) -> bool: ...
 
     @abc.abstractmethod
     def _migrate_data_item(self, reader_info: ReaderInfo, index: int, count: int) -> typing.Optional[ReaderInfo]: ...
@@ -656,13 +648,12 @@ class ProjectStorageSystem(PersistentStorageSystem):
         reader_error_list = list()
         for storage_handler in storage_handlers:
             try:
-                large_format = self._is_storage_handler_large_format(storage_handler)
                 storage_handler_properties = storage_handler.read_properties()
                 storage_handler.prepare_move()
                 assert storage_handler_properties is not None
                 properties = Migration.transform_to_latest(storage_handler_properties)
                 assert properties.get("uuid")
-                reader_info = ReaderInfo(properties, [False], large_format, storage_handler, storage_handler.reference)
+                reader_info = ReaderInfo(properties, [False], storage_handler, storage_handler.reference)
                 reader_info_list.append(reader_info)
             except Exception as e:
                 reader_error_list.append(Persistence.ReaderError(storage_handler.reference, e, traceback.extract_stack()))
@@ -691,7 +682,6 @@ class ProjectStorageSystem(PersistentStorageSystem):
         for reader_info in reader_info_list:
             data_item_properties = reader_info.properties if reader_info.properties else dict()
             if data_item_properties.get("version", 0) == DataItem.DataItem.writer_version:
-                data_item_properties["__large_format"] = reader_info.large_format
                 properties_copy.setdefault("data_items", list()).append(data_item_properties)
 
         def data_item_created(data_item_properties: PersistentDictType) -> str:
@@ -917,7 +907,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
     def _get_storage_handler_factory(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes) -> StorageHandler.StorageHandlerFactoryLike:
         # if there are two handlers, first is small, second is large
         # if there is only one handler, it is used in all cases
-        is_large_format = storage_handler_attributes.n_bytes > _g_large_format_size or storage_handler_attributes._force_large_format
+        is_large_format = storage_handler_attributes.n_bytes > _g_large_format_size
         return self._file_handler_factories[-1] if is_large_format else self._file_handler_factories[0]
 
     def _make_storage_handler(self, storage_handler_attributes: StorageHandler.StorageHandlerAttributes, file_handler_factory: typing.Optional[StorageHandler.StorageHandlerFactoryLike] = None) -> StorageHandler.StorageHandler:
@@ -927,9 +917,6 @@ class FileProjectStorageSystem(ProjectStorageSystem):
 
     def _find_storage_handlers(self) -> typing.Sequence[StorageHandler.StorageHandler]:
         return self.__find_storage_handlers(self.__project_data_path)
-
-    def _is_storage_handler_large_format(self, storage_handler: StorageHandler.StorageHandler) -> bool:
-        return isinstance(storage_handler, HDF5Handler.HDF5Handler)
 
     def _remove_storage_handler(self, storage_handler: StorageHandler.StorageHandler, *, safe: bool = False) -> None:
         assert self.__project_data_path is not None
@@ -971,7 +958,6 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                             os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
                             shutil.move(old_file_path, new_file_path)
                         self._make_storage_handler(make_storage_handler_attributes(data_item)).close()  # what's this line for?
-                        properties["__large_format"] = isinstance(storage_handler, HDF5Handler.HDF5Handler)
                         return properties
         finally:
             for storage_handler in storage_handlers:
@@ -1016,8 +1002,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                     shutil.copystat(storage_handler.reference, target_storage_handler.reference)
                     target_storage_handler.write_properties(Migration.transform_from_latest(copy.deepcopy(properties)), datetime.datetime.now())
                     logging.getLogger("migration").info(f"Copying data item ({index + 1}/{count}) {data_item_uuid} to new library.")
-                    return ReaderInfo(properties, [False], self._is_storage_handler_large_format(target_storage_handler),
-                                      target_storage_handler, target_storage_handler.reference)
+                    return ReaderInfo(properties, [False], target_storage_handler, target_storage_handler.reference)
             logging.getLogger("migration").warning(f"Unable to copy data item {data_item_uuid} to new library.")
             return None
 
@@ -1227,9 +1212,6 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
             storage_handlers.append(MemoryStorageHandler(key, self.__data_properties_map, self.__data_map, self._test_data_read_event))
         return storage_handlers
 
-    def _is_storage_handler_large_format(self, storage_handler: StorageHandler.StorageHandler) -> bool:
-        return False
-
     def _remove_storage_handler(self, storage_handler: StorageHandler.StorageHandler, *, safe: bool = False) -> None:
         storage_handler_reference = storage_handler.reference
         data = self.__data_map.pop(storage_handler_reference, None)
@@ -1252,7 +1234,6 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
         self.__data_properties_map[data_item_uuid_str] = Migration.transform_to_latest(trash_entry["properties"])
         self.__data_map[data_item_uuid_str] = trash_entry["data"]
         properties = self.__data_properties_map.get(data_item_uuid_str, dict())
-        properties["__large_format"] = False
         properties = Migration.transform_to_latest(properties)
         return properties
 
@@ -1276,7 +1257,6 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
         for reader_info in reader_info_list:
             data_item_properties = Utility.clean_dict(reader_info.properties if reader_info.properties else dict())
             if data_item_properties.get("version", 0) == DataItem.DataItem.writer_version:
-                data_item_properties["__large_format"] = reader_info.large_format
                 data_properties_map[reader_info.identifier] = data_item_properties
 
         def data_item_created(data_item_properties: typing.Tuple[str, PersistentDictType]) -> str:

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -94,8 +94,6 @@ class DataItemStorageAdapter:
 
 class MigrationReader(typing.Protocol):
 
-    def get_storage_properties(self) -> PersistentDictType: ...
-
     def _get_migration_stages(self) -> typing.Sequence[ProjectStorageSystemMigrationStage]: ...
 
     def _find_data_items(self, migration_stage: ProjectStorageSystemMigrationStage) -> typing.Sequence[StorageHandler.StorageHandler]: ...
@@ -128,6 +126,8 @@ def migrate_to_latest(source_project_storage_system: MigrationReader,
     # versioning. run newest to oldest so that deletions in newer libraries won't be migrated; nor will data items
     # in older projects with the same uuid in a newer project.
 
+    source_library_uuid: uuid.UUID | None = None
+
     for migration_stage in source_project_storage_system._get_migration_stages():
 
         # find all data items for the given migration stage and return a list of storage handlers.
@@ -154,10 +154,15 @@ def migrate_to_latest(source_project_storage_system: MigrationReader,
                 traceback.print_stack()
             storage_handler.prepare_move()
 
+        new_library_properties = source_project_storage_system._read_library_properties(migration_stage)
+
+        # grab the source_library_uuid if not known already
+        if not source_library_uuid:
+            source_library_uuid = uuid.UUID(new_library_properties.get("uuid", str(uuid.uuid4())))
+
         # now read the library properties which contains the data item deletions. data item deletions exist to
         # facilitate switching between library versions. if the user deletes an item in a newer library, that item
         # is marked as deleted so that if migration is performed again, that deleted item will not be re-migrated.
-        new_library_properties = source_project_storage_system._read_library_properties(migration_stage)
         for deletion in copy.deepcopy(new_library_properties.get("data_item_deletions", list())):
             if deletion not in deletions:
                 deletions.append(deletion)
@@ -235,9 +240,8 @@ def migrate_to_latest(source_project_storage_system: MigrationReader,
     assert library_properties["version"] == PROJECT_VERSION
 
     # propagate the UUID
-    source_library_properties = source_project_storage_system.get_storage_properties()
-    if source_library_properties and "uuid" in source_library_properties:
-        library_properties["uuid"] = source_library_properties["uuid"]
+    if source_library_uuid is not None:
+        library_properties["uuid"] = str(source_library_uuid)
 
     target_project_storage_system._migrate_library_properties(library_properties, reader_info_list)
 
@@ -245,7 +249,7 @@ def migrate_to_latest(source_project_storage_system: MigrationReader,
 class PersistentStorageSystem(Persistence.PersistentStorageInterface):
     """Abstract base class for persistent storage which implements the persistent storage interface.
 
-    Subclasses must implement _read_properties and _write_properties to read/write to persistent storage.
+    Subclasses must implement _read_untransformed_properties and _write_untransformed_properties to read/write to persistent storage.
 
     The `load_properties` method must be called after instantiating the subclass.
     """
@@ -268,35 +272,39 @@ class PersistentStorageSystem(Persistence.PersistentStorageInterface):
         return self.__identifier
 
     @abc.abstractmethod
-    def _write_properties(self) -> None:
-        """Write internal properties, retrieved using _get_properties, to persistent storage."""
+    def _read_untransformed_properties(self) -> PersistentDictType:
+        """Read internal properties from persistent storage.
+
+        Always returns a new copy.
+        """
         ...
 
     @abc.abstractmethod
-    def _read_properties(self) -> PersistentDictType:
-        """Read internal properties from persistent storage."""
+    def _write_untransformed_properties(self, untransformed_properties: PersistentDictType) -> None:
+        """Write internal properties, retrieved using _get_properties, to persistent storage."""
         ...
 
     def __set_persistent_storage(self, item: Persistence.PersistentObject, persistent_dict: typing.Optional[Persistence.PersistentDictType], persistent_storage: typing.Optional[Persistence.PersistentStorageInterface]) -> None:
-        persistent_storage = typing.cast(typing.Optional[PersistentStorageSystem], persistent_storage)
-        if persistent_storage:
-            persistent_storage._unregister_persistent_dict(item)
-        item.persistent_storage = persistent_storage
-        if persistent_storage:
-            persistent_storage._register_persistent_dict(item, persistent_dict)
-        for key in item.item_names:
-            component_item = item.get_item(key)
-            if component_item:
-                d = item.persistent_storage._get_item_persistent_dict(item, key) if item.persistent_storage else None
-                self.__set_persistent_storage(component_item, d if persistent_dict is not None else None, item.persistent_storage if persistent_dict is not None else None)
-        for key in item.relationship_names:
-            for index, relationship_item in enumerate(item.get_relationship_items(key)):
-                d = item.persistent_storage._get_relationship_persistent_dict(item, relationship_item, key, index) if item.persistent_storage else None
-                self.__set_persistent_storage(relationship_item, d if persistent_dict is not None else None, item.persistent_storage if persistent_dict is not None else None)
+        with self.__properties_lock:
+            persistent_storage = typing.cast(typing.Optional[PersistentStorageSystem], persistent_storage)
+            if persistent_storage:
+                persistent_storage._unregister_persistent_dict(item)
+            item.persistent_storage = persistent_storage
+            if persistent_storage:
+                persistent_storage._register_persistent_dict(item, persistent_dict)
+            for key in item.item_names:
+                component_item = item.get_item(key)
+                if component_item:
+                    d = item.persistent_storage._get_item_persistent_dict(item, key) if item.persistent_storage else None
+                    self.__set_persistent_storage(component_item, d if persistent_dict is not None else None, item.persistent_storage if persistent_dict is not None else None)
+            for key in item.relationship_names:
+                for index, relationship_item in enumerate(item.get_relationship_items(key)):
+                    d = item.persistent_storage._get_relationship_persistent_dict(item, relationship_item, key, index) if item.persistent_storage else None
+                    self.__set_persistent_storage(relationship_item, d if persistent_dict is not None else None, item.persistent_storage if persistent_dict is not None else None)
 
     def set_root_item(self, item: Persistence.PersistentObject) -> None:
         """Set the storage system for this item."""
-        self.__set_persistent_storage(item, self.get_storage_properties(), self)
+        self.__set_persistent_storage(item, self.__properties, self)
 
     def unload_item(self, item: Persistence.PersistentObject) -> None:
         self._unregister_persistent_dict(item)
@@ -304,16 +312,38 @@ class PersistentStorageSystem(Persistence.PersistentStorageInterface):
     def load_properties(self) -> None:
         """Read properties and store them in internal storage. Should be called immediately after instantiation."""
         with self.__properties_lock:
-            self.__properties = self._read_properties()
+            self.__properties = self._transform_properties(self._read_untransformed_properties())
 
-    def read_project_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[Persistence.ReaderError]]:
+    def get_properties(self) -> PersistentDictType:
+        with self.__properties_lock:
+            return copy.deepcopy(self.__properties)
+
+    def get_combined_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[Persistence.ReaderError]]:
         # dummy implementation for now until this is combined with load_properties.
         # subclass may override.
-        return dict(), list()
+        with self.__properties_lock:
+            return self.get_properties(), list()
 
-    def get_storage_properties(self) -> PersistentDictType:
-        """Return the internal properties. Callers should not modify; it is ok to not return a copy."""
-        return self.__properties
+    @property
+    def storage_uuid(self) -> uuid.UUID | None:
+        try:
+            with self.__properties_lock:
+                return uuid.UUID(self.__properties.get("uuid", str(uuid.uuid4()))) if self.__properties else None
+        except Exception as e:
+            return None
+
+    @property
+    def is_storage_empty(self) -> bool:
+        with self.__properties_lock:
+            return self.__properties is not None and not self.__properties
+
+    @property
+    def storage_version(self) -> int | None:
+        try:
+            with self.__properties_lock:
+                return self.__properties.get("version", None) if self.__properties else None
+        except Exception as e:
+            return None
 
     def migrate_to_latest(self) -> None:
         pass
@@ -350,13 +380,23 @@ class PersistentStorageSystem(Persistence.PersistentStorageInterface):
 
     def _write_item_properties(self, item: typing.Optional[Persistence.PersistentObject]) -> None:
         persistent_object_parent = item.persistent_object_parent if item else None
+        # if it's the root and not write delayed, write it out.
         if not persistent_object_parent:
             if self.__write_delay_count == 0:
-                self._write_properties()
+                with self.__properties_lock:
+                    self._write_untransformed_properties(self._untransform_properties(self.__properties))
         else:
             self.__write_properties_if_not_delayed(persistent_object_parent.parent)
 
-    def get_properties(self, item: Persistence.PersistentObject) -> typing.Optional[PersistentDictType]:
+    def _transform_properties(self, properties: PersistentDictType) -> PersistentDictType:
+        # subclasses can override to implement transformations to the properties before writing to disk, often for backwards compatibility.
+        return properties
+
+    def _untransform_properties(self, properties: PersistentDictType) -> PersistentDictType:
+        # subclasses can override to implement un-transformations to the properties before writing to disk, often for backwards compatibility.
+        return properties
+
+    def get_item_properties(self, item: Persistence.PersistentObject) -> PersistentDictType | None:
         return self._get_persistent_dict(item)
 
     def __update_modified_and_get_storage_dict(self, item: Persistence.PersistentObject) -> PersistentDictType:
@@ -498,7 +538,7 @@ class FilePersistentStorageSystem(PersistentStorageSystem):
     def path(self) -> pathlib.Path:
         return self.__path
 
-    def _read_properties(self) -> PersistentDictType:
+    def _read_untransformed_properties(self) -> PersistentDictType:
         properties = dict()
         if self.__path and self.__path.exists():
             try:
@@ -508,10 +548,10 @@ class FilePersistentStorageSystem(PersistentStorageSystem):
                 os.replace(self.__path, self.__path.with_suffix(".bak"))
         return properties
 
-    def _write_properties(self) -> None:
+    def _write_untransformed_properties(self, untransformed_properties: PersistentDictType) -> None:
         if self.__path:
             with Utility.AtomicFileWriter(self.__path) as fp:
-                properties = Utility.clean_dict(self.get_storage_properties())
+                properties = Utility.clean_dict(untransformed_properties)
                 json.dump(properties, fp)
 
 
@@ -519,22 +559,22 @@ class MemoryPersistentStorageSystem(PersistentStorageSystem):
     """File based persistent storage system. Useful for testing."""
 
     def __init__(self, *, library_properties: typing.Optional[PersistentDictType] = None) -> None:
-        self.__library_properties = library_properties if library_properties is not None else dict()
+        self.__library_untransformed_properties = library_properties if library_properties is not None else dict()
         super().__init__()
 
     def close(self) -> None:
         pass
 
-    def _read_properties(self) -> PersistentDictType:
-        return copy.deepcopy(self.__library_properties)
+    def _read_untransformed_properties(self) -> PersistentDictType:
+        return copy.deepcopy(self.__library_untransformed_properties)
 
-    def _write_properties(self) -> None:
-        self.__library_properties.clear()
-        self.__library_properties.update(self.get_storage_properties())
+    def _write_untransformed_properties(self, untransformed_properties: PersistentDictType) -> None:
+        self.__library_untransformed_properties.clear()
+        self.__library_untransformed_properties.update(untransformed_properties)
 
     def set_library_properties(self, library_properties: PersistentDictType) -> None:
-        self.__library_properties.clear()
-        self.__library_properties.update(library_properties)
+        self.__library_untransformed_properties.clear()
+        self.__library_untransformed_properties.update(library_properties)
         self.load_properties()
 
 
@@ -599,6 +639,9 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType: ...
 
+    @abc.abstractmethod
+    def normalize_project_data_path(self) -> None: ...
+
     #
 
     @property
@@ -623,21 +666,13 @@ class ProjectStorageSystem(PersistentStorageSystem):
         else:
             return super()._get_relationship_persistent_dict_by_uuid(container, item, key)
 
-    def get_persistent_dict(self, name: str, item_uuid: uuid.UUID) -> PersistentDictType:
-        if name == "data_items":
-            return self._data_properties_map[item_uuid].properties
-        for item_d in self.get_storage_properties()[name]:
-            if uuid.UUID(item_d["uuid"]) == item_uuid:
-                return typing.cast(PersistentDictType, item_d)
-        assert False
-
     def register_storage_handler(self, storage_handler: StorageHandler.StorageHandler, properties: PersistentDictType) -> None:
         data_item_uuid = uuid.UUID(properties["uuid"])
         assert data_item_uuid not in self.__storage_adapter_map
         storage_adapter = DataItemStorageAdapter(storage_handler, properties)
         self.__storage_adapter_map[data_item_uuid] = storage_adapter
 
-    def read_project_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[Persistence.ReaderError]]:
+    def get_combined_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[Persistence.ReaderError]]:
         """Read data items from the data reference handler and return as a dict.
 
         The dict may contain keys for data_items, display_items, data_structures, connections, and computations.
@@ -651,9 +686,9 @@ class ProjectStorageSystem(PersistentStorageSystem):
                 storage_handler_properties = storage_handler.read_properties()
                 storage_handler.prepare_move()
                 assert storage_handler_properties is not None
-                properties = Migration.transform_to_latest(storage_handler_properties)
-                assert properties.get("uuid")
-                reader_info = ReaderInfo(properties, [False], storage_handler, storage_handler.reference)
+                combined_properties = Migration.transform_to_latest(storage_handler_properties)
+                assert combined_properties.get("uuid")
+                reader_info = ReaderInfo(combined_properties, [False], storage_handler, storage_handler.reference)
                 reader_info_list.append(reader_info)
             except Exception as e:
                 reader_error_list.append(Persistence.ReaderError(storage_handler.reference, e, traceback.extract_stack()))
@@ -661,39 +696,41 @@ class ProjectStorageSystem(PersistentStorageSystem):
         # to allow later writing back to storage, associate the data items with their storage adapters
         for reader_info in reader_info_list:
             storage_handler = reader_info.storage_handler
-            properties = reader_info.properties
-            data_item_uuid = uuid.UUID(properties["uuid"])
-            storage_adapter = DataItemStorageAdapter(storage_handler, properties)
+            combined_properties = reader_info.properties
+            data_item_uuid = uuid.UUID(combined_properties["uuid"])
+            storage_adapter = DataItemStorageAdapter(storage_handler, combined_properties)
             old_storage_adapter = self.__storage_adapter_map.pop(data_item_uuid, None)
             if old_storage_adapter:
                 old_storage_adapter.close()
             self.__storage_adapter_map[data_item_uuid] = storage_adapter
 
-        properties_copy = self._read_properties()
+        combined_properties = self.get_properties()
 
         # ensure unique connections
-        connections_list = properties_copy.get("connections", list())
+        connections_list = combined_properties.get("connections", list())
         assert len(connections_list) == len({connection.get("uuid") for connection in connections_list})
 
         # ensure unique computations
-        computations_list = properties_copy.get("computations", list())
+        computations_list = combined_properties.get("computations", list())
         assert len(computations_list) == len({computation.get("uuid") for computation in computations_list})
+
+        # note: combined properties are already "transformed" so there is currently no transform capability for data items.
 
         for reader_info in reader_info_list:
             data_item_properties = reader_info.properties if reader_info.properties else dict()
             if data_item_properties.get("version", 0) == DataItem.DataItem.writer_version:
-                properties_copy.setdefault("data_items", list()).append(data_item_properties)
+                combined_properties.setdefault("data_items", list()).append(data_item_properties)
 
         def data_item_created(data_item_properties: PersistentDictType) -> str:
             # created is a utc timestamp
             earliest_datetime = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc).isoformat()
             return typing.cast(str, data_item_properties.get("created", earliest_datetime))
 
-        data_items_copy = sorted(properties_copy.get("data_items", list()), key=data_item_created)
+        data_items_copy = sorted(combined_properties.get("data_items", list()), key=data_item_created)
         if len(data_items_copy) > 0:
-            properties_copy["data_items"] = data_items_copy
+            combined_properties["data_items"] = data_items_copy
 
-        return Model.transform_forward(properties_copy), reader_error_list
+        return combined_properties, reader_error_list
 
     # override
     def _write_item_properties(self, item: typing.Optional[Persistence.PersistentObject]) -> None:
@@ -701,6 +738,14 @@ class ProjectStorageSystem(PersistentStorageSystem):
             self.__rewrite_data_item_properties(item)
         else:
             super()._write_item_properties(item)
+
+    def _transform_properties(self, properties: PersistentDictType) -> PersistentDictType:
+        # called by the base class to transform properties after reading from storage. this is where we can apply any transformations needed for the data item properties.
+        return Model.transform_forward(copy.deepcopy(properties))
+
+    def _untransform_properties(self, properties: PersistentDictType) -> PersistentDictType:
+        # called by the base class to untransform properties before writing to storage. this is where we can apply any transformations needed for the data item properties.
+        return Model.transform_backward(copy.deepcopy(properties))
 
     # override
     def _insert_item(self, parent: Persistence.PersistentObject, name: str, before_index: int, item: Persistence.PersistentObject) -> None:
@@ -842,14 +887,13 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         self.__project_path = project_path
         self.__project_data_path = project_data_path
 
-    def load_properties(self) -> None:
+    def normalize_project_data_path(self) -> None:
         # in order to be resilient to name changes, first make a list of folders in project_data_folders which
         # (1) can be constructed and (2) which exist. if none actually exist, see if one exists based on the
         # root name. then, if a folder exists, use it. otherwise, use the first one that can be constructed from
         # either the project_data_folders or the root name. this method is expected to supply a project_data_path
         # that can be written; the case where the project is created is where the folder will not exist in the
         # first place.
-        super().load_properties()
         project_data_folder_paths = list()
         existing_project_data_folder_paths = list()
         # always prefer the index file root with " Data" suffix first
@@ -860,7 +904,8 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         if project_data_folder_path.exists():
             existing_project_data_folder_paths.append(project_data_folder_path)
         # now check for any folders listed in the properties
-        for project_data_folder in self.get_storage_properties().get("project_data_folders", list()):
+        properties, errors = self.get_combined_properties()
+        for project_data_folder in properties.get("project_data_folders", list()):
             project_data_folder_path = pathlib.Path(project_data_folder)
             if not project_data_folder_path.is_absolute():
                 project_data_folder_path = self.__project_path.parent / project_data_folder_path
@@ -876,15 +921,15 @@ class FileProjectStorageSystem(ProjectStorageSystem):
     def project_path(self) -> pathlib.Path:
         return self.__project_path
 
-    def _read_properties(self) -> PersistentDictType:
+    def _read_untransformed_properties(self) -> PersistentDictType:
         properties = dict()
         if self.__project_path and self.__project_path.exists():
             with self.__project_path.open("r") as fp:
                 properties = json.load(fp)
         return properties
 
-    def _write_properties(self) -> None:
-        self.__write_properties_inner(Model.transform_backward(copy.deepcopy(self.get_storage_properties())))
+    def _write_untransformed_properties(self, untransformed_properties: PersistentDictType) -> None:
+        self.__write_properties_inner(untransformed_properties)
 
     def __write_properties_inner(self, properties: PersistentDictType) -> None:
         if self.__project_path:
@@ -1187,13 +1232,13 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
         self._test_data_read_event = data_read_event or Event.Event()
         self._write_count = 0
 
-    def _read_properties(self) -> PersistentDictType:
+    def _read_untransformed_properties(self) -> PersistentDictType:
         return copy.deepcopy(self.__library_properties)
 
-    def _write_properties(self) -> None:
+    def _write_untransformed_properties(self, untransformed_properties: PersistentDictType) -> None:
         self._write_count += 1
         self.__library_properties.clear()
-        self.__library_properties.update(Model.transform_backward(copy.deepcopy(self.get_storage_properties())))
+        self.__library_properties.update(untransformed_properties)
 
     def get_identifier(self) -> str:
         return "memory"
@@ -1274,6 +1319,9 @@ class MemoryProjectStorageSystem(ProjectStorageSystem):
 
     def _read_library_properties(self, migration_stage: ProjectStorageSystemMigrationStage) -> PersistentDictType:
         return copy.deepcopy(self.__library_properties)
+
+    def normalize_project_data_path(self) -> None:
+        pass
 
     def _find_data_items(self, migration_stage: ProjectStorageSystemMigrationStage) -> typing.Sequence[StorageHandler.StorageHandler]:
         return self._find_storage_handlers()

--- a/nion/swift/model/ImportExportManager.py
+++ b/nion/swift/model/ImportExportManager.py
@@ -422,7 +422,6 @@ def create_data_element_from_data_item(data_item: DataItem.DataItem, include_dat
     data_element["version"] = 1
     data_element["reader_version"] = 1
     if data_item.has_data:
-        data_element["large_format"] = bool(data_item.large_format)
         if include_data:
             data_element["data"] = data_item.data
         dimensional_calibrations = data_item.dimensional_calibrations

--- a/nion/swift/model/Persistence.py
+++ b/nion/swift/model/Persistence.py
@@ -270,18 +270,25 @@ class PersistentStorageInterface(typing.Protocol):
     def load_properties(self) -> None: ...
 
     @abc.abstractmethod
-    def read_project_properties(self) -> typing.Tuple[PersistentDictType, typing.Sequence[ReaderError]]:
-        """Read from storage."""
-        ...
+    def get_combined_properties(self) -> tuple[PersistentDictType, typing.Sequence[ReaderError]]: ...
 
+    @property
     @abc.abstractmethod
-    def get_storage_properties(self) -> typing.Optional[PersistentDictType]: ...
+    def storage_uuid(self) -> uuid.UUID | None: ...
+
+    @property
+    @abc.abstractmethod
+    def storage_version(self) -> int | None: ...
+
+    @property
+    @abc.abstractmethod
+    def is_storage_empty(self) -> bool: ...
 
     @abc.abstractmethod
     def migrate_to_latest(self) -> None: ...
 
     @abc.abstractmethod
-    def get_properties(self, object: typing.Any) -> typing.Optional[PersistentDictType]: ...
+    def get_item_properties(self, item: PersistentObject) -> PersistentDictType | None: ...
 
     @abc.abstractmethod
     def insert_relationship_item(self, parent: PersistentObject, name: str, before_index: int, item: PersistentObject) -> None: ...
@@ -779,10 +786,6 @@ class PersistentObject(Observable.Observable):
         """Define this item to be the root context."""
         self.__persistent_object_context = PersistentObjectContext()
 
-    def set_storage_system(self, storage_system: PersistentStorageInterface) -> None:
-        """Set the storage system for this item."""
-        storage_system.set_root_item(self)
-
     def update_storage_system(self) -> None:
         """Update the storage system properties by re-reading from storage.
 
@@ -899,11 +902,6 @@ class PersistentObject(Observable.Observable):
         for relationship in self.__relationships.values():
             relationship.close()
         self.__relationships.clear()
-
-    def get_storage_properties(self) -> typing.Optional[PersistentDictType]:
-        """ Return a copy of the properties for the object as a dict. """
-        assert self.persistent_storage
-        return copy.deepcopy(self.persistent_storage.get_properties(self))
 
     @property
     def property_names(self) -> typing.Sequence[str]:

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -139,6 +139,7 @@ class ProjectReference(Persistence.PersistentObject):
                 project_storage_system = self.make_storage(profile_context)
                 if project_storage_system:
                     project_storage_system.load_properties()
+                    project_storage_system.normalize_project_data_path()
                 # handle the case where the project storage system is never read; the folder project case.
                 # this will get set again below if the project is read.
                 self.__project_state = "missing"
@@ -167,6 +168,7 @@ class ProjectReference(Persistence.PersistentObject):
             project_storage_system = self.make_storage(profile_context)
             if project_storage_system:
                 project_storage_system.load_properties()
+                project_storage_system.normalize_project_data_path()
                 if not cache_factory:
                     assert cache_dir_path
 
@@ -212,6 +214,7 @@ class ProjectReference(Persistence.PersistentObject):
         project_storage_system = self.make_storage(profile_context)
         if project_storage_system:
             project_storage_system.load_properties()
+            project_storage_system.normalize_project_data_path()
             with contextlib.closing(Project.Project(project_storage_system)) as project:
                 project.prepare_read_project()  # sets up the uuid, used next.
                 return project.uuid
@@ -328,7 +331,6 @@ class FolderProjectReference(ProjectReference):
              "project_data_folders": [str(target_data_path.stem)]})
         target_project_path.write_text(target_project_data_json, "utf-8")
         with contextlib.closing(FileStorageSystem.make_index_project_storage_system(target_project_path)) as new_storage_system:
-            new_storage_system.load_properties()
             FileStorageSystem.migrate_to_latest(
                 typing.cast(FileStorageSystem.MigrationReader, project_storage_system),
                 typing.cast(FileStorageSystem.MigrationWriter, new_storage_system)
@@ -476,8 +478,7 @@ class Profile(Persistence.PersistentObject):
         # ensure a storage system; use a memory based storage as a fallback (for testing).
         self.storage_system = storage_system or FileStorageSystem.make_memory_persistent_storage_system()
         self.storage_system.load_properties()
-
-        self.set_storage_system(self.storage_system)
+        self.storage_system.set_root_item(self)
 
         self.__cache_dir_path = cache_dir_path
         self.__cache_factory = cache_factory
@@ -597,15 +598,15 @@ class Profile(Persistence.PersistentObject):
         return self.storage_system
 
     def read_profile(self) -> None:
-        # read the properties from the storage system. called after open.
-        properties = self.storage_system.get_storage_properties()
-
         # if the properties match the current version, read the properties.
-        if properties is not None and properties.get("version", 0) == FileStorageSystem.PROFILE_VERSION:
+        if self.storage_system.storage_version == FileStorageSystem.PROFILE_VERSION:
             self.begin_reading()
             try:
                 if not self.project_references:  # hack for testing. tests will have already set up profile.
-                    self.read_from_dict(properties)
+                    # read the properties from the storage system. called after open.
+                    properties, errors = self.storage_system.get_combined_properties()
+                    if properties:  # this is implied since storage system is not None, but be defensive.
+                        self.read_from_dict(properties)
             finally:
                 self.finish_reading()
             self.storage_system.set_property(self, "uuid", str(self.uuid))

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -70,8 +70,7 @@ class Project(Persistence.PersistentObject):
         self.__reader_errors: typing.Sequence[Persistence.ReaderError] = list()
 
         self.__storage_system = storage_system
-
-        self.set_storage_system(self.__storage_system)
+        self.__storage_system.set_root_item(self)
 
         self.__cache_factory = cache_factory
         self.__cache = cache_factory.create_cache() if cache_factory else None
@@ -202,16 +201,11 @@ class Project(Persistence.PersistentObject):
 
     @property
     def project_uuid(self) -> typing.Optional[uuid.UUID]:
-        properties = self.__storage_system.get_storage_properties()
-        try:
-            return uuid.UUID(properties.get("uuid", str(uuid.uuid4()))) if properties else None
-        except Exception as e:
-            return None
+        return self.__storage_system.storage_uuid
 
     @property
     def project_state(self) -> str:
-        properties = self.__storage_system.get_storage_properties()
-        if properties is not None and not properties:
+        if self.__storage_system.is_storage_empty:
             return "missing"
         project_uuid = self.project_uuid
         project_version = self.project_version
@@ -224,11 +218,7 @@ class Project(Persistence.PersistentObject):
 
     @property
     def project_version(self) -> typing.Optional[int]:
-        properties = self.__storage_system.get_storage_properties()
-        try:
-            return properties.get("version", None) if properties else None
-        except Exception:
-            return None
+        return self.__storage_system.storage_version
 
     @property
     def project_filter(self) -> ListModel.Filter:
@@ -283,7 +273,7 @@ class Project(Persistence.PersistentObject):
     def prepare_read_project(self) -> None:
         self.__project_load_start_time = time.time()
         logging.getLogger("loader").info(f"Loading project {self.__storage_system.get_identifier()}")
-        self._raw_properties, self.__reader_errors = self.__storage_system.read_project_properties()  # combines library and data item properties
+        self._raw_properties, self.__reader_errors = self.__storage_system.get_combined_properties()  # combines library and data item properties
         self.uuid = uuid.UUID(self._raw_properties.get("uuid", str(uuid.uuid4())))
 
         for reader_error in self.__reader_errors:
@@ -485,6 +475,7 @@ class Project(Persistence.PersistentObject):
     def migrate_to_latest(self) -> None:
         self.__storage_system.migrate_to_latest()
         self.__storage_system.load_properties()
+        self.__storage_system.normalize_project_data_path()
         self.update_storage_system()  # reload the properties
         self.prepare_read_project()
         self.read_project()

--- a/nion/swift/model/Project.py
+++ b/nion/swift/model/Project.py
@@ -427,8 +427,7 @@ class Project(Persistence.PersistentObject):
         item_d = self.__storage_system.restore_item(data_item_uuid)
         if item_d is not None:
             data_item_uuid = uuid.UUID(item_d.get("uuid"))
-            large_format = item_d.get("__large_format", False)
-            data_item = DataItem.DataItem(item_uuid=data_item_uuid, large_format=large_format)
+            data_item = DataItem.DataItem(item_uuid=data_item_uuid)
             data_item.begin_reading()
             data_item.read_from_dict(item_d)
             data_item.finish_reading()
@@ -507,9 +506,7 @@ class Project(Persistence.PersistentObject):
 
 def data_item_factory(lookup_id: typing.Callable[[str], str]) -> DataItem.DataItem:
     data_item_uuid = uuid.UUID(lookup_id("uuid"))
-    # TODO: typing hack for default arg
-    large_format = typing.cast(typing.Callable[..., typing.Any], lookup_id)("__large_format", False)
-    return DataItem.DataItem(item_uuid=data_item_uuid, large_format=large_format)
+    return DataItem.DataItem(item_uuid=data_item_uuid)
 
 
 def display_item_factory(lookup_id: typing.Callable[[str], str]) -> DisplayItem.DisplayItem:

--- a/nion/swift/model/StorageHandler.py
+++ b/nion/swift/model/StorageHandler.py
@@ -95,7 +95,6 @@ class StorageHandlerAttributes:
     created_local: datetime.datetime
     session_id: str | None
     n_bytes: int
-    _force_large_format: bool = False
 
 
 class StorageHandlerProvider(typing.Protocol):

--- a/nion/swift/test/DataItem_test.py
+++ b/nion/swift/test/DataItem_test.py
@@ -81,7 +81,7 @@ class TestDataItemClass(unittest.TestCase):
             self.assertNotEqual(id(data), id(data_item_copy.data))
             # make sure properties and other items got copied
             #self.assertEqual(len(data_item_copy.properties), 19)  # not valid since properties only exist if in document
-            self.assertIsNot(data_item.properties, data_item_copy.properties)
+            self.assertIsNot(data_item.persistent_storage.get_item_properties(data_item), data_item_copy.persistent_storage.get_item_properties(data_item_copy))
             # uuid should not match
             self.assertNotEqual(data_item.uuid, data_item_copy.uuid)
             # metadata get copied?

--- a/nion/swift/test/Display_test.py
+++ b/nion/swift/test/Display_test.py
@@ -493,7 +493,8 @@ class TestDisplayClass(unittest.TestCase):
                 document_model.append_data_item(data_item)
                 display_item = document_model.get_display_item_for_data_item(data_item)
                 display_item.display_data_channels[0].reset_display_limits()
-                Utility.clean_dict(data_item.properties)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(Utility.clean_dict(data_item_properties), data_item_properties)
 
     def test_reset_display_limits_on_complex_data_gives_reasonable_results(self):
         with TestContext.create_memory_context() as test_context:
@@ -572,7 +573,8 @@ class TestDisplayClass(unittest.TestCase):
             display_panel.set_display_panel_display_item(display_item)
             display_panel.display_canvas_item.layout_immediate((640, 480))
             display_panel.enter_key_pressed()
-            self.assertEqual(Utility.clean_dict(display_item.properties), display_item.properties)
+            display_item_properties = display_item.persistent_storage.get_item_properties(display_item)
+            self.assertEqual(Utility.clean_dict(display_item_properties), display_item_properties)
 
     def test_display_range_is_recalculated_with_new_data(self):
         with TestContext.create_memory_context() as test_context:

--- a/nion/swift/test/ImportExportManager_test.py
+++ b/nion/swift/test/ImportExportManager_test.py
@@ -16,13 +16,12 @@ import numpy
 # local libraries
 from nion.data import Calibration
 from nion.data import DataAndMetadata
-from nion.swift import Application
 from nion.swift.model import DataItem
+from nion.swift.model import FileStorageSystem
 from nion.swift.model import Graphics
 from nion.swift.model import ImportExportManager
 from nion.swift.model import Utility
 from nion.swift.test import TestContext
-from nion.ui import TestUI
 from nion.utils import DateTime
 
 
@@ -410,46 +409,8 @@ class TestImportExportManagerClass(unittest.TestCase):
             data_element = ImportExportManager.create_data_element_from_data_item(data_item, include_data=False)
             json.dumps(data_element)
 
-    def test_data_item_to_data_element_and_back_keeps_large_format_flag(self):
-        data_item = DataItem.DataItem(numpy.zeros((4, 4, 4)), large_format=True)
-        with contextlib.closing(data_item):
-            data_element = ImportExportManager.create_data_element_from_data_item(data_item, include_data=True)
-            self.assertTrue(data_element.get("large_format"))
-            with contextlib.closing(ImportExportManager.create_data_item_from_data_element(data_element)) as data_item:
-                self.assertTrue(data_item.large_format)
-
-    def test_importing_rgb_does_not_set_large_format(self):
-        data_item = DataItem.DataItem(numpy.zeros((8, 8, 4), dtype=float))
-        with contextlib.closing(data_item):
-            data_item_rgb = DataItem.DataItem(numpy.zeros((8, 8, 4), dtype=numpy.uint8))
-            with contextlib.closing(data_item_rgb):
-                data_element = ImportExportManager.create_data_element_from_data_item(data_item, include_data=True)
-                data_element_rgb = ImportExportManager.create_data_element_from_data_item(data_item_rgb, include_data=True)
-                data_element.pop("large_format")
-                data_element_rgb.pop("large_format")
-                with contextlib.closing(ImportExportManager.create_data_item_from_data_element(data_element)) as data_item:
-                    with contextlib.closing(ImportExportManager.create_data_item_from_data_element(data_element_rgb)) as data_item_rgb:
-                        self.assertTrue(data_item.large_format)
-                        self.assertFalse(data_item_rgb.large_format)
-
-    def test_importing_large_numpy_file_sets_large_format_flag(self):
-        current_working_directory = os.getcwd()
-        file_path_npy = os.path.join(current_working_directory, "__file.npy")
-        numpy.save(file_path_npy, numpy.zeros((4, 4, 4)))
-        handler = ImportExportManager.NumPyImportExportHandler("numpy-io-handler", "npy", ["npy"])
-        try:
-            data_items = handler.read_data_items("npy", pathlib.Path(file_path_npy))
-            self.assertEqual(len(data_items), 1)
-            data_item = data_items[0]
-            self.assertTrue(data_item.large_format)
-            for data_item in data_items:
-                data_item.close()
-        finally:
-            os.remove(file_path_npy)
-
     def test_data_item_with_numpy_bool_to_data_element_produces_json_compatible_dict(self):
         data_item = DataItem.DataItem(numpy.zeros((16, 16)))
-        data_item.large_format = numpy.prod((2,3,4), dtype=numpy.int64) > 10  # produces a numpy.bool_
         with contextlib.closing(data_item):
             data_element = ImportExportManager.create_data_element_from_data_item(data_item, include_data=False)
             json.dumps(data_element)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -1322,10 +1322,11 @@ class TestStorageClass(unittest.TestCase):
             document_model = document_controller.document_model
             data_item = DataItem.DataItem(numpy.zeros((8, 8), numpy.uint32))
             document_model.append_data_item(data_item)
-            self.assertTrue("data_shape" in data_item.properties)
-            self.assertTrue("data_dtype" in data_item.properties)
-            self.assertTrue("uuid" in data_item.properties)
-            self.assertTrue("version" in data_item.properties)
+            data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+            self.assertTrue("data_shape" in data_item_properties)
+            self.assertTrue("data_dtype" in data_item_properties)
+            self.assertTrue("uuid" in data_item_properties)
+            self.assertTrue("version" in data_item_properties)
 
     def test_deleting_dependent_after_deleting_source_succeeds(self):
         with create_temp_profile_context() as profile_context:
@@ -1613,7 +1614,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(len(document_model.data_items), 1)
                 data_item = document_model.data_items[0]
                 display_item = document_model.get_display_item_for_data_item(data_item)
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
                 self.assertEqual(len(display_item.data_item.dimensional_calibrations), 2)
                 self.assertEqual(display_item.data_item.dimensional_calibrations[0], Calibration.Calibration(offset=1.0, scale=2.0, units="mm"))
                 self.assertEqual(display_item.data_item.dimensional_calibrations[1], Calibration.Calibration(offset=1.0, scale=2.0, units="mm"))
@@ -1643,9 +1645,11 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(len(document_model.data_items), 1)
                 data_item = document_model.data_items[0]
                 display_item = document_model.display_items[0]
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
-                self.assertTrue("uuid" in display_item.properties)
-                self.assertTrue("uuid" in display_item.properties["graphics"][0])
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
+                display_item_properties = display_item.persistent_storage.get_item_properties(display_item)
+                self.assertTrue("uuid" in display_item_properties)
+                self.assertTrue("uuid" in display_item_properties["graphics"][0])
 
     def test_data_items_v3_migration(self):
         # construct v3 data item
@@ -1667,7 +1671,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(len(document_model.data_items), 1)
                 data_item = document_model.data_items[0]
                 display_item = document_model.get_display_item_for_data_item(data_item)
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
                 self.assertEqual(len(display_item.data_item.dimensional_calibrations), 2)
                 self.assertEqual(display_item.data_item.dimensional_calibrations[0], Calibration.Calibration(offset=1.0, scale=2.0, units="mm"))
                 self.assertEqual(display_item.data_item.dimensional_calibrations[1], Calibration.Calibration(offset=1.0, scale=2.0, units="mm"))
@@ -1693,7 +1698,8 @@ class TestStorageClass(unittest.TestCase):
                 # check it
                 self.assertEqual(len(document_model.data_items), 1)
                 data_item = document_model.data_items[0]
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
                 self.assertIsNotNone(document_model.get_data_item_computation(data_item))
                 # not really checking beyond this; the program has changed enough to make the region connection not work without a data source
 
@@ -1727,7 +1733,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(str(document_model.data_items[0].uuid), data_item_dict["uuid"])
                 self.assertEqual(str(document_model.data_items[1].uuid), data_item2_dict["uuid"])
                 data_item = document_model.data_items[1]
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
                 self.assertIsNotNone(document_model.get_data_item_computation(data_item))
                 self.assertEqual(len(document_model.get_data_item_computation(data_item).variables), 1)
                 self.assertEqual(document_model.get_data_item_computation(data_item).get_input_data_item("src"), document_model.data_items[0])
@@ -1777,7 +1784,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(str(document_model.data_items[1].uuid), data_item2_dict["uuid"])
                 self.assertEqual(str(document_model.data_items[2].uuid), data_item3_dict["uuid"])
                 data_item = document_model.data_items[1]
-                self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
                 self.assertIsNotNone(document_model.get_data_item_computation(data_item))
                 self.assertEqual(len(document_model.get_data_item_computation(data_item).variables), 1)
                 self.assertEqual(document_model.get_data_item_computation(data_item).get_input_data_item("src"), document_model.data_items[0])
@@ -1878,7 +1886,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_cross_correlate_migration(self):
         # construct v8 data items
@@ -1951,7 +1960,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_gaussian_blur_migration(self):
         # construct v8 data items
@@ -2025,7 +2035,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_median_filter_migration(self):
         # construct v8 data items
@@ -2079,7 +2090,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_slice_migration(self):
         # construct v8 data items
@@ -2134,7 +2146,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_crop_migration(self):
         # construct v8 data items
@@ -2190,7 +2203,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_projection_migration(self):
         # construct v8 data items
@@ -2263,7 +2277,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_convert_to_scalar_migration(self):
         # construct v8 data items
@@ -2336,7 +2351,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_resample_migration(self):
         # construct v8 data items
@@ -2391,7 +2407,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_pick_migration(self):
         # construct v8 data items
@@ -2454,7 +2471,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertFalse(numpy.array_equal(data0, data1))
                 self.assertTrue(numpy.array_equal(data1, data[0, 0, :]))
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_line_profile_migration(self):
         # construct v8 data items
@@ -2515,7 +2533,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v8_to_v9_unknown_migration(self):
         # construct v8 data items
@@ -2560,7 +2579,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(len(document_model.data_items), 2)
                 self.assertIsNone(document_model.get_data_item_computation(document_model.data_items[1]))
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v9_to_v10_migration(self):
         # construct v9 data items with regions, make sure they get translated to graphics
@@ -2634,7 +2654,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertAlmostEqual(graphics[4].start, 0.2)
                 self.assertAlmostEqual(graphics[4].end, 0.3)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v9_to_v10_line_profile_migration(self):
         # construct v9 data items with regions, make sure they get translated to graphics
@@ -2691,7 +2712,8 @@ class TestStorageClass(unittest.TestCase):
                 dst_display_item = document_model.get_display_item_for_data_item(document_model.data_items[1])
                 self.assertEqual(src_display_item.graphics[0], document_model.get_data_item_computation(dst_display_item.data_item).get_input("line_region"))
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v10_to_v11_created_date_migration(self):
         with create_memory_profile_context() as profile_context:
@@ -2777,7 +2799,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v10_to_v11_gaussian_migration(self):
         with create_memory_profile_context() as profile_context:
@@ -2834,7 +2857,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v10_to_v11_cross_correlate_migration(self):
         with create_memory_profile_context() as profile_context:
@@ -2912,7 +2936,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertIsNotNone(DocumentModel.evaluate_data(computation).data)
                 self.assertIsNone(computation.error_text)
                 for data_item in document_model.data_items:
-                    self.assertEqual(data_item.properties["version"], DataItem.DataItem.writer_version)
+                    data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
+                    self.assertEqual(data_item_properties["version"], DataItem.DataItem.writer_version)
 
     def test_data_items_v11_to_v12_line_profile_migration(self):
         with create_memory_profile_context() as profile_context:
@@ -3100,7 +3125,7 @@ class TestStorageClass(unittest.TestCase):
                 document_model._project.migrate_to_latest()
                 data_item = document_model.data_items[0]
                 display_item = document_model.display_items[0]
-                data_item_properties = data_item.properties
+                data_item_properties = data_item.persistent_storage.get_item_properties(data_item)
                 self.assertEqual("title", data_item.title)
                 self.assertEqual("caption", data_item.caption)
                 self.assertEqual("20170101-120000", data_item.session_id)
@@ -3587,6 +3612,19 @@ class TestStorageClass(unittest.TestCase):
             with document_model.ref():
                 document_model._project.migrate_to_latest()
                 self.assertEqual(len(document_model.data_items), 1)
+
+    def test_migrate_using_upgrade_works(self):
+        with create_temp_profile_context() as profile_context:
+            # construct workspace with old file
+            library_path = profile_context.projects_dir / "Nion Swift Workspace.nslib"
+            data_path = profile_context.projects_dir / "Nion Swift Data"
+            with library_path.open("w") as fp:
+                json.dump({"uuid": str(uuid.uuid4()), "version": 0}, fp)
+            profile = profile_context.create_profile()
+            project_reference = profile.add_project_folder(profile_context.projects_dir)
+            new_project_reference = profile.upgrade(project_reference)
+            profile.read_project(new_project_reference)
+            self.assertEqual("loaded", new_project_reference.project_state)
 
     # @unittest.expectedFailure
     def future_test_storage_cache_disabled_during_transaction(self):

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -871,22 +871,6 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(1, len(document_model.data_items))
                 self.assertEqual(data_item_uuid, document_model.data_items[0].uuid)
 
-    def test_data_changes_update_large_format_file(self):
-        with create_temp_profile_context() as profile_context:
-            zeros = numpy.zeros((8, 8), numpy.uint32)
-            ones = numpy.ones((8, 8), numpy.uint32)
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                data_item = DataItem.DataItem(ones)
-                data_item.large_format = True
-                document_model.append_data_item(data_item)
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                document_model.data_items[0].set_data(zeros)
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                self.assertTrue(numpy.array_equal(document_model.data_items[0].data, zeros))
-
     def test_file_format_adjusts_to_data_size(self):
         with create_temp_profile_context() as profile_context:
             document_model = profile_context.create_document_model(auto_close=False)
@@ -913,29 +897,6 @@ class TestStorageClass(unittest.TestCase):
             with document_model.ref():
                 self.assertTrue(numpy.array_equal(document_model.data_items[0].data, data16))
                 self.assertEqual(99, document_model.data_items[0].metadata["a"])
-
-    def test_data_changes_reserve_large_format_file(self):
-        with create_temp_profile_context() as profile_context:
-            zeros = numpy.zeros((8, 8), numpy.uint32)
-            ones = numpy.ones((8, 8), numpy.uint32)
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                data_item = DataItem.DataItem()
-                data_item.large_format = True
-                document_model.append_data_item(data_item)
-                data_item.reserve_data(data_shape=ones.shape, data_dtype=ones.dtype, data_descriptor=DataAndMetadata.DataDescriptor(False, 0, 2))
-                self.assertTrue(numpy.array_equal(zeros, data_item.data))
-                data_item.set_data_and_metadata_partial(data_item.xdata.data_metadata,
-                                                  DataAndMetadata.new_data_and_metadata(ones), (slice(0,8), slice(0, 8)),
-                                                  (slice(0,8), slice(0, 8)))
-                self.assertTrue(numpy.array_equal(ones, data_item.data))
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                self.assertTrue(numpy.array_equal(document_model.data_items[0].data, ones))
-                document_model.data_items[0].set_data(zeros)
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                self.assertTrue(numpy.array_equal(document_model.data_items[0].data, zeros))
 
     def test_file_format_adjusts_to_data_size_when_reserved(self):
         with create_temp_profile_context() as profile_context:
@@ -4166,48 +4127,6 @@ class TestStorageClass(unittest.TestCase):
             document_model = profile_context.create_document_model(auto_close=False)
             with document_model.ref():
                 self.assertEqual(len(document_model.data_items), 1)
-
-    def test_snapshot_copies_storage_format(self):
-        with create_temp_profile_context() as profile_context:
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                data_item1 = DataItem.DataItem(numpy.ones((16, 16), numpy.uint32))
-                data_item2 = DataItem.DataItem(numpy.ones((16, 16), numpy.uint32))
-                data_item2.large_format = True
-                document_model.append_data_item(data_item1)
-                document_model.append_data_item(data_item2)
-            # read it back
-            document_model = profile_context.create_document_model(auto_close=False)
-            with document_model.ref():
-                data_item1 = document_model.data_items[0]
-                data_item2 = document_model.data_items[1]
-                data_item1a = document_model.get_display_item_snapshot_new(document_model.get_display_item_for_data_item(data_item1)).data_item
-                data_item2a = document_model.get_display_item_snapshot_new(document_model.get_display_item_for_data_item(data_item2)).data_item
-                data_item1b = copy.deepcopy(data_item1)
-                data_item2b = copy.deepcopy(data_item2)
-                document_model.append_data_item(data_item1b)
-                document_model.append_data_item(data_item2b)
-                file_path1 = data_item1._test_get_file_path()
-                file_path2 = data_item2._test_get_file_path()
-                file_path1a = data_item1a._test_get_file_path()
-                file_path2a = data_item2a._test_get_file_path()
-                file_path1b = data_item1b._test_get_file_path()
-                file_path2b = data_item2b._test_get_file_path()
-            file_path1_base, file_path1_ext = os.path.splitext(file_path1)
-            file_path2_base, file_path2_ext = os.path.splitext(file_path2)
-            file_path1a_base, file_path1a_ext = os.path.splitext(file_path1a)
-            file_path2a_base, file_path2a_ext = os.path.splitext(file_path2a)
-            file_path1b_base, file_path1b_ext = os.path.splitext(file_path1b)
-            file_path2b_base, file_path2b_ext = os.path.splitext(file_path2b)
-            # check assumptions, works for both NData+HDF5 or HDF5 only
-            self.assertTrue(profile_context._file_handler_factories[0].is_matching(file_path1))
-            self.assertTrue(profile_context._file_handler_factories[-1].is_matching(file_path2))
-            # self.assertNotEqual(file_path1_ext, file_path2_ext)  # assumes different file formats, use 2 lines above instead
-            # check results
-            self.assertEqual(file_path1_ext, file_path1a_ext)
-            self.assertEqual(file_path2_ext, file_path2a_ext)
-            self.assertEqual(file_path1_ext, file_path1b_ext)
-            self.assertEqual(file_path2_ext, file_path2b_ext)
 
     def test_pending_data_on_new_data_item_updates_properly(self):
         with create_temp_profile_context() as profile_context:


### PR DESCRIPTION
Fixes #1914

- **Eliminate explicit support for large_format flags. Part of a storage refactoring.**
- **Fix storage issue to store transformed properties in dict.**

---

- Eliminates the 'properties' property on data and display items. Callers must now explicitly use persistent_storage.get_item_properties(). This makes the code more clear.
-  Eliminates the poorly defined `PersistentStorageSystem.get_storage_properties` and replaces it with `get_properties`.
- Ensures the `__properties` stored in `PersistentStorageSystem` are the transformed properties, which they were not before. This ensures the 'in memory' state matches the current version of the class.
- Explicitly labels the reader/writer methods to be clear that they are reading/writing untransformed data.
- Renames `read_project_properties` to `get_combined_properties` for clarity.
- Add transform/untransform virtual methods to be used while reading and writing.
- Split the normalization part of `load_properties` into `normalize_project_data_path` and add a test for that code path.
- Other minor cleanup and test updates.

See also:
- [persistent object model design document](https://github.com/nion-software/nionswift/blob/master/design/persistent_object_model.md)