### PR TITLE
Rename project on disk

### DIFF
--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -939,6 +939,41 @@ class Application(UIApplication.BaseApplication):
 
         self.event_loop.call_later(command_delay or 0.0, execute_next_command, commands, list(commands), command_delay or 0.0, repeat or 1)
 
+    def rename_project(self, project_reference: Profile.ProjectReference, name: str) -> None:
+        """Rename the project reference to the given name.
+
+        If the project reference is the current project, it will be closed and reopened after renaming to update the title.
+        """
+        with self.prevent_close():
+            old_title = project_reference.title
+            renaming_current_project = self.profile.last_project_reference == project_reference.uuid
+            document_controller = self.document_controllers[0]
+            assert document_controller is not None
+            if renaming_current_project:
+                document_controller.request_close()
+            error_message: str | None = None
+            new_project_reference: Profile.ProjectReference | None = None
+            try:
+                new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
+                error_message = "\n".join(rename_result.error_messages)
+            except Exception as e:
+                # Catch and log any exceptions during the rename process
+                error_message = _("Exception during renaming project")
+                logging.exception(e)
+                new_project_reference = project_reference
+            finally:
+                # Reopen the project only when renaming the current project and when the project reference is returned
+                if renaming_current_project and new_project_reference is not None:
+                    self.switch_project_reference(new_project_reference)
+                    assert new_project_reference.project is not None
+                    new_project_reference.project.title = name
+                    self.profile.last_project_reference = new_project_reference.uuid
+
+                if error_message:
+                    self.__show_project_error_dialog(_("Error Renaming Project"), error_message)
+                else:
+                    logging.info(f"Renamed Project \"{old_title}\" to \"{name}\"")
+
 
 def get_root_dir() -> str:
     root_dir = os.path.dirname((os.path.dirname(os.path.abspath(__file__))))

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1212,7 +1212,7 @@ class NameProjectViewModel:
 
     def update_project_status_label(self, project_name: str | None = None, directory: str | None = None) -> None:
         project_name = project_name or self.filename.value or str()
-        directory = directory or self.directory.value
+        directory = directory or self.directory.value or str()
 
         is_valid, errors = self.verify_project_name(project_name, directory, self.profile, self.check_name_available_fn)
 

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -59,6 +59,7 @@ from nion.utils import Geometry
 from nion.utils import ListModel
 from nion.utils import Model
 from nion.utils import Registry
+from nion.utils import Stream
 
 if typing.TYPE_CHECKING:
     from nion.swift.model import DisplayItem
@@ -1173,6 +1174,179 @@ class ChooseProjectAction(UIWindow.Action):
         application = typing.cast(Application, context.application)
         application.show_choose_project_dialog()
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+
+class NameProjectViewModel:
+    """Represents the NameProjectDialog model."""
+    def __init__(self, filename: str, directory: str, profile: Profile.Profile, check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None):
+        self.filename = Model.PropertyModel(filename)
+        self.filename_warning = Model.PropertyModel(str())
+        self.project_name_status_label = Model.PropertyModel(str())
+        self.accept_button_enabled = Model.PropertyModel(False)
+        self.directory = Model.PropertyModel(directory)
+        self.profile = profile
+        self.check_name_available_fn = check_name_available_fn
+
+    @staticmethod
+    def verify_project_name(project_name: str, base_directory: str, profile: Profile.Profile,
+                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
+            -> tuple[bool, typing.Sequence[str] | None]:
+        """Verify that a project name is a valid filename and doesn't already exist."""
+        if project_name == "":
+            return False, ["Project name cannot be empty"]
+        is_valid, error_messages = Utility.verify_filename_is_legal(project_name)
+        if not is_valid and error_messages:
+            return is_valid, error_messages
+
+        errors: list[str] = []
+        if check_name_available_fn:
+            name_available_result = check_name_available_fn(project_name, base_directory)
+            errors.extend(name_available_result.error_messages or [])
+            if name_available_result.success and name_available_result.project_path:
+                # Check for an orphaned project reference exists, it would need to be removed manually
+                project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
+                if project_reference is not None:
+                    errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
+
+        return not errors, errors
+
+    def update_project_status_label(self, project_name: str | None = None, directory: str | None = None) -> None:
+        project_name = project_name or self.filename.value or str()
+        directory = directory or self.directory.value
+
+        is_valid, errors = self.verify_project_name(project_name, directory, self.profile, self.check_name_available_fn)
+
+        self.accept_button_enabled.value = is_valid
+        if is_valid:  # The name is valid and doesn't already exist.
+            self.project_name_status_label.value = str()
+        elif errors:  # Display the error messages.
+            error_str = "\n".join(errors)
+            self.project_name_status_label.value = error_str
+
+
+class NameProjectDialog(Declarative.Handler):
+    def __init__(self, ui: UserInterface.UserInterface, document_controller: DocumentController.DocumentController,
+                 application: Application, directory: str, project_name: str, accept_fn: typing.Callable[[str, str], None],
+                 dialog_name: str, choose_directory_visible: bool,
+                 check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult]):
+        """Declarative Dialog handler for creating/renaming a project.
+
+        accept_fn will receive the name and directory when the confirm button is pressed
+        choose_directory_visible will show the choose directory button when set to True.
+        dialog_name is the text to show on the confirm button and in the dialog title.
+        project_name_available_fn is the ProjectStorageSystem function to check if the project exists, that takes the project name and base directory and returns a ProjectNameResult. If None, no check for an existing project will be done.
+        """
+        super().__init__()
+        self.ui = ui
+        self.__application = application
+        self.viewmodel = NameProjectViewModel(project_name, directory, self.__application.profile, check_name_available_fn)
+        self._project_name_line_edit: UserInterface.LineEditWidget | None = None
+        self.accept_fn = accept_fn
+        # build the UI
+        u = Declarative.DeclarativeUI()
+
+        title = dialog_name
+        directory_header = u.create_row(
+            u.create_spacing(13),
+            u.create_label(text=_("Projects Folder: ")),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        show_directory_row = u.create_row(
+            u.create_spacing(26),
+            u.create_label(text="@binding(viewmodel.directory.value)", min_width=280, size_policy_horizontal='min-expanding', text_alignment_vertical='top'),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        choose_directory_row = u.create_row(
+            u.create_spacing(26),
+            u.create_push_button(text=_("Choose..."), on_clicked="choose_directory"),
+            u.create_stretch(),
+            u.create_spacing(13), visible=choose_directory_visible
+        )
+
+        project_name_header_row = u.create_row(
+            u.create_spacing(13),
+            u.create_label(text=_("Project Name: ")),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        project_name_row = u.create_row(
+            u.create_spacing(26),
+            u.create_line_edit(name="_project_name_line_edit", text="@binding(viewmodel.filename.value)", width=400,
+                               on_text_edited="handle_project_name_changed", on_escape_pressed="handle_cancel", on_return_pressed="handle_accept"),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        project_name_status_row = u.create_row(
+            u.create_spacing(26),
+            u.create_label(text="@binding(viewmodel.project_name_status_label.value)", color="red"),
+            u.create_stretch(),
+            u.create_spacing(13)
+        )
+
+        column = u.create_column(
+            u.create_spacing(12),
+            directory_header,
+            u.create_spacing(8),
+            show_directory_row,
+            u.create_spacing(8),
+            choose_directory_row,
+            u.create_spacing(8),
+            project_name_header_row,
+            u.create_spacing(8),
+            project_name_row,
+            u.create_spacing(4),
+            project_name_status_row,
+            u.create_stretch(),
+            u.create_spacing(16)
+        )
+
+        self.dialog = typing.cast(Dialog.ActionDialog, Declarative.construct(document_controller.ui, document_controller, u.create_modeless_dialog(column, title=title), self))
+        self.dialog.add_button(_("Cancel"), lambda: True)
+        self._accept_button = self.dialog.add_button(dialog_name, self.handle_accept_clicked)
+
+        def update_accept_button(_: typing.Any) -> None:
+            self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False
+            self._accept_button.tool_tip = self.viewmodel.project_name_status_label.value or str()
+
+        self.__accept_button_enabled_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
+        self.__accept_button_tool_tip_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
+
+        self.viewmodel.update_project_status_label()
+        self.dialog.show()
+        assert self._project_name_line_edit is not None
+        self._project_name_line_edit.focused = True
+        self._project_name_line_edit.select_all()
+
+    def handle_project_name_changed(self, _widget: UserInterface.LineEditWidget, text: str) -> None:
+        self.viewmodel.update_project_status_label(text)
+
+    def choose_directory(self, _widget: UserInterface.PushButtonWidget) -> None:
+        existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Project Directory"), self.viewmodel.directory.value or str())
+        if existing_directory:
+            self.viewmodel.directory.value = existing_directory
+            self.ui.set_persistent_string("project_directory", existing_directory)
+        self.viewmodel.update_project_status_label()
+
+    def handle_accept_clicked(self) -> bool:
+        self.viewmodel.update_project_status_label()
+        if self._accept_button.enabled:
+            self.dialog.request_close()
+            self.accept_fn(self.viewmodel.filename.value or "Untitled", self.viewmodel.directory.value or str())
+        return False
+
+    def handle_accept(self, widget: UserInterface.Widget) -> bool:
+        self.handle_accept_clicked()
+        return True
+
+    def handle_cancel(self, widget: UserInterface.Widget) -> bool:
+        self.dialog.request_close()
+        return True
 
 
 UIWindow.register_action(NewProjectAction())

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -908,6 +908,41 @@ class Application(UIApplication.BaseApplication):
 
         self.event_loop.call_later(command_delay or 0.0, execute_next_command, commands, list(commands), command_delay or 0.0, repeat or 1)
 
+    def rename_project(self, project_reference: Profile.ProjectReference, name: str) -> None:
+        """Rename the project reference to the given name.
+
+        If the project reference is the current project, it will be closed and reopened after renaming to update the title.
+        """
+        with self.prevent_close():
+            old_title = project_reference.title
+            renaming_current_project = self.profile.last_project_reference == project_reference.uuid
+            document_controller = self.document_controllers[0]
+            assert document_controller is not None
+            if renaming_current_project:
+                document_controller.request_close()
+            error_message: str | None = None
+            new_project_reference: Profile.ProjectReference | None = None
+            try:
+                new_project_reference, rename_result = self.profile.rename_project(project_reference, name)
+                error_message = "\n".join(rename_result.error_messages)
+            except Exception as e:
+                # Catch and log any exceptions during the rename process
+                error_message = _("Exception during renaming project")
+                logging.exception(e)
+                new_project_reference = project_reference
+            finally:
+                # Reopen the project only when renaming the current project and when the project reference is returned
+                if renaming_current_project and new_project_reference is not None:
+                    self.switch_project_reference(new_project_reference)
+                    assert new_project_reference.project is not None
+                    new_project_reference.project.title = name
+                    self.profile.last_project_reference = new_project_reference.uuid
+
+                if error_message:
+                    self.__show_project_error_dialog(_("Error Renaming Project"), error_message)
+                else:
+                    logging.info(f"Renamed Project \"{old_title}\" to \"{name}\"")
+
 
 def get_root_dir() -> str:
     root_dir = os.path.dirname((os.path.dirname(os.path.abspath(__file__))))

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1039,8 +1039,8 @@ class NewProjectAction(UIWindow.Action):
         project_title = self.get_project_base_name(directory)
 
         def handle_create_clicked(new_name: str, new_directory: str) -> None:
-            self.set_string_property(context, "name", new_name)
-            self.set_string_property(context, "directory", new_directory)
+            self.set_string_property(context,"name", new_name)
+            self.set_string_property(context,"directory", new_directory)
             self.execute(context)
 
         NameProjectDialog(application.ui, document_controller, application, directory, project_name=project_title,
@@ -1091,8 +1091,8 @@ class NameProjectViewModel:
 
     @staticmethod
     def verify_project_name(project_name: str, base_directory: str, profile: Profile.Profile,
-                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None
-                            ) -> tuple[bool, typing.Sequence[str] | None]:
+                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
+            -> tuple[bool, typing.Sequence[str] | None]:
         """Verify that a project name is a valid filename and doesn't already exist."""
         if project_name == "":
             return False, ["Project name cannot be empty"]
@@ -1105,7 +1105,7 @@ class NameProjectViewModel:
             name_available_result = check_name_available_fn(project_name, base_directory)
             errors.extend(name_available_result.error_messages or [])
             if name_available_result.success and name_available_result.project_path:
-                # Check if an orphaned project reference exists, it would need to be removed manually by the user as there is no way for to do that automatically
+                # Check for an orphaned project reference exists, it would need to be removed manually
                 project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
                 if project_reference is not None:
                     errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
@@ -1114,7 +1114,7 @@ class NameProjectViewModel:
 
     def update_project_status_label(self, project_name: str | None = None, directory: str | None = None) -> None:
         project_name = project_name or self.filename.value or str()
-        directory = directory or self.directory.value or str()
+        directory = directory or self.directory.value
 
         is_valid, errors = self.verify_project_name(project_name, directory, self.profile, self.check_name_available_fn)
 
@@ -1136,8 +1136,7 @@ class NameProjectDialog(Declarative.Handler):
         accept_fn will receive the name and directory when the confirm button is pressed
         choose_directory_visible will show the choose directory button when set to True.
         dialog_name is the text to show on the confirm button and in the dialog title.
-        check_name_available_fn is the ProjectStorageSystem function to check if the project exists.
-        It takes the project name and base directory and returns a ProjectNameResult.
+        project_name_available_fn is the ProjectStorageSystem function to check if the project exists, that takes the project name and base directory and returns a ProjectNameResult. If None, no check for an existing project will be done.
         """
         super().__init__()
         self.ui = ui
@@ -1213,12 +1212,12 @@ class NameProjectDialog(Declarative.Handler):
         self.dialog.add_button(_("Cancel"), lambda: True)
         self._accept_button = self.dialog.add_button(dialog_name, self.handle_accept_clicked)
 
-        def update_accept_button(_: str | bool | None) -> None:
+        def update_accept_button(_: typing.Any) -> None:
             self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False
             self._accept_button.tool_tip = self.viewmodel.project_name_status_label.value or str()
 
-        self.__accept_button_enabled_action: Stream.ValueStreamAction[str | bool | None] = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
-        self.__accept_button_tool_tip_action: Stream.ValueStreamAction[str | bool | None] = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
+        self.__accept_button_enabled_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
+        self.__accept_button_tool_tip_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
 
         self.viewmodel.update_project_status_label()
         self.dialog.show()

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1002,148 +1002,49 @@ PreferencesDialog.PreferencesManager().register_preference_pane(FeaturesPreferen
 class NewProjectAction(UIWindow.Action):
     action_id = "project.new_project"
     action_name = _("New Project...")
+    check_project_name_is_available = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available  # The FileProjectStorageSystem is used as the default project storage system
+
+    @staticmethod
+    def get_project_base_name(directory: str) -> str:
+        """Get a default project base name using the current datetime.
+
+        If a project already exists with that name in the directory then try appending an index to the name until a unique name is found.
+        """
+        project_base_name = _("Nion Swift Project") + " " + datetime.datetime.now().strftime("%Y%m%d")
+        project_base_index_str = ""
+        for i in range(1, 9999):
+            name_available_result = NewProjectAction.check_project_name_is_available(project_base_name + project_base_index_str, directory)
+            if name_available_result.success:
+                break
+            project_base_index_str = f" ({str(i)})"
+
+        return project_base_name + project_base_index_str
 
     def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
-        raise NotImplementedError()
+        application = typing.cast(Application, context.application)
+        with application.prevent_close():
+            project_name = self.get_string_property(context, "name")
+            directory = self.get_string_property(context, "directory")
+            assert project_name is not None
+            assert directory is not None
+            application.create_project_reference(pathlib.Path(directory), project_name)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
     def invoke(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
         context = typing.cast(DocumentController.DocumentController.ActionContext, context)
-
-        class NewProjectDialog(Dialog.ActionDialog):
-
-            def __init__(self, ui: UserInterface.UserInterface, app: Application, event_loop: asyncio.AbstractEventLoop, profile: Profile.Profile) -> None:
-                super().__init__(ui, title=_("New Project"), app=app, persistent_id="new_project_dialog")
-
-                self.directory = self.ui.get_persistent_string("project_directory", self.ui.get_document_location())
-
-                project_base_name = _("Nion Swift Project") + " " + datetime.datetime.now().strftime("%Y%m%d")
-                project_base_index = 0
-                project_base_index_str = ""
-                while os.path.exists(os.path.join(self.directory, project_base_name + project_base_index_str)):
-                    project_base_index += 1
-                    project_base_index_str = " " + str(project_base_index)
-
-                self.project_name = project_base_name + project_base_index_str
-
-                def handle_close() -> bool:
-                    self.request_close()
-                    return True
-
-                # this is invoked by the button. the dialog will be closed by returning True. see Dialog.add_button.
-                # it should not explicitly close the dialog.
-                def handle_new() -> bool:
-                    app.create_project_reference(pathlib.Path(self.directory), self.__project_name_field.text or "untitled")
-                    return True
-
-                # this is invoked by pressing return in the project name field. it will create the project and close the dialog.
-                def handle_new_and_close() -> bool:
-                    handle_new()
-                    self.request_close()
-                    return True
-
-                def verify_project_name(text: str) -> None:
-                    is_valid, errors = Utility.verify_filename_is_legal(text)
-                    create_project_button.enabled = is_valid
-                    if errors is None:
-                        create_project_button.tool_tip = None
-                        project_name_status_label.text = None
-                    else:
-                        error_str = "\n".join(errors)
-                        create_project_button.tool_tip = error_str
-                        project_name_status_label.text = error_str
-                        project_name_status_label.text_color = "red"
-                column = self.ui.create_column_widget()
-
-                directory_header_row = self.ui.create_row_widget()
-                directory_header_row.add_spacing(13)
-                directory_header_row.add(self.ui.create_label_widget(_("Projects Folder: "), properties={"font": "bold"}))
-                directory_header_row.add_stretch()
-                directory_header_row.add_spacing(13)
-
-                show_directory_row = self.ui.create_row_widget()
-                show_directory_row.add_spacing(26)
-                directory_label = self.ui.create_label_widget(self.directory)
-                show_directory_row.add(directory_label)
-                show_directory_row.add_stretch()
-                show_directory_row.add_spacing(13)
-
-                choose_directory_row = self.ui.create_row_widget()
-                choose_directory_row.add_spacing(26)
-                choose_directory_button = self.ui.create_push_button_widget(_("Choose..."))
-                choose_directory_row.add(choose_directory_button)
-                choose_directory_row.add_stretch()
-                choose_directory_row.add_spacing(13)
-
-                project_name_header_row = self.ui.create_row_widget()
-                project_name_header_row.add_spacing(13)
-                project_name_header_row.add(self.ui.create_label_widget(_("Project Name: "), properties={"font": "bold"}))
-                project_name_header_row.add_stretch()
-                project_name_header_row.add_spacing(13)
-
-                project_name_row = self.ui.create_row_widget()
-                project_name_row.add_spacing(26)
-                project_name_field = self.ui.create_line_edit_widget(properties={"width": 400})
-                project_name_field.text = self.project_name
-                project_name_field.on_return_pressed = handle_new_and_close
-                project_name_field.on_escape_pressed = handle_close
-                project_name_field.on_text_edited = verify_project_name
-                project_name_row.add(project_name_field)
-                project_name_row.add_stretch()
-                project_name_row.add_spacing(13)
-
-                project_name_status_label = self.ui.create_label_widget()
-                project_name_status_row = self.ui.create_row_widget()
-                project_name_status_row.add_spacing(26)
-                project_name_status_row.add(project_name_status_label)
-                project_name_status_row.add_stretch()
-                project_name_status_row.add_spacing(13)
-
-                column.add_spacing(12)
-                column.add(directory_header_row)
-                column.add_spacing(8)
-                column.add(show_directory_row)
-                column.add_spacing(8)
-                column.add(choose_directory_row)
-                column.add_spacing(16)
-                column.add(project_name_header_row)
-                column.add_spacing(8)
-                column.add(project_name_row)
-                column.add_spacing(4)
-                column.add(project_name_status_row)
-                column.add_stretch()
-                column.add_spacing(16)
-
-                def choose() -> None:
-                    existing_directory, directory = self.ui.get_existing_directory_dialog(_("Choose Project Directory"), self.directory)
-                    if existing_directory:
-                        self.directory = existing_directory
-                        directory_label.text = self.directory
-                        self.ui.set_persistent_string("project_directory", self.directory)
-
-                choose_directory_button.on_clicked = choose
-
-                self.add_button(_("Cancel"), lambda: True)
-                create_project_button = self.add_button(_("Create Project"), handle_new)
-
-                self.content.add(column)
-
-                self.__project_name_field = project_name_field
-
-            def close(self) -> None:
-                if self.app:
-                    self.app._exit_prevent_close_state()
-                super().close()
-
-            def show(self, *, size: typing.Optional[Geometry.IntSize] = None, position: typing.Optional[Geometry.IntPoint] = None) -> None:
-                super().show(size=size, position=position)
-                self.__project_name_field.focused = True
-                self.__project_name_field.select_all()
-
+        document_controller = typing.cast(DocumentController.DocumentController, context.window)
         application = typing.cast(Application, context.application)
-        profile = application.profile
-        application._enter_prevent_close_state()
-        new_project_dialog = NewProjectDialog(application.ui, application, application.event_loop, profile)
-        new_project_dialog.show()
+        directory = application.ui.get_persistent_string("project_directory", application.ui.get_document_location())
+        project_title = self.get_project_base_name(directory)
+
+        def handle_create_clicked(new_name: str, new_directory: str) -> None:
+            self.set_string_property(context,"name", new_name)
+            self.set_string_property(context,"directory", new_directory)
+            self.execute(context)
+
+        NameProjectDialog(application.ui, document_controller, application, directory, project_name=project_title,
+                          accept_fn=handle_create_clicked, dialog_name="New Project", choose_directory_visible=True,
+                          check_name_available_fn=NewProjectAction.check_project_name_is_available)
 
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1009,10 +1009,11 @@ class NewProjectAction(UIWindow.Action):
         """Get a default project base name using the current datetime.
 
         If a project already exists with that name in the directory then try appending an index to the name until a unique name is found.
+        The max index checked is 999, so in that case the project name will not be unique.
         """
         project_base_name = _("Nion Swift Project") + " " + datetime.datetime.now().strftime("%Y%m%d")
         project_base_index_str = ""
-        for i in range(1, 9999):
+        for i in range(1, 1000):
             name_available_result = NewProjectAction.check_project_name_is_available(project_base_name + project_base_index_str, directory)
             if name_available_result.success:
                 break
@@ -1038,8 +1039,8 @@ class NewProjectAction(UIWindow.Action):
         project_title = self.get_project_base_name(directory)
 
         def handle_create_clicked(new_name: str, new_directory: str) -> None:
-            self.set_string_property(context,"name", new_name)
-            self.set_string_property(context,"directory", new_directory)
+            self.set_string_property(context, "name", new_name)
+            self.set_string_property(context, "directory", new_directory)
             self.execute(context)
 
         NameProjectDialog(application.ui, document_controller, application, directory, project_name=project_title,
@@ -1090,8 +1091,8 @@ class NameProjectViewModel:
 
     @staticmethod
     def verify_project_name(project_name: str, base_directory: str, profile: Profile.Profile,
-                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None) \
-            -> tuple[bool, typing.Sequence[str] | None]:
+                            check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None = None
+                            ) -> tuple[bool, typing.Sequence[str] | None]:
         """Verify that a project name is a valid filename and doesn't already exist."""
         if project_name == "":
             return False, ["Project name cannot be empty"]
@@ -1104,7 +1105,7 @@ class NameProjectViewModel:
             name_available_result = check_name_available_fn(project_name, base_directory)
             errors.extend(name_available_result.error_messages or [])
             if name_available_result.success and name_available_result.project_path:
-                # Check for an orphaned project reference exists, it would need to be removed manually
+                # Check if an orphaned project reference exists, it would need to be removed manually by the user as there is no way for to do that automatically
                 project_reference = profile.get_project_reference_by_path(name_available_result.project_path)
                 if project_reference is not None:
                     errors.append(_("Project Reference") + f" \"{project_reference.title}\" " + _("already exists, remove it via Choose Project before proceeding"))
@@ -1113,7 +1114,7 @@ class NameProjectViewModel:
 
     def update_project_status_label(self, project_name: str | None = None, directory: str | None = None) -> None:
         project_name = project_name or self.filename.value or str()
-        directory = directory or self.directory.value
+        directory = directory or self.directory.value or str()
 
         is_valid, errors = self.verify_project_name(project_name, directory, self.profile, self.check_name_available_fn)
 
@@ -1135,7 +1136,8 @@ class NameProjectDialog(Declarative.Handler):
         accept_fn will receive the name and directory when the confirm button is pressed
         choose_directory_visible will show the choose directory button when set to True.
         dialog_name is the text to show on the confirm button and in the dialog title.
-        project_name_available_fn is the ProjectStorageSystem function to check if the project exists, that takes the project name and base directory and returns a ProjectNameResult. If None, no check for an existing project will be done.
+        check_name_available_fn is the ProjectStorageSystem function to check if the project exists.
+        It takes the project name and base directory and returns a ProjectNameResult.
         """
         super().__init__()
         self.ui = ui
@@ -1211,12 +1213,12 @@ class NameProjectDialog(Declarative.Handler):
         self.dialog.add_button(_("Cancel"), lambda: True)
         self._accept_button = self.dialog.add_button(dialog_name, self.handle_accept_clicked)
 
-        def update_accept_button(_: typing.Any) -> None:
+        def update_accept_button(_: str | bool | None) -> None:
             self._accept_button.enabled = self.viewmodel.accept_button_enabled.value or False
             self._accept_button.tool_tip = self.viewmodel.project_name_status_label.value or str()
 
-        self.__accept_button_enabled_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
-        self.__accept_button_tool_tip_action = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
+        self.__accept_button_enabled_action: Stream.ValueStreamAction[str | bool | None] = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.accept_button_enabled, "value"), update_accept_button)
+        self.__accept_button_tool_tip_action: Stream.ValueStreamAction[str | bool | None] = Stream.ValueStreamAction(Stream.PropertyChangedEventStream(self.viewmodel.project_name_status_label, "value"), update_accept_button)
 
         self.viewmodel.update_project_status_label()
         self.dialog.show()

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -742,6 +742,14 @@ class Application(UIApplication.BaseApplication):
                             profile.remove_project_reference(project_reference_item.project_reference)
 
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
+
+                        def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
+                            action = RenameProjectAction(project_reference)
+                            document_controller = self.__application.document_controllers[0]
+                            action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
+
+                        menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
+
                         menu.popup(gx, gy)
                     return True
 
@@ -1113,6 +1121,61 @@ class ChooseProjectAction(UIWindow.Action):
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
+class RenameProjectAction(UIWindow.Action):
+    """Renames the current project, if it exists. If the current project is not found, this action does nothing.
+
+    The invoke method must be used to call the rename function, calling execute will raise a NotImplementedError.
+    """
+    action_id = "project.rename_current_project"
+    action_name = _("Rename Project")
+    action_parameters = [
+        UIWindow.ActionStringProperty("name")
+    ]
+
+    def __init__(self, project_reference: Profile.ProjectReference | None = None) -> None:
+        super().__init__()
+        self.project_reference = project_reference
+
+    def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        assert self.project_reference is not None
+        project_name = self.get_string_property(context, "name")
+        assert project_name is not None
+        application = typing.cast(Application, context.application)
+        application.rename_project(self.project_reference, project_name)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+    def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        context = typing.cast(DocumentController.DocumentController.ActionContext, context_)
+        document_controller = typing.cast(DocumentController.DocumentController, context.window)
+        application = typing.cast(Application, context.application)
+
+        if self.project_reference is None:  # If the project reference is not set then use the current project reference
+            last_project_uuid = application.profile.last_project_reference
+            if last_project_uuid is not None:
+                self.project_reference = application.profile.get_project_reference(last_project_uuid)
+
+        if self.project_reference is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        if self.project_reference.project is None:
+            project_storage_system = self.project_reference.make_storage(application.profile.profile_context)
+        else:
+            project_storage_system = self.project_reference.project.project_storage_system
+
+        if project_storage_system is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        def handle_rename_clicked(new_name: str, _: str) -> None:
+            self.set_string_property(context,"name", new_name)
+            self.execute(context)
+
+        directory = self.project_reference.path.parent.as_posix()
+        NameProjectDialog(application.ui, document_controller, application, directory, project_name=self.project_reference.title,
+                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False,
+                          check_name_available_fn=project_storage_system.check_project_name_is_available)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+
 class NameProjectViewModel:
     """Represents the NameProjectDialog model."""
     def __init__(self, filename: str, directory: str, profile: Profile.Profile, check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None):
@@ -1289,3 +1352,4 @@ class NameProjectDialog(Declarative.Handler):
 UIWindow.register_action(NewProjectAction())
 UIWindow.register_action(OpenProjectAction())
 UIWindow.register_action(ChooseProjectAction())
+UIWindow.register_action(RenameProjectAction())

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -734,7 +734,8 @@ class Application(UIApplication.BaseApplication):
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
 
                         def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
-                            action = RenameProjectAction(project_reference, accept_fn=self.close_window)
+                            action = RenameProjectAction()
+                            action.project_reference = project_reference
                             document_controller = self.__application.document_controllers[0]
                             action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
 
@@ -1101,15 +1102,13 @@ class ChooseProjectAction(UIWindow.Action):
 class RenameProjectAction(UIWindow.Action):
     """Rename a project.
 
-    If initialized with a project_reference then that will be used instead of using the current project.
+    If self.project_reference is set then it will be used instead of using the current project.
     Calling invoke will cause a UI window to appear prompting to rename the project which calls execute with the name provided.
     Calling execute uses the stored name to get the application to rename the project.
-    The accept_fn if provided is called before execute when the new project button is clicked in the UI window.
     """
-    def __init__(self, project_reference: Profile.ProjectReference | None = None, accept_fn: typing.Callable[[], None] | None = None) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.accept_fn = accept_fn
-        self.project_reference = project_reference
+        self.project_reference: Profile.ProjectReference | None = None
 
     action_id = "project.rename_project"
     action_name = _("Rename Project")
@@ -1127,7 +1126,6 @@ class RenameProjectAction(UIWindow.Action):
         application.rename_project(self.project_reference, project_name)
         # Clear the now invalid project_reference so if this is invoked again it gets the latest project reference
         self.project_reference = None
-        self.accept_fn = None
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
     def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
@@ -1151,8 +1149,6 @@ class RenameProjectAction(UIWindow.Action):
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
         def handle_rename_clicked(new_name: str, _: str) -> None:
-            if callable(self.accept_fn):
-                self.accept_fn()
             self.set_string_property(context, "name", new_name)
             self.execute(context)
 

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -1116,7 +1116,8 @@ class RenameProjectAction(UIWindow.Action):
     action_parameters = [
         UIWindow.ActionStringProperty("name")
     ]
-    check_project_name_is_available = FileStorageSystem.check_file_project_name_is_available  # The FileProjectStorageSystem is used as the default project storage system
+    # The FileProjectStorageSystem is used as the default project storage system
+    check_project_name_is_available = FileStorageSystem.check_file_project_name_is_available
 
     def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
         assert self.project_reference is not None
@@ -1124,7 +1125,8 @@ class RenameProjectAction(UIWindow.Action):
         assert project_name is not None
         application = typing.cast(Application, context.application)
         application.rename_project(self.project_reference, project_name)
-        self.project_reference = None  # Clear the now invalid project_reference so if it is invoked again it get the current project reference again
+        # Clear the now invalid project_reference so if this is invoked again it gets the latest project reference
+        self.project_reference = None
         self.accept_fn = None
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -937,7 +937,7 @@ class Application(UIApplication.BaseApplication):
                 # Catch and log any exceptions during the rename process
                 error_message = _("Exception during renaming project")
                 logging.exception(e)
-                new_project_reference = project_reference
+                new_project_reference = project_reference if self.profile.get_project_reference(project_reference.uuid) else None
             finally:
                 # Reopen the project only when renaming the current project and when the project reference is returned
                 if renaming_current_project and new_project_reference is not None:
@@ -1124,7 +1124,7 @@ class RenameProjectAction(UIWindow.Action):
         assert project_name is not None
         application = typing.cast(Application, context.application)
         application.rename_project(self.project_reference, project_name)
-        self.project_reference = None  # The same action is reused by the action so clear it no that it is invalid
+        self.project_reference = None  # Clear the now invalid project_reference so if it is invoked again it get the current project reference again
         self.accept_fn = None
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
@@ -1141,15 +1141,6 @@ class RenameProjectAction(UIWindow.Action):
             application.show_ok_dialog(_("Rename Project Error"), message="Unable to rename project. No project reference could be found.")
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
-        if self.project_reference.project is None:
-            project_storage_system = self.project_reference.make_storage(application.profile.profile_context)
-        else:
-            project_storage_system = self.project_reference.project.project_storage_system
-
-        if project_storage_system is None:
-            application.show_ok_dialog(_("Rename Project Error"), message="Unable to rename project. Project storage system could not be found.")
-            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
-
         directory = self.project_reference.path.parent.as_posix()
         check_project_result = RenameProjectAction.check_project_name_is_available(self.project_reference.title, directory)
 
@@ -1158,7 +1149,9 @@ class RenameProjectAction(UIWindow.Action):
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
         def handle_rename_clicked(new_name: str, _: str) -> None:
-            self.set_string_property(context,"name", new_name)
+            if callable(self.accept_fn):
+                self.accept_fn()
+            self.set_string_property(context, "name", new_name)
             self.execute(context)
 
         NameProjectDialog(application.ui, application, directory, project_name=self.project_reference.title,

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -734,7 +734,7 @@ class Application(UIApplication.BaseApplication):
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
 
                         def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
-                            action = RenameProjectAction(project_reference)
+                            action = RenameProjectAction(project_reference, accept_fn=self.close_window)
                             document_controller = self.__application.document_controllers[0]
                             action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
 
@@ -1099,19 +1099,24 @@ class ChooseProjectAction(UIWindow.Action):
 
 
 class RenameProjectAction(UIWindow.Action):
-    """Renames the current project, if it exists. If the current project is not found, this action does nothing.
+    """Rename a project.
 
-    The invoke method must be used to call the rename function, calling execute will raise a NotImplementedError.
+    If initialized with a project_reference then that will be used instead of using the current project.
+    Calling invoke will cause a UI window to appear prompting to rename the project which calls execute with the name provided.
+    Calling execute uses the stored name to get the application to rename the project.
+    The accept_fn if provided is called before execute when the new project button is clicked in the UI window.
     """
-    action_id = "project.rename_current_project"
+    def __init__(self, project_reference: Profile.ProjectReference | None = None, accept_fn: typing.Callable[[], None] | None = None) -> None:
+        super().__init__()
+        self.accept_fn = accept_fn
+        self.project_reference = project_reference
+
+    action_id = "project.rename_project"
     action_name = _("Rename Project")
     action_parameters = [
         UIWindow.ActionStringProperty("name")
     ]
-
-    def __init__(self, project_reference: Profile.ProjectReference | None = None) -> None:
-        super().__init__()
-        self.project_reference = project_reference
+    check_project_name_is_available = FileStorageSystem.check_file_project_name_is_available  # The FileProjectStorageSystem is used as the default project storage system
 
     def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
         assert self.project_reference is not None
@@ -1119,11 +1124,12 @@ class RenameProjectAction(UIWindow.Action):
         assert project_name is not None
         application = typing.cast(Application, context.application)
         application.rename_project(self.project_reference, project_name)
+        self.project_reference = None  # The same action is reused by the action so clear it no that it is invalid
+        self.accept_fn = None
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
     def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
         context = typing.cast(DocumentController.DocumentController.ActionContext, context_)
-        document_controller = typing.cast(DocumentController.DocumentController, context.window)
         application = typing.cast(Application, context.application)
 
         if self.project_reference is None:  # If the project reference is not set then use the current project reference
@@ -1132,6 +1138,7 @@ class RenameProjectAction(UIWindow.Action):
                 self.project_reference = application.profile.get_project_reference(last_project_uuid)
 
         if self.project_reference is None:
+            application.show_ok_dialog(_("Rename Project Error"), message="Unable to rename project. No project reference could be found.")
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
         if self.project_reference.project is None:
@@ -1140,16 +1147,23 @@ class RenameProjectAction(UIWindow.Action):
             project_storage_system = self.project_reference.project.project_storage_system
 
         if project_storage_system is None:
+            application.show_ok_dialog(_("Rename Project Error"), message="Unable to rename project. Project storage system could not be found.")
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        directory = self.project_reference.path.parent.as_posix()
+        check_project_result = RenameProjectAction.check_project_name_is_available(self.project_reference.title, directory)
+
+        if check_project_result.success:
+            application.show_ok_dialog(_("Rename Project Error"), message="Unable to rename project. Project reference does not have any project file available.")
             return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
 
         def handle_rename_clicked(new_name: str, _: str) -> None:
             self.set_string_property(context,"name", new_name)
             self.execute(context)
 
-        directory = self.project_reference.path.parent.as_posix()
-        NameProjectDialog(application.ui, document_controller, application, directory, project_name=self.project_reference.title,
+        NameProjectDialog(application.ui, application, directory, project_name=self.project_reference.title,
                           accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False,
-                          check_name_available_fn=project_storage_system.check_project_name_is_available)
+                          check_name_available_fn=RenameProjectAction.check_project_name_is_available, parent_window=context.window)
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 

--- a/nion/swift/Application.py
+++ b/nion/swift/Application.py
@@ -732,6 +732,14 @@ class Application(UIApplication.BaseApplication):
                             profile.remove_project_reference(project_reference_item.project_reference)
 
                         menu.add_menu_item(_(f"Remove Project from List"), functools.partial(remove_project, index))
+
+                        def rename_selected_project(project_reference: Profile.ProjectReference) -> None:
+                            action = RenameProjectAction(project_reference)
+                            document_controller = self.__application.document_controllers[0]
+                            action.invoke(UIWindow.ActionContext(self.__application, document_controller, None))
+
+                        menu.add_menu_item(_("Rename Project"), functools.partial(rename_selected_project, project_reference_item.project_reference))
+
                         menu.popup(gx, gy)
                     return True
 
@@ -1090,6 +1098,61 @@ class ChooseProjectAction(UIWindow.Action):
         return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
 
 
+class RenameProjectAction(UIWindow.Action):
+    """Renames the current project, if it exists. If the current project is not found, this action does nothing.
+
+    The invoke method must be used to call the rename function, calling execute will raise a NotImplementedError.
+    """
+    action_id = "project.rename_current_project"
+    action_name = _("Rename Project")
+    action_parameters = [
+        UIWindow.ActionStringProperty("name")
+    ]
+
+    def __init__(self, project_reference: Profile.ProjectReference | None = None) -> None:
+        super().__init__()
+        self.project_reference = project_reference
+
+    def execute(self, context: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        assert self.project_reference is not None
+        project_name = self.get_string_property(context, "name")
+        assert project_name is not None
+        application = typing.cast(Application, context.application)
+        application.rename_project(self.project_reference, project_name)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+    def invoke(self, context_: UIWindow.ActionContext) -> UIWindow.ActionResult:
+        context = typing.cast(DocumentController.DocumentController.ActionContext, context_)
+        document_controller = typing.cast(DocumentController.DocumentController, context.window)
+        application = typing.cast(Application, context.application)
+
+        if self.project_reference is None:  # If the project reference is not set then use the current project reference
+            last_project_uuid = application.profile.last_project_reference
+            if last_project_uuid is not None:
+                self.project_reference = application.profile.get_project_reference(last_project_uuid)
+
+        if self.project_reference is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        if self.project_reference.project is None:
+            project_storage_system = self.project_reference.make_storage(application.profile.profile_context)
+        else:
+            project_storage_system = self.project_reference.project.project_storage_system
+
+        if project_storage_system is None:
+            return UIWindow.ActionResult(UIWindow.ActionStatus.CANCELLED)
+
+        def handle_rename_clicked(new_name: str, _: str) -> None:
+            self.set_string_property(context,"name", new_name)
+            self.execute(context)
+
+        directory = self.project_reference.path.parent.as_posix()
+        NameProjectDialog(application.ui, document_controller, application, directory, project_name=self.project_reference.title,
+                          accept_fn=handle_rename_clicked, dialog_name="Rename Project", choose_directory_visible=False,
+                          check_name_available_fn=project_storage_system.check_project_name_is_available)
+        return UIWindow.ActionResult(UIWindow.ActionStatus.FINISHED)
+
+
 class NameProjectViewModel:
     """Represents the NameProjectDialog model."""
     def __init__(self, filename: str, directory: str, profile: Profile.Profile, check_name_available_fn: typing.Callable[[str, str], FileStorageSystem.ProjectNameResult] | None):
@@ -1277,3 +1340,4 @@ class NameProjectDialog(Declarative.WindowHandler):
 UIWindow.register_action(NewProjectAction())
 UIWindow.register_action(OpenProjectAction())
 UIWindow.register_action(ChooseProjectAction())
+UIWindow.register_action(RenameProjectAction())

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -664,12 +664,12 @@ class ProjectStorageSystem(PersistentStorageSystem):
     def rename_project(self, name: str) -> ProjectNameResult:
         """Rename the project.
 
-        Returns a ProjectRenameResult.
-        ProjectRenameResult.project_path will be the new project path or the original if the project path did not change.
-        ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
+        Returns a ProjectNameResult.
+        ProjectNameResult.project_path will be the new project path or the original if the project path did not change.
+        ProjectNameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
         The project path changing names does not indicate success, only the ProjectNameResult.success should be used to check success.
         """
-        return ProjectNameResult(["Project renaming is not supported for this storage system."], None)
+        return ProjectNameResult([_("Project renaming is not supported for this storage system.")], None)
 
     @property
     def _data_properties_map(self) -> typing.Dict[uuid.UUID, DataItemStorageAdapter]:

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -1191,6 +1191,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         old_data_path = self.__project_data_path
         old_project_path = self.__project_path
         new_project_path = old_project_path.parent / f"{name}.nsproj"
+        new_data_path = old_data_path.parent / f"{name} Data" if old_data_path else ""
         try:
             self.__project_path = old_project_path.rename(new_project_path)
         except Exception as e:
@@ -1199,9 +1200,9 @@ class FileProjectStorageSystem(ProjectStorageSystem):
 
         error_messages = []
         try:
-            # The directory must be checked to exist because load_properties will set the data path to the default even when the directory does not exist
+            # If the directory doesn't exist then don't try renaming it
             if old_data_path is not None:
-                self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
+                self.__project_data_path = old_data_path.rename(new_data_path)
         except Exception as e:
             error_messages.append(_("Exception while renaming the Data Folder"))
             logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -48,7 +48,7 @@ _g_large_format_size = 16 * 1024 * 1024
 
 @dataclasses.dataclass(frozen=True)
 class ProjectNameResult:
-    """Result of checking a project name is available.
+    """Result of checking a project name is available or of renaming a project.
 
     project_path will be None when the project path does not change otherwise it will be the new project path.
     error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
@@ -671,6 +671,16 @@ class ProjectStorageSystem(PersistentStorageSystem):
         """
         return ProjectNameResult([], None)
 
+    def rename_project(self, name: str) -> ProjectNameResult:
+        """Rename the project.
+
+        Returns a ProjectRenameResult.
+        ProjectRenameResult.project_path will be the new project path or the original if the project path did not change.
+        ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
+        The project path changing names does not indicate success, only the ProjectNameResult.success should be used to check success.
+        """
+        return ProjectNameResult(["Project renaming is not supported for this storage system."], None)
+
     @property
     def _data_properties_map(self) -> typing.Dict[uuid.UUID, DataItemStorageAdapter]:
         return self.__storage_adapter_map
@@ -1195,6 +1205,48 @@ class FileProjectStorageSystem(ProjectStorageSystem):
             error_messages.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
 
         return ProjectNameResult(error_messages, new_project_path)
+
+    def rename_project(self, name: str) -> ProjectNameResult:
+        """Renames the project file with the given name. See ProjectStorageSystem.rename_project.
+
+        The returned ProjectRenameResult.project_path will be the new project path.
+        ProjectRenameResult.error_message will be empty when the rename was successful otherwise it will contain error message for the user, the exception is written separately to the logger.
+        The project file and data folder (if the data folder exists) are attempted to be renamed.
+        If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
+        If undoing the renaming of the project file fails then the project file's name will have changed, but there will still be an error message.
+        """
+        self.load_properties()
+        self.normalize_project_data_path()
+        # normalize_project_data_path can set the data path to a non-existent directory instead of None, so if it doesn't exist we set it to None
+        if self.__project_data_path is None or not self.__project_data_path.is_dir():
+            self.__project_data_path = None
+
+        old_data_path = self.__project_data_path
+        old_project_path = self.__project_path
+        new_project_path = old_project_path.parent / f"{name}.nsproj"
+        try:
+            self.__project_path = old_project_path.rename(new_project_path)
+        except Exception as e:
+            logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
+            return ProjectNameResult([_("Exception while renaming the Project File")], self.__project_path)
+
+        error_messages = []
+        try:
+            # The directory must be checked to exist because load_properties will set the data path to the default even when the directory does not exist
+            if old_data_path is not None:
+                self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
+        except Exception as e:
+            error_messages.append(_("Exception while renaming the Data Folder"))
+            logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
+            try:  # Try to undo the rename of the project file when the data folder failed to rename
+                if new_project_path.exists():
+                    self.__project_path = new_project_path.rename(old_project_path)
+            except Exception as e2:
+                error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
+                logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
+
+        self._write_untransformed_properties(self._untransform_properties(self.get_properties()))  # Trigger the writing of the project_data_folders in the project file
+        return ProjectNameResult(error_messages, self.__project_path)
 
 
 class MemoryStorageHandler(StorageHandler.StorageHandler):

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import abc
 import contextlib
 import copy
+import dataclasses
 import datetime
+import gettext
 import json
 import logging
 import traceback
@@ -28,6 +30,7 @@ from nion.swift.model import StorageHandler
 from nion.swift.model import Utility
 from nion.utils import Event
 
+_ = gettext.gettext
 
 # define the versions that get stored in the JSON files
 PROFILE_VERSION = 2
@@ -41,6 +44,22 @@ _CreateStorageHandlerFn = typing.Type[StorageHandler.StorageHandler]
 
 
 _g_large_format_size = 16 * 1024 * 1024
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectNameResult:
+    """Result of checking a project name is available.
+
+    project_path will be None when the project path does not change otherwise it will be the new project path.
+    error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
+    The success property is True when there are no errors and False when there are errors.
+    """
+    error_messages: typing.Sequence[str]
+    project_path: pathlib.Path | None
+
+    @property
+    def success(self) -> bool:
+        return not self.error_messages
 
 
 class ReaderInfo:
@@ -642,7 +661,15 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def normalize_project_data_path(self) -> None: ...
 
-    #
+    @staticmethod
+    def check_project_name_is_available(name: str, directory: str) -> ProjectNameResult:
+        """Check if the provided project name is available for use.
+
+        Returns a ProjectNameResult.
+        ProjectNameResult.project_path is set to the path that would be used for the project if the name is available, otherwise None.
+        ProjectNameResult.error_message contains a sequence of error messages if there are any.
+        """
+        return ProjectNameResult([], None)
 
     @property
     def _data_properties_map(self) -> typing.Dict[uuid.UUID, DataItemStorageAdapter]:
@@ -1144,6 +1171,30 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                         logging.error(str(e))
                         raise
         return storage_handlers
+
+    @staticmethod
+    def check_project_name_is_available(name: str, directory: str) -> ProjectNameResult:
+        """Check if the provided project name is available for use.
+
+        Checks the directory exists then checks that no existing project file or data folder is in that directory with the same name.
+        Returns ProjectNameResult with the calculated project_path and error_messages.
+        """
+        error_messages = []
+        directory_path = pathlib.Path(directory)
+        new_project_path = pathlib.Path(directory, name).with_suffix(".nsproj")
+        if not directory_path.is_dir():
+            error_messages.append(_("Base Directory") + f" \"{directory_path}\" " + _("doesn't exist"))
+            return ProjectNameResult(error_messages, new_project_path)
+
+        new_data_path = new_project_path.parent / f"{name} Data"
+        new_project_path_exists = new_project_path.exists()
+        data_path_exists = new_data_path.is_dir()
+        if new_project_path_exists:
+            error_messages.append(_("Project Name") + f" \"{new_project_path.name}\" " + _("already exists"))
+        if data_path_exists:
+            error_messages.append(_("Data Folder") + f" \"{new_data_path.stem}\" " + _("already exists"))
+
+        return ProjectNameResult(error_messages, new_project_path)
 
 
 class MemoryStorageHandler(StorageHandler.StorageHandler):

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -667,7 +667,7 @@ class ProjectStorageSystem(PersistentStorageSystem):
 
         Returns a ProjectNameResult.
         ProjectNameResult.project_path is set to the path that would be used for the project if the name is available, otherwise None.
-        ProjectNameResult.error_message contains a sequence of error messages if there are any.
+        ProjectNameResult.error_messages contains a sequence of error messages if there are any.
         """
         return ProjectNameResult([], None)
 
@@ -1179,7 +1179,7 @@ class FileProjectStorageSystem(ProjectStorageSystem):
         Checks the directory exists then checks that no existing project file or data folder is in that directory with the same name.
         Returns ProjectNameResult with the calculated project_path and error_messages.
         """
-        error_messages = []
+        error_messages: list[str] = []
         directory_path = pathlib.Path(directory)
         new_project_path = pathlib.Path(directory, name).with_suffix(".nsproj")
         if not directory_path.is_dir():

--- a/nion/swift/model/FileStorageSystem.py
+++ b/nion/swift/model/FileStorageSystem.py
@@ -48,7 +48,7 @@ _g_large_format_size = 16 * 1024 * 1024
 
 @dataclasses.dataclass(frozen=True)
 class ProjectNameResult:
-    """Result of checking a project name is available.
+    """Result of checking a project name is available or of renaming a project.
 
     project_path will be None when the project path does not change otherwise it will be the new project path.
     error_messages will be empty when there are no errors, otherwise it is a sequence of error messages.
@@ -661,6 +661,16 @@ class ProjectStorageSystem(PersistentStorageSystem):
     @abc.abstractmethod
     def normalize_project_data_path(self) -> None: ...
 
+    def rename_project(self, name: str) -> ProjectNameResult:
+        """Rename the project.
+
+        Returns a ProjectRenameResult.
+        ProjectRenameResult.project_path will be the new project path or the original if the project path did not change.
+        ProjectRenameResult.error_message will be empty when there are no errors, otherwise it will be an error message.
+        The project path changing names does not indicate success, only the ProjectNameResult.success should be used to check success.
+        """
+        return ProjectNameResult(["Project renaming is not supported for this storage system."], None)
+
     @property
     def _data_properties_map(self) -> typing.Dict[uuid.UUID, DataItemStorageAdapter]:
         return self.__storage_adapter_map
@@ -1162,6 +1172,48 @@ class FileProjectStorageSystem(ProjectStorageSystem):
                         logging.error(str(e))
                         raise
         return storage_handlers
+
+    def rename_project(self, name: str) -> ProjectNameResult:
+        """Renames the project file with the given name. See ProjectStorageSystem.rename_project.
+
+        The returned ProjectRenameResult.project_path will be the new project path.
+        ProjectRenameResult.error_message will be empty when the rename was successful otherwise it will contain error message for the user, the exception is written separately to the logger.
+        The project file and data folder (if the data folder exists) are attempted to be renamed.
+        If the data folder did exist but failed be renamed then this will attempt to undo the renaming of the project file.
+        If undoing the renaming of the project file fails then the project file's name will have changed, but there will still be an error message.
+        """
+        self.load_properties()
+        self.normalize_project_data_path()
+        # normalize_project_data_path can set the data path to a non-existent directory instead of None, so if it doesn't exist we set it to None
+        if self.__project_data_path is None or not self.__project_data_path.is_dir():
+            self.__project_data_path = None
+
+        old_data_path = self.__project_data_path
+        old_project_path = self.__project_path
+        new_project_path = old_project_path.parent / f"{name}.nsproj"
+        try:
+            self.__project_path = old_project_path.rename(new_project_path)
+        except Exception as e:
+            logging.exception(_("Failed to rename project. Renaming Project File gave an exception:\n") + str(e))
+            return ProjectNameResult([_("Exception while renaming the Project File")], self.__project_path)
+
+        error_messages = []
+        try:
+            # The directory must be checked to exist because load_properties will set the data path to the default even when the directory does not exist
+            if old_data_path is not None:
+                self.__project_data_path = old_data_path.rename(old_data_path.parent / f"{name} Data")
+        except Exception as e:
+            error_messages.append(_("Exception while renaming the Data Folder"))
+            logging.exception(_("Failed to rename project. Renaming Data Folder gave an exception:\n") + str(e))
+            try:  # Try to undo the rename of the project file when the data folder failed to rename
+                if new_project_path.exists():
+                    self.__project_path = new_project_path.rename(old_project_path)
+            except Exception as e2:
+                error_messages.append(_("WARNING: Project File and Data Folder names have diverged"))
+                logging.exception(_("Failed to undo Data Folder rename. Renaming project file gave exception:\n") + str(e2))
+
+        self._write_untransformed_properties(self._untransform_properties(self.get_properties()))  # Trigger the writing of the project_data_folders in the project file
+        return ProjectNameResult(error_messages, self.__project_path)
 
 
 def check_file_project_name_is_available(name: str, directory: str) -> ProjectNameResult:

--- a/nion/swift/model/Profile.py
+++ b/nion/swift/model/Profile.py
@@ -639,6 +639,35 @@ class Profile(Persistence.PersistentObject):
             return self.add_project_index(path, load=False)
         return None
 
+    def rename_project(self, project_reference: ProjectReference, name: str) -> tuple[ProjectReference, FileStorageSystem.ProjectNameResult]:
+        """Rename the project, managing the loading and unloading of the project and calling the ProjectStorageSystem rename_project function.
+
+        Returns the newly loaded project reference and the rename result as a tuple to be unpacked.
+        """
+        project = project_reference.project
+
+        if project is None:
+            project_storage_system = project_reference.make_storage(self.profile_context)
+        else:
+            project_storage_system = project.project_storage_system
+        assert project_storage_system is not None
+
+        if project_reference.project_state == "loaded":
+            project_reference.unload_project()  # Defensively ensure the project is unloaded to avoid a traceback when removing the project reference
+        self.remove_project_reference(project_reference)
+
+        rename_result = project_storage_system.rename_project(name)
+
+        project_path = project_reference.path  # Load the old path unless the returned project path exists
+        if rename_result.project_path is not None and rename_result.project_path.exists():
+            project_path = rename_result.project_path
+
+        # Open project creates and adds the project to the profile, but does not read/load the project.
+        # The project reference should be added even when the renaming fails
+        new_project_reference = self.open_project(project_path)
+        assert new_project_reference is not None
+        return new_project_reference, rename_result
+
     def get_project_reference(self, uuid_: uuid.UUID) -> typing.Optional[ProjectReference]:
         for project_reference in self.project_references:
             if project_reference.uuid == uuid_:

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -23,6 +23,10 @@
                 "items": []
             },
             {
+                "type": "item",
+                "action_id": "project.rename_current_project"
+            },
+            {
                 "type": "separator"
             },
             {

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -24,7 +24,7 @@
             },
             {
                 "type": "item",
-                "action_id": "project.rename_current_project"
+                "action_id": "project.rename_project"
             },
             {
                 "type": "separator"

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -1,6 +1,5 @@
 # standard libraries
 import contextlib
-import copy
 import typing
 import unittest
 
@@ -10,12 +9,10 @@ import numpy
 # local libraries
 from nion.swift import Application
 from nion.swift import Facade
-from nion.swift.model import Connection
 from nion.swift.model import DataItem
-from nion.swift.model import DisplayItem
+from nion.swift.model import FileStorageSystem
 from nion.swift.model import Profile
 from nion.swift.test import TestContext
-from nion.ui import TestUI
 
 
 Facade.initialize()
@@ -82,3 +79,18 @@ class TestProjectClass(unittest.TestCase):
                 project_reference.close()
 
     # do not import same project (by uuid) twice
+
+    def test_project_name_viewmodel_is_invalid_with_existing_reference(self) -> None:
+        with TestContext.MemoryProfileContext() as profile_context:
+            profile = profile_context.create_profile()
+            project_reference = profile.project_references[0]
+            reference_path = project_reference.path
+            base_directory = reference_path.parent
+            # In order to get to the test path the check available function just returns a success with a path to the existing reference
+            def check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
+                return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
+
+            viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, check_project_name_is_available)
+            viewmodel.update_project_status_label(project_reference.title)
+            self.assertFalse(viewmodel.accept_button_enabled.value)
+            self.assertEqual(viewmodel.project_name_status_label.value, f"Project Reference \"{reference_path.stem}\" already exists, remove it via Choose Project before proceeding")

--- a/nion/swift/test/Project_test.py
+++ b/nion/swift/test/Project_test.py
@@ -81,13 +81,15 @@ class TestProjectClass(unittest.TestCase):
     # do not import same project (by uuid) twice
 
     def test_project_name_viewmodel_is_invalid_with_existing_reference(self) -> None:
+        """Test the NameProjectViewModel to check that if the name is available but there is an existing project reference associated with the path there is an error message."""
         with TestContext.MemoryProfileContext() as profile_context:
             profile = profile_context.create_profile()
             project_reference = profile.project_references[0]
             reference_path = project_reference.path
             base_directory = reference_path.parent
-            # In order to get to the test path the check available function just returns a success with a path to the existing reference
+
             def check_project_name_is_available(_name: str, _directory: str) -> FileStorageSystem.ProjectNameResult:
+                # In order to get to the test path the check available function just returns a success with a path to the existing reference
                 return FileStorageSystem.ProjectNameResult([], reference_path)  # Return the project path with no errors so it can be checked against the existing references
 
             viewmodel = Application.NameProjectViewModel(project_reference.title, str(base_directory), profile, check_project_name_is_available)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -26,6 +26,7 @@ from nion.swift import DisplayPanel
 from nion.swift import DocumentController
 from nion.swift import Facade
 from nion.swift import Thumbnails
+from nion.swift.Application import NewProjectAction
 from nion.swift.model import Cache
 from nion.swift.model import Connection
 from nion.swift.model import DataGroup
@@ -4601,6 +4602,50 @@ class TestStorageClass(unittest.TestCase):
         gc.collect()
         memory_usage = memory_usage_resource() - memory_start
         self.assertTrue(memory_usage < 0.2)
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_project(self) -> None:
+        with open("ExistingProject.nsproj", "w"):
+            current_working_directory = pathlib.Path.cwd()
+            check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+            self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+            self.assertEqual(check_name_result.error_messages, ["Project Name \"ExistingProject.nsproj\" already exists"])
+        os.remove("ExistingProject.nsproj")
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_data_folder(self) -> None:
+        os.mkdir("ExistingProject Data")
+        current_working_directory = pathlib.Path.cwd()
+        check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+        self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+        self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
+        os.rmdir("ExistingProject Data")
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_invalid_directory(self) -> None:
+        invalid_directory = pathlib.Path.cwd() / "Not_A_Directory"
+        check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(invalid_directory))
+        self.assertEqual(check_name_result.project_path, (invalid_directory / "ExistingProject").with_suffix(".nsproj"))
+        self.assertEqual(check_name_result.error_messages, [f"Base Directory \"{invalid_directory}\" doesn't exist"])
+
+    def test_get_project_base_name(self) -> None:
+        """Test that the get_project_base_name appends an increment to the end if a file by that name already exists.
+
+        Since the base name uses the date if you got unlucky this test could fail when part ran before midnight and the assertion after but this is unlikely.
+        """
+        with create_temp_profile_context() as profile_context:
+            projects_dir_str = str(profile_context.projects_dir)
+            Cache.db_make_directory_if_needed(projects_dir_str)
+            project_name = NewProjectAction.get_project_base_name(projects_dir_str)
+            # Create a project file at with that name so the next call should increment the name
+            with open(profile_context.projects_dir / pathlib.Path(project_name).with_suffix(".nsproj"), "w"):
+                pass
+
+            project_name_1 = NewProjectAction.get_project_base_name(projects_dir_str)
+            self.assertEqual(project_name_1, f"{project_name} (1)")
+
+            with open(profile_context.projects_dir / pathlib.Path(project_name_1).with_suffix(".nsproj"), "w"):
+                pass
+
+            project_name_2 = NewProjectAction.get_project_base_name(projects_dir_str)
+            self.assertEqual(project_name_2, f"{project_name} (2)")
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -26,7 +26,6 @@ from nion.swift import DisplayPanel
 from nion.swift import DocumentController
 from nion.swift import Facade
 from nion.swift import Thumbnails
-from nion.swift.Application import NewProjectAction
 from nion.swift.model import Cache
 from nion.swift.model import Connection
 from nion.swift.model import DataGroup
@@ -4604,20 +4603,24 @@ class TestStorageClass(unittest.TestCase):
         self.assertTrue(memory_usage < 0.2)
 
     def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_project(self) -> None:
-        with open("ExistingProject.nsproj", "w"):
+        try:
+            with open("ExistingProject.nsproj", "w"):
+                current_working_directory = pathlib.Path.cwd()
+                check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
+                self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
+                self.assertEqual(check_name_result.error_messages, ["Project Name \"ExistingProject.nsproj\" already exists"])
+        finally:
+            os.remove("ExistingProject.nsproj")
+
+    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_data_folder(self) -> None:
+        try:
+            os.mkdir("ExistingProject Data")
             current_working_directory = pathlib.Path.cwd()
             check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
             self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
-            self.assertEqual(check_name_result.error_messages, ["Project Name \"ExistingProject.nsproj\" already exists"])
-        os.remove("ExistingProject.nsproj")
-
-    def test_file_project_storage_system_check_project_name_is_unavailable_with_existing_data_folder(self) -> None:
-        os.mkdir("ExistingProject Data")
-        current_working_directory = pathlib.Path.cwd()
-        check_name_result = FileStorageSystem.FileProjectStorageSystem.check_project_name_is_available("ExistingProject", str(current_working_directory))
-        self.assertEqual(check_name_result.project_path, (current_working_directory / "ExistingProject").with_suffix(".nsproj"))
-        self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
-        os.rmdir("ExistingProject Data")
+            self.assertEqual(check_name_result.error_messages, ["Data Folder \"ExistingProject Data\" already exists"])
+        finally:
+            os.rmdir("ExistingProject Data")
 
     def test_file_project_storage_system_check_project_name_is_unavailable_with_invalid_directory(self) -> None:
         invalid_directory = pathlib.Path.cwd() / "Not_A_Directory"
@@ -4633,18 +4636,18 @@ class TestStorageClass(unittest.TestCase):
         with create_temp_profile_context() as profile_context:
             projects_dir_str = str(profile_context.projects_dir)
             Cache.db_make_directory_if_needed(projects_dir_str)
-            project_name = NewProjectAction.get_project_base_name(projects_dir_str)
+            project_name = Application.NewProjectAction.get_project_base_name(projects_dir_str)
             # Create a project file at with that name so the next call should increment the name
             with open(profile_context.projects_dir / pathlib.Path(project_name).with_suffix(".nsproj"), "w"):
                 pass
 
-            project_name_1 = NewProjectAction.get_project_base_name(projects_dir_str)
+            project_name_1 = Application.NewProjectAction.get_project_base_name(projects_dir_str)
             self.assertEqual(project_name_1, f"{project_name} (1)")
 
             with open(profile_context.projects_dir / pathlib.Path(project_name_1).with_suffix(".nsproj"), "w"):
                 pass
 
-            project_name_2 = NewProjectAction.get_project_base_name(projects_dir_str)
+            project_name_2 = Application.NewProjectAction.get_project_base_name(projects_dir_str)
             self.assertEqual(project_name_2, f"{project_name} (2)")
 
 

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4650,6 +4650,192 @@ class TestStorageClass(unittest.TestCase):
             project_name_2 = Application.NewProjectAction.get_project_base_name(projects_dir_str)
             self.assertEqual(project_name_2, f"{project_name} (2)")
 
+    def test_rename_current_project_with_no_items(self) -> None:
+        """Test the application's rename_project works for the simplest case of no data items.
+
+        This is ProjectStorageSystem independent, testing the project reference is updated and the project is reloaded.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                app.rename_project(project_reference, "new_name")
+                project_reference = profile.project_references[0]
+
+                self.assertIsNotNone(project_reference.project)  # Check the project reopened
+                self.assertEqual("new_name", project_reference.project.title)  # Check the title was updated
+                self.assertEqual("loaded", project_reference.project_state)  # Check the project was reloaded
+                self.assertEqual("new_name", project_reference.path.stem)
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_data_item(self) -> None:
+        """Test the application's rename_project works with a basic data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6)), large_format=False)
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:  # If the test fails the document controller may have not been closed by renaming so close it here
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_large_format_data_item(self) -> None:
+        """Test the application's rename_project works with a h5 backed data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6, 5)), large_format=True)
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_workspace(self) -> None:
+        """Test the application's rename_project works with a workspace.
+
+        This is ProjectStorageSystem independent, only testing that the workspace layout was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                workspace_controller = document_controller.workspace_controller
+                assert workspace_controller is not None
+
+                display_panel = workspace_controller.display_panels[0]
+                document_controller.selected_display_panel = display_panel
+                document_controller.perform_action("workspace.split_horizontal")
+                old_workspace_layout = copy.deepcopy(document_controller.workspace_controller._workspace_layout)
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+                self.assertEqual(old_workspace_layout, document_controller.workspace_controller._workspace_layout)
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_file_project_storage_system_renames_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the project file.
+
+        This creates the project file manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": []})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name.nsproj").exists())
+
+    def test_file_project_storage_system_renames_data_folder(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder.
+
+        This creates the project file and data folder manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())
+
+    def test_file_project_storage_system_renames_data_folder_in_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder in the project file project_data_folders property."""
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            new_project_path = profile_context.projects_dir / "new_name.nsproj"
+            with new_project_path.open("r") as fp:
+                properties = json.load(fp)
+                self.assertEqual(["new_name Data"], properties["project_data_folders"])
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4710,6 +4710,192 @@ class TestStorageClass(unittest.TestCase):
             project_name_2 = Application.NewProjectAction.get_project_base_name(projects_dir_str)
             self.assertEqual(project_name_2, f"{project_name} (2)")
 
+    def test_rename_current_project_with_no_items(self) -> None:
+        """Test the application's rename_project works for the simplest case of no data items.
+
+        This is ProjectStorageSystem independent, testing the project reference is updated and the project is reloaded.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                app.rename_project(project_reference, "new_name")
+                project_reference = profile.project_references[0]
+
+                self.assertIsNotNone(project_reference.project)  # Check the project reopened
+                self.assertEqual("new_name", project_reference.project.title)  # Check the title was updated
+                self.assertEqual("loaded", project_reference.project_state)  # Check the project was reloaded
+                self.assertEqual("new_name", project_reference.path.stem)
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_data_item(self) -> None:
+        """Test the application's rename_project works with a basic data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6)), large_format=False)
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:  # If the test fails the document controller may have not been closed by renaming so close it here
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_large_format_data_item(self) -> None:
+        """Test the application's rename_project works with a h5 backed data item.
+
+        This is ProjectStorageSystem independent, only testing that the data item was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                document_model = app.document_model
+                data_item = DataItem.DataItem(numpy.zeros((6, 6, 5)), large_format=True)
+                document_model.append_data_item(data_item)
+                original_snapshot = data_item.snapshot()
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+
+                self.assertEqual(1, len(document_controller.document_model.data_items))
+                self.assertTrue(numpy.array_equal(original_snapshot.data, document_controller.document_model.data_items[0].data))
+                self.assertEqual(original_snapshot.metadata, document_controller.document_model.data_items[0].metadata)
+                self.assertEqual(original_snapshot.title, document_controller.document_model.data_items[0].title)
+                self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
+                self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
+            finally:
+                original_snapshot.close()
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_rename_current_project_preserves_workspace(self) -> None:
+        """Test the application's rename_project works with a workspace.
+
+        This is ProjectStorageSystem independent, only testing that the workspace layout was preserved.
+        """
+        with create_temp_profile_context() as profile_context:
+            profile = profile_context.create_profile(project_name="Project")
+            ui = TestUI.UserInterface()
+            app = Application.Application(ui, set_global=False)
+            app._set_profile_for_test(profile)
+            project_reference = profile.project_references[0]
+            document_controller = app.open_project_window(project_reference)
+            app._set_document_model(document_controller.document_model)
+            app.initialize(load_plug_ins=False)
+            try:
+                workspace_controller = document_controller.workspace_controller
+                assert workspace_controller is not None
+
+                display_panel = workspace_controller.display_panels[0]
+                document_controller.selected_display_panel = display_panel
+                document_controller.perform_action("workspace.split_horizontal")
+                old_workspace_layout = copy.deepcopy(document_controller.workspace_controller._workspace_layout)
+
+                app.rename_project(project_reference, "new_name")
+                document_controller = app.document_controllers[0]
+                self.assertEqual(old_workspace_layout, document_controller.workspace_controller._workspace_layout)
+            finally:
+                app._set_profile_for_test(None)
+                app.exit()
+                app.deinitialize()
+                if document_controller.count > 0:
+                    document_controller.request_close()
+
+    def test_file_project_storage_system_renames_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the project file.
+
+        This creates the project file manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": []})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name.nsproj").exists())
+
+    def test_file_project_storage_system_renames_data_folder(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder.
+
+        This creates the project file and data folder manually to ensure no dependency on the default project storage system, which may change at some point.
+        """
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            self.assertTrue((profile_context.projects_dir / "new_name Data").is_dir())
+
+    def test_file_project_storage_system_renames_data_folder_in_project_file(self) -> None:
+        """Test that the FileProjectStorageSystem rename_project renames the data folder in the project file project_data_folders property."""
+        with create_temp_profile_context() as profile_context:
+            Cache.db_make_directory_if_needed(str(profile_context.projects_dir))
+            pathlib.Path.mkdir(profile_context.projects_dir / "ExistingProject Data")
+            project_path = profile_context.projects_dir / pathlib.Path("ExistingProject").with_suffix(".nsproj")
+            project_uuid = uuid.uuid4()
+            project_data_json = json.dumps({"version": FileStorageSystem.PROJECT_VERSION, "uuid": str(project_uuid), "project_data_folders": ["ExistingProject Data"]})
+            project_path.write_text(project_data_json, "utf-8")
+            storage_system = FileStorageSystem.make_index_project_storage_system(project_path)
+            storage_system.load_properties()  # No actual data is saved so the project storage data path has to be populated by manually calling this
+            storage_system.rename_project("new_name")
+            new_project_path = profile_context.projects_dir / "new_name.nsproj"
+            with new_project_path.open("r") as fp:
+                properties = json.load(fp)
+                self.assertEqual(["new_name Data"], properties["project_data_folders"])
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)

--- a/nion/swift/test/Storage_test.py
+++ b/nion/swift/test/Storage_test.py
@@ -4753,12 +4753,13 @@ class TestStorageClass(unittest.TestCase):
             document_controller = app.open_project_window(project_reference)
             app._set_document_model(document_controller.document_model)
             app.initialize(load_plug_ins=False)
+            original_snapshot: DataItem.DataItem | None = None
             try:
                 document_model = app.document_model
                 data_item = DataItem.DataItem(numpy.zeros((6, 6)), large_format=False)
                 document_model.append_data_item(data_item)
                 original_snapshot = data_item.snapshot()
-
+                assert original_snapshot is not None
                 app.rename_project(project_reference, "new_name")
                 document_controller = app.document_controllers[0]
 
@@ -4769,7 +4770,8 @@ class TestStorageClass(unittest.TestCase):
                 self.assertEqual(original_snapshot.timezone, document_controller.document_model.data_items[0].timezone)
                 self.assertEqual(original_snapshot.timezone_offset, document_controller.document_model.data_items[0].timezone_offset)
             finally:
-                original_snapshot.close()
+                if original_snapshot:
+                    original_snapshot.close()
                 app._set_profile_for_test(None)
                 app.exit()
                 app.deinitialize()


### PR DESCRIPTION
Fixes #504. ~Requires #1926.~
This PR was split from #1874 since the commit history and PR comments made it hard to discuss/review properly.
This requires the dialog and check function from #1926.

The current project can be renamed via a new menu item in File "Rename Project". This closes the current project, performs the renaming, then reopens the project. Other projects can also be renamed via the "Choose Project" menu. You can right click one of the projects in the list and select "Rename Project" to rename the project (this does not close the existing project or open the renamed one).

When renaming the current project any active tasks running may be interrupted since the project is closed then reopened. This is not prevented and any issues caused by this are out of the scope of this PR.