### PR TITLE
Adds in graph_style options for Line Graphs

### DIFF
--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2096,7 +2096,7 @@ class GraphStyleChooserHandler(Declarative.Handler):
         # use the graph style of the first display layer as the representative value
         display_layers = self._display_item.display_layers
         if display_layers:
-            return typing.cast(typing.Optional[str], display_layers[0].graph_style)
+            return display_layers[0].graph_style
         return None
 
     def change_graph_style(self, widget: Declarative.UIWidget, current_index: int) -> None:

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -2070,6 +2070,45 @@ class DisplayTypeChooserHandler(Declarative.Handler):
             self._document_controller.push_undo_command(command)
 
 
+class GraphStyleChooserHandler(Declarative.Handler):
+    """Chooser for the line plot graph style (graph_style), applied to all display layers."""
+
+    def __init__(self, display_item: DisplayItem.DisplayItem, document_controller: DocumentController.DocumentController) -> None:
+        super().__init__()
+        self._document_controller = document_controller
+        self._display_item = display_item
+        self._graph_style_items = (_("Default (Bar)"), _("Bar"), _("Line"))
+        self._graph_style_flags = (None, "bar", "line")
+        self._graph_style_reverse_map = {None: 0, "bar": 1, "line": 2}
+        self._current_index = self._graph_style_reverse_map.get(self.__current_graph_style, 0)
+
+        u = Declarative.DeclarativeUI()
+
+        self.ui_view = u.create_row(
+            u.create_label(text=_("Graph Style"), text_alignment_vertical="vcenter", text_alignment_horizontal="right", width=100),
+            u.create_combo_box(items=self._graph_style_items, on_current_index_changed="change_graph_style", current_index="@binding(_current_index)"),
+            u.create_stretch(),
+            spacing=8
+        )
+
+    @property
+    def __current_graph_style(self) -> typing.Optional[str]:
+        # use the graph style of the first display layer as the representative value
+        display_layers = self._display_item.display_layers
+        if display_layers:
+            return typing.cast(typing.Optional[str], display_layers[0].graph_style)
+        return None
+
+    def change_graph_style(self, widget: Declarative.UIWidget, current_index: int) -> None:
+        current_graph_style = self._graph_style_flags[current_index]
+        document_model = self._document_controller.document_model
+        for index in range(len(self._display_item.display_layers)):
+            if self._display_item.get_display_layer_property(index, "graph_style") != current_graph_style:
+                command = ChangeDisplayLayerPropertyCommand(document_model, self._display_item, index, "graph_style", current_graph_style)
+                command.perform()
+                self._document_controller.push_undo_command(command)
+
+
 class ContrastStringConverter(Converter.ConverterLike[float, str]):
 
     def convert(self, value: typing.Optional[float]) -> typing.Optional[str]:
@@ -2244,6 +2283,9 @@ class LinePlotDisplayInspectorSection(InspectorSection):
         self._display_type_chooser = DisplayTypeChooserHandler(display_item, document_controller)
         display_type_chooser_widget = Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, self._display_type_chooser)
 
+        self._graph_style_chooser = GraphStyleChooserHandler(display_item, document_controller)
+        graph_style_chooser_widget = Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, self._graph_style_chooser)
+
         self._line_plot_display_section_handler = LinePlotDisplaySectionHandler(document_controller, display_item)
         widget = Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, self._line_plot_display_section_handler)
 
@@ -2251,6 +2293,7 @@ class LinePlotDisplayInspectorSection(InspectorSection):
         legend_position_chooser_widget = Declarative.DeclarativeWidget(document_controller.ui, document_controller.event_loop, self._legend_position_chooser)
 
         self.add_widget_to_content(display_type_chooser_widget)
+        self.add_widget_to_content(graph_style_chooser_widget)
         self.add_widget_to_content(widget)
         self.add_widget_to_content(legend_position_chooser_widget)
 

--- a/nion/swift/Inspector.py
+++ b/nion/swift/Inspector.py
@@ -932,6 +932,13 @@ class LinePlotDisplayLayerHandler(Declarative.Handler):
                 spacing=8
             ),
             u.create_row(
+                u.create_label(text=_("Graph Style"), width=80, text_alignment_vertical="vcenter", text_alignment_horizontal="right"),
+                u.create_combo_box(items=self._line_plot_display_layer_model.graph_style_items,
+                                   current_index="@binding(_line_plot_display_layer_model.current_graph_style_index_model.value)"),
+                u.create_stretch(),
+                spacing=8
+            ),
+            u.create_row(
                 u.create_label(text=_("Complex Display"), width=120),
                 u.create_combo_box(items=self._line_plot_display_layer_model.display_type_items,
                                    current_index="@binding(_line_plot_display_layer_model.current_display_type_index_model.value)"),
@@ -1007,6 +1014,12 @@ class LinePlotDisplayLayerModel(Observable.Observable):
         self.stroke_color_model = DisplayLayerPropertyCommandModel(document_controller, display_item, display_layer, "stroke_color")
         self.stroke_width_model = DisplayLayerPropertyCommandModel(document_controller, display_item, display_layer, "stroke_width")
 
+        self.graph_style_items = [_("Bar"), _("Line")]
+        self._graph_style_flags = ["bar", "line"]
+        self._graph_style_reverse_map = {p: i for i, p in enumerate(self._graph_style_flags)}
+        current_graph_style = display_layer.graph_style or "bar"
+        self.current_graph_style_index_model = Model.PropertyModel[int](self._graph_style_reverse_map.get(current_graph_style, 0))
+
         self.display_type_items = [_("Log Absolute"), _("Absolute"), _("Phase"), _("Real"), _("Imaginary")]
         self._display_type_flags = ["log-absolute", "absolute", "phase", "real", "imaginary"]
         self._display_type_reverse_map = {p: i for i, p in enumerate(self._display_type_flags)}
@@ -1018,6 +1031,8 @@ class LinePlotDisplayLayerModel(Observable.Observable):
             ReferenceCounting.weak_partial(LinePlotDisplayLayerModel.__on_data_index_changed, self))
         self.__display_type_index_listener_model = self.current_display_type_index_model.property_changed_event.listen(
             ReferenceCounting.weak_partial(LinePlotDisplayLayerModel.__on_display_type_index_changed, self))
+        self.__graph_style_index_listener_model = self.current_graph_style_index_model.property_changed_event.listen(
+            ReferenceCounting.weak_partial(LinePlotDisplayLayerModel.__on_graph_style_index_changed, self))
 
     @property
     def is_data_complex(self) -> bool:
@@ -1045,6 +1060,16 @@ class LinePlotDisplayLayerModel(Observable.Observable):
                                                                    complex_display_type=new_type)
             command.perform()
             self.document_controller.push_undo_command(command)
+
+    def __on_graph_style_index_changed(self, property: str) -> None:
+        if property == "value":
+            new_style = self._graph_style_flags[self.current_graph_style_index_model.value or 0]
+            index = self.display_item.display_layers.index(self.display_layer)
+            if self.display_item.get_display_layer_property(index, "graph_style") != new_style:
+                command = ChangeDisplayLayerPropertyCommand(self.document_controller.document_model,
+                                                            self.display_item, index, "graph_style", new_style)
+                command.perform()
+                self.document_controller.push_undo_command(command)
 
     def __on_display_layer_list_changed(self, key: str, value: typing.Any, index: int) -> None:
         # changes affect all indices after index of change
@@ -2068,6 +2093,7 @@ class DisplayTypeChooserHandler(Declarative.Handler):
             command = ChangeDisplayTypeCommand(self._document_controller.document_model, self._display_item, display_type=current_display_type)
             command.perform()
             self._document_controller.push_undo_command(command)
+
 
 
 class ContrastStringConverter(Converter.ConverterLike[float, str]):

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -136,13 +136,30 @@ class LineGraphSegment:
             drawing_context.stroke()
 
 
-def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
-                         scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
-                         scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
-                         line_graph_x_calibration: Calibration.Calibration,
-                         rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
-                         axis_scale: LinePlotDisplay.AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
-    """Calculate the line graph segments for the given parameters.
+@dataclasses.dataclass
+class _VisibleDataInfo:
+    """Geometry and rebinned data describing the portion of a data series visible in the plot area.
+
+    Produced by _prepare_visible_data and consumed by calculate_bar_segments / calculate_line_segments.
+    """
+    plot_height: int
+    plot_width: int
+    plot_origin_y: int
+    plot_origin_x: int
+    binned_data: _NDArray
+    binned_data_is_nan: _NDArray
+    binned_left: int
+
+
+def _prepare_visible_data(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
+                          scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                          scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                          line_graph_x_calibration: Calibration.Calibration,
+                          rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                          ) -> typing.Optional[_VisibleDataInfo]:
+    """Shared setup for bar/line segment calculations.
+
+    Returns a _VisibleDataInfo with the clipped plot geometry and rebinned data, or None if nothing to draw.
 
     Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
     represents the calibration of the graph itself, which may include multiple data items with different
@@ -155,14 +172,13 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
         calibrated_min_channel = min(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
         calibrated_max_channel = max(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel <= calibrated_right_channel or calibrated_max_channel >= calibrated_left_channel:
-            return list(), 0  # data is outside drawing area
+            return None  # data is outside drawing area
     else:
         # note: x_calibration is the same as calibrated_xdata_calibration. it is the x-dimension. use short names.
         calibrated_min_channel = max(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
         calibrated_max_channel = min(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel >= calibrated_right_channel or calibrated_max_channel <= calibrated_left_channel:
-            return list(), 0  # data is outside drawing area
-    # calculate the left/right channels as indexes into the data arrays and the left/right pixels for drawing.
+            return None  # data is outside drawing area
     left_channel_index = round(x_calibration.convert_from_calibrated_value(calibrated_min_channel))
     right_channel_index = round(x_calibration.convert_from_calibrated_value(calibrated_max_channel))
     left_pixel = round((calibrated_min_channel - calibrated_left_channel) / (calibrated_right_channel - calibrated_left_channel) * plot_width + plot_origin_x)
@@ -175,7 +191,7 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     if 0 <= left_channel_index < right_channel_index and right_channel_index <= scaled_xdata.dimensional_shape[-1]:
         visible_scaled_xdata = scaled_xdata[left_channel_index:right_channel_index]
     else:
-        return list(), 0
+        return None
     visible_x_calibration = visible_scaled_xdata.dimensional_calibrations[-1]
     # these variables are repurposed. TODO: pick better names
     visible_calibrated_left_channel = visible_x_calibration.convert_to_calibrated_value(0)
@@ -184,67 +200,170 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     uncalibrated_visible_left_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_left_channel)
     uncalibrated_visible_right_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_right_channel)
     uncalibrated_visible_width = uncalibrated_visible_right_channel - uncalibrated_visible_left_channel
+
+    if scaled_data_range == 0.0 or uncalibrated_visible_width <= 0.0:
+        return None
+
+    # NOTE: axis_scale not available here; baseline calculated by caller using axis_scale
+    # Return placeholder 0.0 for baseline – caller must fill in
+    calibrated_data = visible_scaled_xdata._data_ex
+    binned_length = int(calibrated_data.shape[-1] * plot_width / uncalibrated_visible_width)
+    if binned_length <= 0:
+        return None
+    binned_data = Image.rebin_1d(calibrated_data, binned_length, rebin_cache)
+    binned_data_is_nan = numpy.isnan(binned_data)
+    binned_left = int(uncalibrated_visible_left_channel * plot_width / uncalibrated_visible_width)
+    return _VisibleDataInfo(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                            binned_data, binned_data_is_nan, binned_left)
+
+
+def calculate_bar_segments(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
+                           scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                           scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                           line_graph_x_calibration: Calibration.Calibration,
+                           rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                           axis_scale: LinePlotDisplay.AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
+    """Calculate bar/histogram segments — staircase path, one horizontal step per pixel.
+
+    Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
+    represents the calibration of the graph itself, which may include multiple data items with different
+    calibrations. the units will match.
+    """
+    prepared = _prepare_visible_data(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                                     scaled_xdata, scaled_data_min, scaled_data_range,
+                                     calibrated_left_channel, calibrated_right_channel,
+                                     line_graph_x_calibration, rebin_cache)
+    if prepared is None:
+        return list(), 0
+    plot_height = prepared.plot_height
+    plot_width = prepared.plot_width
+    plot_origin_y = prepared.plot_origin_y
+    plot_origin_x = prepared.plot_origin_x
+    binned_data = prepared.binned_data
+    binned_data_is_nan = prepared.binned_data_is_nan
+    binned_left = prepared.binned_left
+    binned_length = len(binned_data)
+
+    origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
+    baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
+    baseline = min(plot_origin_y + plot_height, baseline)
+    baseline = max(plot_origin_y, baseline)
+
     segments: typing.List[LineGraphSegment] = list()
     segment = LineGraphSegment()
     # use line_commands as an optimization for adding line commands to the path. this is critical for performance.
-    line_commands = segment.line_commands
-    # segment_path = segment.path  # partially optimized; see note below
     # note: testing performance using a loop around drawing commands in test_line_plot_handle_calibrated_x_axis_with_negative_scale
-    if scaled_data_range != 0.0 and uncalibrated_visible_width > 0.0:
-        origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
-        baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
-
-        baseline = min(plot_origin_y + plot_height, baseline)
-        baseline = max(plot_origin_y, baseline)
-        # rebin so that uncalibrated_visible_width corresponds to plot width
-        calibrated_data = visible_scaled_xdata._data_ex
-        binned_length = int(calibrated_data.shape[-1] * plot_width / uncalibrated_visible_width)
-        did_draw = False
-        if binned_length > 0:
-            binned_data = Image.rebin_1d(calibrated_data, binned_length, rebin_cache)
-            binned_data_is_nan = numpy.isnan(binned_data)
-            binned_left = int(uncalibrated_visible_left_channel * plot_width / uncalibrated_visible_width)
-            # draw the plot
-            last_py = baseline
-            for i in range(0, plot_width):
-                px = plot_origin_x + i
-                binned_index = binned_left + i
-                if binned_index >= 0 and binned_index < binned_length and not binned_data_is_nan[binned_index]:
-                    data_value = binned_data[binned_index]
-                    # plot_origin_y is the TOP of the drawing
-                    # py extends DOWNWARDS
-                    py = plot_origin_y + plot_height - (plot_height * (data_value - scaled_data_min) / scaled_data_range)
-                    py = max(plot_origin_y, py)
-                    py = min(plot_origin_y + plot_height, py)
-                    if did_draw:
-                        # only draw horizontal lines when necessary
-                        if py != last_py:
-                            # draw forward from last_px to px at last_py level
-                            # note: using optimized line commands to optimize this critical code.
-                            line_commands.append((px, last_py))
-                            line_commands.append((px, py))
-                            # partially optimized code below.
-                            # segment_path.line_to(px, last_py)
-                            # segment_path.line_to(px, py)
-                    else:
-                        did_draw = True
-                        segment.first_line_to(px, py)
-                    last_py = py
-                else:
-                    if did_draw:
-                        did_draw = False
-                        segment.final_line_to(px, last_py)
-                        segments.append(segment)
-                        segment = LineGraphSegment()
-                        # update line_commands (a path drawing optimization) for the new segment.
-                        line_commands = segment.line_commands
-
-            segment.final_line_to(plot_origin_x + plot_width, last_py)
-
+    line_commands = segment.line_commands
+    did_draw = False
+    last_py = baseline
+    for i in range(0, plot_width):
+        px = plot_origin_x + i
+        binned_index = binned_left + i
+        if binned_index >= 0 and binned_index < binned_length and not binned_data_is_nan[binned_index]:
+            data_value = binned_data[binned_index]
+            # plot_origin_y is the TOP of the drawing
+            # py extends DOWNWARDS
+            py = plot_origin_y + plot_height - (plot_height * (data_value - scaled_data_min) / scaled_data_range)
+            py = max(plot_origin_y, py)
+            py = min(plot_origin_y + plot_height, py)
             if did_draw:
+                # only draw horizontal lines when necessary
+                if py != last_py:
+                    # draw forward from last_px to px at last_py level
+                    # note: using optimized line commands to optimize this critical code.
+                    line_commands.append((px, last_py))
+                    line_commands.append((px, py))
+            else:
+                did_draw = True
+                segment.first_line_to(px, py)
+            last_py = py
+        else:
+            if did_draw:
+                did_draw = False
+                segment.final_line_to(px, last_py)
                 segments.append(segment)
-        return segments, baseline
-    return list(), 0
+                segment = LineGraphSegment()
+                # update line_commands (a path drawing optimization) for the new segment.
+                line_commands = segment.line_commands
+
+    segment.final_line_to(plot_origin_x + plot_width, last_py)
+
+    if did_draw:
+        segments.append(segment)
+    return segments, baseline
+
+
+def calculate_line_segments(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
+                             scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                             scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                             line_graph_x_calibration: Calibration.Calibration,
+                             rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                             axis_scale: LinePlotDisplay.AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
+    """Calculate line-graph segments — diagonal lines directly connecting adjacent data points.
+
+    Unlike the bar style which draws a staircase, the line style maps each data sample to its
+    exact x pixel position and draws straight lines between them.  NaN values break the line
+    into separate segments.
+
+    Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
+    represents the calibration of the graph itself, which may include multiple data items with different
+    calibrations. the units will match.
+    """
+    x_calibration = scaled_xdata.dimensional_calibrations[-1]
+    assert x_calibration.units == line_graph_x_calibration.units
+
+    if scaled_data_range == 0.0:
+        return list(), 0
+
+    origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
+    baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
+    baseline = min(plot_origin_y + plot_height, baseline)
+    baseline = max(plot_origin_y, baseline)
+
+    # Map the calibrated channel range of the graph to pixel x-coordinates.
+    # calibrated_left_channel → plot_origin_x, calibrated_right_channel → plot_origin_x + plot_width
+    cal_width = calibrated_right_channel - calibrated_left_channel
+    if cal_width == 0.0:
+        return list(), 0
+
+    data = scaled_xdata._data_ex
+    n_samples = data.shape[-1]
+
+    segments: typing.List[LineGraphSegment] = list()
+    segment = LineGraphSegment()
+    line_commands = segment.line_commands
+    did_draw = False
+    last_py = baseline
+
+    for sample_index in range(n_samples):
+        # Convert sample index → calibrated value → pixel x
+        cal_value = x_calibration.convert_to_calibrated_value(sample_index + 0.5)  # centre of sample bin
+        px = plot_origin_x + plot_width * (cal_value - calibrated_left_channel) / cal_width
+
+        data_value = data[sample_index]
+        if numpy.isnan(data_value):
+            if did_draw:
+                did_draw = False
+                segment.final_line_to(px, last_py)
+                segments.append(segment)
+                segment = LineGraphSegment()
+                line_commands = segment.line_commands
+            continue
+
+        py = plot_origin_y + plot_height - (plot_height * (float(data_value) - scaled_data_min) / scaled_data_range)
+        py = max(float(plot_origin_y), min(float(plot_origin_y + plot_height), py))
+
+        if did_draw:
+            line_commands.append((px, py))
+        else:
+            did_draw = True
+            segment.first_line_to(px, py)
+        last_py = py
+
+    if did_draw:
+        segment.final_line_to(plot_origin_x + plot_width, last_py)
+        segments.append(segment)
+    return segments, baseline
 
 
 def draw_frame(drawing_context: DrawingContext.DrawingContext, plot_height: int, plot_origin_x: int, plot_origin_y: int, plot_width: int) -> None:
@@ -333,12 +452,14 @@ class MappedCalibratedDataAndMetadataCacheItem:
 
 @dataclasses.dataclass(frozen=True)
 class SegmentsCacheItem:
+    """Cache item for bar_graph and line_graph styles that produce LineGraphSegment lists."""
     scaled_xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
     axes: typing.Optional[LinePlotDisplay.LineGraphAxes]
     canvas_bounds: Geometry.IntRect
+    graph_style: str  # "bar" or "line"
 
-    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LinePlotDisplay.LineGraphAxes], Geometry.IntRect]:
-        return id(self.scaled_xdata.data) if self.scaled_xdata else None, self.axes, self.canvas_bounds
+    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LinePlotDisplay.LineGraphAxes], Geometry.IntRect, str]:
+        return id(self.scaled_xdata.data) if self.scaled_xdata else None, self.axes, self.canvas_bounds, self.graph_style
 
     def calculate(self) -> typing.Tuple[typing.List[LineGraphSegment], float]:
         scaled_xdata = self.scaled_xdata
@@ -364,12 +485,13 @@ class SegmentsCacheItem:
 
             # draw the line plot itself
             if x_calibration and x_calibration.units == scaled_xdata.dimensional_calibrations[-1].units:
-                segments, baseline = calculate_line_graph(plot_height, plot_width, plot_origin_y, plot_origin_x,
-                                                          scaled_xdata,
-                                                          scaled_data_min, scaled_data_range,
-                                                          calibrated_left_channel,
-                                                          calibrated_right_channel, x_calibration,
-                                                          None, axes.axis_scale)
+                calc_fn = calculate_line_segments if self.graph_style == "line" else calculate_bar_segments
+                segments, baseline = calc_fn(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                                             scaled_xdata,
+                                             scaled_data_min, scaled_data_range,
+                                             calibrated_left_channel,
+                                             calibrated_right_channel, x_calibration,
+                                             None, axes.axis_scale)
         return segments, baseline
 
 
@@ -378,11 +500,11 @@ def draw_fills(line_graph_layer: LinePlotDisplay.LineGraphLayer, drawing_context
         scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(line_graph_layer.xdata, line_graph_layer.axes)
         scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
         scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
-        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds)
+        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds, line_graph_layer.graph_style)
         segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
         segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
         for segment in segments:
-            segment.fill(drawing_context, baseline, Color.Color(line_graph_layer.fill_color))
+            segment.fill(drawing_context, baseline, line_graph_layer.fill_color)
         return scaled_xdata_cache_value, segments_cache_value
     return tuple()
 
@@ -392,11 +514,11 @@ def draw_strokes(line_graph_layer: LinePlotDisplay.LineGraphLayer, drawing_conte
         scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(line_graph_layer.xdata, line_graph_layer.axes)
         scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
         scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
-        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds)
+        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds, line_graph_layer.graph_style)
         segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
         segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
         for segment in segments:
-            segment.stroke(drawing_context, baseline, Color.Color(line_graph_layer.stroke_color), line_graph_layer.stroke_width)
+            segment.stroke(drawing_context, baseline, line_graph_layer.stroke_color, line_graph_layer.stroke_width)
         return scaled_xdata_cache_value, segments_cache_value
     return tuple()
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -333,7 +333,7 @@ def calculate_line_segments(plot_height: int, plot_width: int, plot_origin_y: in
     segment = LineGraphSegment()
     line_commands = segment.line_commands
     did_draw = False
-    last_py = baseline
+    last_py: float = baseline
 
     for sample_index in range(n_samples):
         # Convert sample index → calibrated value → pixel x

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -337,7 +337,7 @@ def calculate_line_segments(plot_height: int, plot_width: int, plot_origin_y: in
 
     for sample_index in range(n_samples):
         # Convert sample index → calibrated value → pixel x
-        cal_value = x_calibration.convert_to_calibrated_value(sample_index + 0.5)  # centre of sample bin
+        cal_value = x_calibration.convert_to_calibrated_value(sample_index)  # centre of sample bin
         px = plot_origin_x + plot_width * (cal_value - calibrated_left_channel) / cal_width
 
         data_value = data[sample_index]

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -566,8 +566,18 @@ def draw_fills(line_graph_layer: LinePlotDisplay.LineGraphLayer, drawing_context
         segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds, line_graph_layer.graph_style)
         segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
         segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
-        for segment in segments:
-            segment.fill(drawing_context, baseline, line_graph_layer.fill_color)
+        with drawing_context.saver():
+            # clip to the plot area. bar-graph bars are centered and the first/last bars extend
+            # half a bar beyond the plot edges by design, so the fill must be clipped (like the
+            # stroke) to avoid spilling off the left/right side of the graph.
+            drawing_context.clip_rect(
+                canvas_bounds.left,
+                canvas_bounds.top,
+                canvas_bounds.width,
+                canvas_bounds.height
+            )
+            for segment in segments:
+                segment.fill(drawing_context, baseline, line_graph_layer.fill_color)
         return scaled_xdata_cache_value, segments_cache_value
     return tuple()
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -136,13 +136,31 @@ class LineGraphSegment:
             drawing_context.stroke()
 
 
-def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
-                         scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
-                         scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
-                         line_graph_x_calibration: Calibration.Calibration,
-                         rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
-                         axis_scale: LinePlotDisplay.AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
-    """Calculate the line graph segments for the given parameters.
+@dataclasses.dataclass
+class _VisibleDataInfo:
+    """Geometry and rebinned data describing the portion of a data series visible in the plot area.
+
+    Produced by _prepare_visible_data and consumed by calculate_bar_segments / calculate_line_segments.
+    """
+    plot_height: int
+    plot_width: int
+    plot_origin_y: int
+    plot_origin_x: int
+    binned_data: _NDArray
+    binned_data_is_nan: _NDArray
+    binned_left: int
+    pixels_per_channel: float
+
+
+def _prepare_visible_data(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
+                          scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                          scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                          line_graph_x_calibration: Calibration.Calibration,
+                          rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                          ) -> typing.Optional[_VisibleDataInfo]:
+    """Shared setup for bar/line segment calculations.
+
+    Returns a _VisibleDataInfo with the clipped plot geometry and rebinned data, or None if nothing to draw.
 
     Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
     represents the calibration of the graph itself, which may include multiple data items with different
@@ -155,14 +173,13 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
         calibrated_min_channel = min(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
         calibrated_max_channel = max(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel <= calibrated_right_channel or calibrated_max_channel >= calibrated_left_channel:
-            return list(), 0  # data is outside drawing area
+            return None  # data is outside drawing area
     else:
         # note: x_calibration is the same as calibrated_xdata_calibration. it is the x-dimension. use short names.
         calibrated_min_channel = max(calibrated_left_channel, x_calibration.convert_to_calibrated_value(0))
         calibrated_max_channel = min(calibrated_right_channel, x_calibration.convert_to_calibrated_value(scaled_xdata.dimensional_shape[-1]))
         if calibrated_min_channel >= calibrated_right_channel or calibrated_max_channel <= calibrated_left_channel:
-            return list(), 0  # data is outside drawing area
-    # calculate the left/right channels as indexes into the data arrays and the left/right pixels for drawing.
+            return None  # data is outside drawing area
     left_channel_index = round(x_calibration.convert_from_calibrated_value(calibrated_min_channel))
     right_channel_index = round(x_calibration.convert_from_calibrated_value(calibrated_max_channel))
     left_pixel = round((calibrated_min_channel - calibrated_left_channel) / (calibrated_right_channel - calibrated_left_channel) * plot_width + plot_origin_x)
@@ -175,7 +192,7 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     if 0 <= left_channel_index < right_channel_index and right_channel_index <= scaled_xdata.dimensional_shape[-1]:
         visible_scaled_xdata = scaled_xdata[left_channel_index:right_channel_index]
     else:
-        return list(), 0
+        return None
     visible_x_calibration = visible_scaled_xdata.dimensional_calibrations[-1]
     # these variables are repurposed. TODO: pick better names
     visible_calibrated_left_channel = visible_x_calibration.convert_to_calibrated_value(0)
@@ -184,67 +201,221 @@ def calculate_line_graph(plot_height: int, plot_width: int, plot_origin_y: int, 
     uncalibrated_visible_left_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_left_channel)
     uncalibrated_visible_right_channel = visible_x_calibration.convert_from_calibrated_value(visible_calibrated_right_channel)
     uncalibrated_visible_width = uncalibrated_visible_right_channel - uncalibrated_visible_left_channel
+
+    if scaled_data_range == 0.0 or uncalibrated_visible_width <= 0.0:
+        return None
+
+    calibrated_data = visible_scaled_xdata._data_ex
+    binned_length = int(calibrated_data.shape[-1] * plot_width / uncalibrated_visible_width)
+    if binned_length <= 0:
+        return None
+    binned_data = Image.rebin_1d(calibrated_data, binned_length, rebin_cache)
+    binned_data_is_nan = numpy.isnan(binned_data)
+    binned_left = int(uncalibrated_visible_left_channel * plot_width / uncalibrated_visible_width)
+    # pixels covered by a single data channel, used by centered "bar" style to shift the staircase left by half a channel.
+    pixels_per_channel = plot_width / uncalibrated_visible_width
+    return _VisibleDataInfo(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                            binned_data, binned_data_is_nan, binned_left, pixels_per_channel)
+
+
+def calculate_bar_segments(
+        plot_height: int,
+        plot_width: int,
+        plot_origin_y: int,
+        plot_origin_x: int,
+        scaled_xdata: DataAndMetadata.DataAndMetadata,
+        scaled_data_min: float,
+        scaled_data_range: float,
+        calibrated_left_channel: float,
+        calibrated_right_channel: float,
+        line_graph_x_calibration: Calibration.Calibration,
+        rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+        axis_scale: LinePlotDisplay.AxisScale
+) -> typing.Tuple[typing.List[LineGraphSegment], int]:
+
+    x_calibration = scaled_xdata.dimensional_calibrations[-1]
+    assert x_calibration.units == line_graph_x_calibration.units
+
+    if scaled_data_range == 0.0:
+        return list(), 0
+
+    origin_display = axis_scale.display_origin(
+        scaled_data_min,
+        scaled_data_min + scaled_data_range)
+
+    baseline = (plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range))
+
+    baseline = min(plot_origin_y + plot_height, baseline)
+    baseline = max(plot_origin_y, baseline)
+
+    cal_width = calibrated_right_channel - calibrated_left_channel
+    if cal_width == 0.0:
+        return list(), baseline
+
+    data = scaled_xdata._data_ex
+    n_samples = data.shape[-1]
+
+    if n_samples <= 0:
+        return list(), baseline
+
+    # Visible sample range.
+    edge_a = x_calibration.convert_from_calibrated_value(calibrated_left_channel)
+    edge_b = x_calibration.convert_from_calibrated_value(calibrated_right_channel)
+
+    first_sample = max(0, int(math.floor(min(edge_a, edge_b))) - 1)
+
+    last_sample = min(n_samples - 1, int(math.ceil(max(edge_a, edge_b))) + 1)
+
+    if first_sample > last_sample:
+        return list(), baseline
+
+    # Width of one channel in screen pixels.
+    #
+    # The axis is unchanged, therefore the first and last bars
+    # will naturally be clipped by half a bar at the graph edge.
+    channel_width_px = plot_width / max(1, (n_samples - 1))
+
+    segments: typing.List[LineGraphSegment] = []
+
+    segment: typing.Optional[LineGraphSegment] = None
+
+    last_px_right: float = 0.0
+    last_py: float = 0.0
+    for sample_index in range(first_sample, last_sample + 1):
+
+        value = float(data[sample_index])
+
+        if numpy.isnan(value):
+            if segment is not None:
+                segment.final_line_to(last_px_right, last_py)
+                segments.append(segment)
+                segment = None
+            continue
+
+        cal_value = x_calibration.convert_to_calibrated_value(sample_index)
+
+        px_center = (plot_origin_x + plot_width * (cal_value - calibrated_left_channel) / cal_width)
+
+        px_left = px_center - channel_width_px * 0.5
+        px_right = px_center + channel_width_px * 0.5
+
+        py = (plot_origin_y + plot_height - plot_height * (value - scaled_data_min) / scaled_data_range)
+
+        py = max(float(plot_origin_y), min(float(plot_origin_y + plot_height), py))
+
+        if segment is None:
+            segment = LineGraphSegment()
+            segment.first_line_to(px_left, py)
+        else:
+            # Vertical edge.
+            segment.line_commands.append((px_left, last_py))
+
+            # Move to new level.
+            segment.line_commands.append((px_left, py))
+
+        # Horizontal top of bar.
+        segment.line_commands.append((px_right, py))
+
+        last_px_right = px_right
+        last_py = py
+
+    if segment is not None:
+        segment.final_line_to(last_px_right, last_py)
+        segments.append(segment)
+
+    return segments, baseline
+
+
+def calculate_line_segments(plot_height: int, plot_width: int, plot_origin_y: int, plot_origin_x: int,
+                             scaled_xdata: DataAndMetadata.DataAndMetadata, scaled_data_min: float,
+                             scaled_data_range: float, calibrated_left_channel: float, calibrated_right_channel: float,
+                             line_graph_x_calibration: Calibration.Calibration,
+                             rebin_cache: typing.Optional[typing.Dict[str, typing.Any]],
+                             axis_scale: LinePlotDisplay.AxisScale) -> typing.Tuple[typing.List[LineGraphSegment], int]:
+    """Calculate line-graph segments — diagonal lines directly connecting adjacent data points.
+
+    Unlike the bar style which draws a staircase, the line style maps each data sample to its
+    exact x pixel position and draws straight lines between them.  NaN values break the line
+    into separate segments. The iteration is clipped to the visible sample range so it stays
+    bounded when zoomed into a small window rather than scanning the entire data array.
+
+    Note: line_graph_x_calibration may not match the calibration of scaled_xdata since the x_calibration
+    represents the calibration of the graph itself, which may include multiple data items with different
+    calibrations. the units will match.
+    """
+    x_calibration = scaled_xdata.dimensional_calibrations[-1]
+    assert x_calibration.units == line_graph_x_calibration.units
+
+    if scaled_data_range == 0.0:
+        return list(), 0
+
+    origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
+    baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
+    baseline = min(plot_origin_y + plot_height, baseline)
+    baseline = max(plot_origin_y, baseline)
+
+    # Map the calibrated channel range of the graph to pixel x-coordinates.
+    # calibrated_left_channel → plot_origin_x, calibrated_right_channel → plot_origin_x + plot_width
+    cal_width = calibrated_right_channel - calibrated_left_channel
+    if cal_width == 0.0:
+        return list(), 0
+
+    data = scaled_xdata._data_ex
+    n_samples = data.shape[-1]
+    if n_samples <= 0:
+        return list(), 0
+
+    # Clip the iteration to the visible sample range so this is bounded by the number of samples actually
+    # on screen rather than the full (possibly huge) data array. This preserves the true line-graph look —
+    # exact sample positions connected by diagonals — while avoiding an unbounded O(n) per-frame loop when
+    # zoomed into a small window. A one-sample margin is included on each side so the line still connects
+    # to points just off-screen and reaches the plot edges.
+    edge_a = x_calibration.convert_from_calibrated_value(calibrated_left_channel)
+    edge_b = x_calibration.convert_from_calibrated_value(calibrated_right_channel)
+    first_sample = int(math.floor(min(edge_a, edge_b))) - 1
+    last_sample = int(math.ceil(max(edge_a, edge_b))) + 1
+    first_sample = max(0, first_sample)
+    last_sample = min(n_samples - 1, last_sample)
+    if first_sample > last_sample:
+        return list(), 0
+
     segments: typing.List[LineGraphSegment] = list()
     segment = LineGraphSegment()
-    # use line_commands as an optimization for adding line commands to the path. this is critical for performance.
     line_commands = segment.line_commands
-    # segment_path = segment.path  # partially optimized; see note below
-    # note: testing performance using a loop around drawing commands in test_line_plot_handle_calibrated_x_axis_with_negative_scale
-    if scaled_data_range != 0.0 and uncalibrated_visible_width > 0.0:
-        origin_display = axis_scale.display_origin(scaled_data_min, scaled_data_min + scaled_data_range)
-        baseline = plot_origin_y + plot_height - int(plot_height * float(origin_display - scaled_data_min) / scaled_data_range)
+    did_draw = False
+    last_px: float = plot_origin_x
+    last_py: float = baseline
 
-        baseline = min(plot_origin_y + plot_height, baseline)
-        baseline = max(plot_origin_y, baseline)
-        # rebin so that uncalibrated_visible_width corresponds to plot width
-        calibrated_data = visible_scaled_xdata._data_ex
-        binned_length = int(calibrated_data.shape[-1] * plot_width / uncalibrated_visible_width)
-        did_draw = False
-        if binned_length > 0:
-            binned_data = Image.rebin_1d(calibrated_data, binned_length, rebin_cache)
-            binned_data_is_nan = numpy.isnan(binned_data)
-            binned_left = int(uncalibrated_visible_left_channel * plot_width / uncalibrated_visible_width)
-            # draw the plot
-            last_py = baseline
-            for i in range(0, plot_width):
-                px = plot_origin_x + i
-                binned_index = binned_left + i
-                if binned_index >= 0 and binned_index < binned_length and not binned_data_is_nan[binned_index]:
-                    data_value = binned_data[binned_index]
-                    # plot_origin_y is the TOP of the drawing
-                    # py extends DOWNWARDS
-                    py = plot_origin_y + plot_height - (plot_height * (data_value - scaled_data_min) / scaled_data_range)
-                    py = max(plot_origin_y, py)
-                    py = min(plot_origin_y + plot_height, py)
-                    if did_draw:
-                        # only draw horizontal lines when necessary
-                        if py != last_py:
-                            # draw forward from last_px to px at last_py level
-                            # note: using optimized line commands to optimize this critical code.
-                            line_commands.append((px, last_py))
-                            line_commands.append((px, py))
-                            # partially optimized code below.
-                            # segment_path.line_to(px, last_py)
-                            # segment_path.line_to(px, py)
-                    else:
-                        did_draw = True
-                        segment.first_line_to(px, py)
-                    last_py = py
-                else:
-                    if did_draw:
-                        did_draw = False
-                        segment.final_line_to(px, last_py)
-                        segments.append(segment)
-                        segment = LineGraphSegment()
-                        # update line_commands (a path drawing optimization) for the new segment.
-                        line_commands = segment.line_commands
+    for sample_index in range(first_sample, last_sample + 1):
+        # Convert sample index → calibrated value → pixel x
+        cal_value = x_calibration.convert_to_calibrated_value(sample_index)
+        px = plot_origin_x + plot_width * (cal_value - calibrated_left_channel) / cal_width
 
-            segment.final_line_to(plot_origin_x + plot_width, last_py)
-
+        data_value = data[sample_index]
+        if numpy.isnan(data_value):
             if did_draw:
+                did_draw = False
+                segment.final_line_to(last_px, last_py)
                 segments.append(segment)
-        return segments, baseline
-    return list(), 0
+                segment = LineGraphSegment()
+                line_commands = segment.line_commands
+            continue
+
+        py = plot_origin_y + plot_height - (plot_height * (float(data_value) - scaled_data_min) / scaled_data_range)
+        py = max(float(plot_origin_y), min(float(plot_origin_y + plot_height), py))
+
+        if did_draw:
+            line_commands.append((px, py))
+        else:
+            did_draw = True
+            segment.first_line_to(px, py)
+        last_px = px
+        last_py = py
+
+    if did_draw:
+        segment.final_line_to(last_px, last_py)
+        segments.append(segment)
+    return segments, baseline
 
 
 def draw_frame(drawing_context: DrawingContext.DrawingContext, plot_height: int, plot_origin_x: int, plot_origin_y: int, plot_width: int, drawing_metrics: UISettings.DrawingMetrics) -> None:
@@ -336,12 +507,14 @@ class MappedCalibratedDataAndMetadataCacheItem:
 
 @dataclasses.dataclass(frozen=True)
 class SegmentsCacheItem:
+    """Cache item for bar_graph and line_graph styles that produce LineGraphSegment lists."""
     scaled_xdata: typing.Optional[DataAndMetadata.DataAndMetadata]
     axes: typing.Optional[LinePlotDisplay.LineGraphAxes]
     canvas_bounds: Geometry.IntRect
+    graph_style: str  # "step" | "bar" | "line"
 
-    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LinePlotDisplay.LineGraphAxes], Geometry.IntRect]:
-        return id(self.scaled_xdata.data) if self.scaled_xdata else None, self.axes, self.canvas_bounds
+    def key(self) -> typing.Tuple[typing.Optional[int], typing.Optional[LinePlotDisplay.LineGraphAxes], Geometry.IntRect, str]:
+        return id(self.scaled_xdata.data) if self.scaled_xdata else None, self.axes, self.canvas_bounds, self.graph_style
 
     def calculate(self) -> typing.Tuple[typing.List[LineGraphSegment], float]:
         scaled_xdata = self.scaled_xdata
@@ -367,12 +540,21 @@ class SegmentsCacheItem:
 
             # draw the line plot itself
             if x_calibration and x_calibration.units == scaled_xdata.dimensional_calibrations[-1].units:
-                segments, baseline = calculate_line_graph(plot_height, plot_width, plot_origin_y, plot_origin_x,
-                                                          scaled_xdata,
-                                                          scaled_data_min, scaled_data_range,
-                                                          calibrated_left_channel,
-                                                          calibrated_right_channel, x_calibration,
-                                                          None, axes.axis_scale)
+                if self.graph_style == "line":
+                    segments, baseline = calculate_line_segments(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                                                                 scaled_xdata,
+                                                                 scaled_data_min, scaled_data_range,
+                                                                 calibrated_left_channel,
+                                                                 calibrated_right_channel, x_calibration,
+                                                                 None, axes.axis_scale)
+                else:
+                    # "bar" (centered staircase spanning [c-0.5, c+0.5))
+                    segments, baseline = calculate_bar_segments(plot_height, plot_width, plot_origin_y, plot_origin_x,
+                                                                scaled_xdata,
+                                                                scaled_data_min, scaled_data_range,
+                                                                calibrated_left_channel,
+                                                                calibrated_right_channel, x_calibration,
+                                                                None, axes.axis_scale)
         return segments, baseline
 
 
@@ -381,11 +563,11 @@ def draw_fills(line_graph_layer: LinePlotDisplay.LineGraphLayer, drawing_context
         scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(line_graph_layer.xdata, line_graph_layer.axes)
         scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
         scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
-        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds)
+        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds, line_graph_layer.graph_style)
         segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
         segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
         for segment in segments:
-            segment.fill(drawing_context, baseline, Color.Color(line_graph_layer.fill_color))
+            segment.fill(drawing_context, baseline, line_graph_layer.fill_color)
         return scaled_xdata_cache_value, segments_cache_value
     return tuple()
 
@@ -395,12 +577,21 @@ def draw_strokes(line_graph_layer: LinePlotDisplay.LineGraphLayer, drawing_conte
         scaled_data_and_metadata_cache_item = MappedCalibratedDataAndMetadataCacheItem(line_graph_layer.xdata, line_graph_layer.axes)
         scaled_xdata_cache_value = composer_cache.get_cache_value(scaled_data_and_metadata_cache_item)
         scaled_xdata = typing.cast(typing.Optional[DataAndMetadata.DataAndMetadata], scaled_xdata_cache_value.value)
-        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds)
+        segments_cache_item = SegmentsCacheItem(scaled_xdata, line_graph_layer.axes, canvas_bounds, line_graph_layer.graph_style)
         segments_cache_value = composer_cache.get_cache_value(segments_cache_item)
         segments, baseline = typing.cast(typing.Tuple[typing.List[LineGraphSegment], float], segments_cache_value.value)
-        for segment in segments:
-            scaled_stroke_width = drawing_metrics.scale_stroke(line_graph_layer.stroke_width)
-            segment.stroke(drawing_context, baseline, Color.Color(line_graph_layer.stroke_color), scaled_stroke_width)
+
+        with drawing_context.saver():
+            drawing_context.clip_rect(
+                canvas_bounds.left,
+                canvas_bounds.top,
+                canvas_bounds.width,
+                canvas_bounds.height
+            )
+            for segment in segments:
+                scaled_stroke_width = drawing_metrics.scale_stroke(line_graph_layer.stroke_width)
+                segment.stroke(drawing_context, baseline, Color.Color(line_graph_layer.stroke_color), scaled_stroke_width)
+
         return scaled_xdata_cache_value, segments_cache_value
     return tuple()
 

--- a/nion/swift/LineGraphCanvasItem.py
+++ b/nion/swift/LineGraphCanvasItem.py
@@ -273,7 +273,7 @@ def calculate_bar_segments(
     #
     # The axis is unchanged, therefore the first and last bars
     # will naturally be clipped by half a bar at the graph edge.
-    channel_width_px = plot_width / max(1, (n_samples - 1))
+    channel_width_px = plot_width * abs(x_calibration.scale) / abs(cal_width)
 
     segments: typing.List[LineGraphSegment] = []
 

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -613,8 +613,8 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         assert canvas_bounds
         plot_rect = canvas_bounds.translated(plot_origin)
         axes = self.__last_axes
-        left_channel = axes.drawn_left_channel if axes else 0
-        right_channel = axes.drawn_right_channel if axes else 0
+        left_channel = int(axes.drawn_left_channel) if axes else 0
+        right_channel = int(axes.drawn_right_channel) if axes else 0
         return LinePlotCanvasItemMapping(data_scale, plot_rect, left_channel, right_channel)
 
     @property
@@ -846,7 +846,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
                 if canvas_bounds and canvas_bounds.contains_point(mouse):
                     mouse = mouse - canvas_bounds.origin
                     x = float(mouse.x) / canvas_bounds.width
-                    px = axes.drawn_left_channel + int(x * (axes.drawn_right_channel - axes.drawn_left_channel))
+                    px = int(axes.drawn_left_channel) + int(x * (axes.drawn_right_channel - axes.drawn_left_channel))
                     pos_1d = px,
         return pos_1d
 

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1623,6 +1623,7 @@ class DisplayLayer(Schema.Entity):
     stroke_color = Schema.EntityAttribute[typing.Optional[str]]()
     fill_color = Schema.EntityAttribute[typing.Optional[str]]()
     stroke_width = Schema.EntityAttribute[typing.Optional[int]]()
+    graph_style = Schema.EntityAttribute[typing.Optional[str]]()  # "bar" | "line" | "scatter"
     display_data_channel = Schema.EntityAttribute[typing.Optional[DisplayDataChannel]]()
 
     def __init__(self, display_layer_properties: typing.Optional[Persistence.PersistentDictType] = None) -> None:
@@ -1684,6 +1685,7 @@ class DisplayLayerInfo:
     stroke_color: str | None
     fill_color: str | None
     stroke_width: int | None
+    graph_style: str | None = None  # line-plot style: "bar" | "line" | "scatter" (None = default "bar")
 
 
 @dataclasses.dataclass
@@ -2700,7 +2702,8 @@ class DisplayItem(Persistence.PersistentObject):
                 label=label,
                 stroke_color=display_layer.stroke_color,
                 fill_color=display_layer.fill_color,
-                stroke_width=display_layer.stroke_width
+                stroke_width=display_layer.stroke_width,
+                graph_style=display_layer.graph_style,
             )
             display_layer_list.append(display_layer_info)
         return display_layer_list
@@ -2721,7 +2724,7 @@ class DisplayItem(Persistence.PersistentObject):
     @display_layers_list.setter
     def display_layers_list(self, value: list[DisplayLayer]) -> None:
         assert len(value) == len(self.display_layers)
-        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width"]
+        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width", "graph_style"]
         for index, (display_layer, new_display_layer) in enumerate(zip(self.display_layers, value)):
             for property in properties:
                 property_value = getattr(new_display_layer, property)

--- a/nion/swift/model/DisplayItem.py
+++ b/nion/swift/model/DisplayItem.py
@@ -1623,6 +1623,7 @@ class DisplayLayer(Schema.Entity):
     stroke_color = Schema.EntityAttribute[typing.Optional[str]]()
     fill_color = Schema.EntityAttribute[typing.Optional[str]]()
     stroke_width = Schema.EntityAttribute[typing.Optional[int]]()
+    graph_style = Schema.EntityAttribute[typing.Optional[str]]()  # "bar" | "line"
     display_data_channel = Schema.EntityAttribute[typing.Optional[DisplayDataChannel]]()
 
     def __init__(self, display_layer_properties: typing.Optional[Persistence.PersistentDictType] = None) -> None:
@@ -1684,6 +1685,7 @@ class DisplayLayerInfo:
     stroke_color: str | None
     fill_color: str | None
     stroke_width: int | None
+    graph_style: str | None = None  # line-plot style: "bar" | "line" (None = default "bar")
 
 
 @dataclasses.dataclass
@@ -2700,7 +2702,8 @@ class DisplayItem(Persistence.PersistentObject):
                 label=label,
                 stroke_color=display_layer.stroke_color,
                 fill_color=display_layer.fill_color,
-                stroke_width=display_layer.stroke_width
+                stroke_width=display_layer.stroke_width,
+                graph_style=display_layer.graph_style,
             )
             display_layer_list.append(display_layer_info)
         return display_layer_list
@@ -2721,7 +2724,7 @@ class DisplayItem(Persistence.PersistentObject):
     @display_layers_list.setter
     def display_layers_list(self, value: list[DisplayLayer]) -> None:
         assert len(value) == len(self.display_layers)
-        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width"]
+        properties = ["data_row", "fill_color", "stroke_color", "label", "stroke_width", "graph_style"]
         for index, (display_layer, new_display_layer) in enumerate(zip(self.display_layers, value)):
             for property in properties:
                 property_value = getattr(new_display_layer, property)

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -390,18 +390,20 @@ class LineGraphLayer:
                  axes: typing.Optional[LineGraphAxes],
                  fill_color: typing.Optional[Color.Color],
                  stroke_color: typing.Optional[Color.Color],
-                 stroke_width: typing.Optional[float]) -> None:
+                 stroke_width: typing.Optional[float],
+                 graph_style: typing.Optional[str] = None) -> None:
         self.__xdata = xdata
         self.__fill_color = fill_color
         self.__stroke_color = stroke_color
         self.__stroke_width = stroke_width or 0.5
+        self.__graph_style: str = graph_style or "bar"
         self.__canvas_bounds: typing.Optional[Geometry.IntRect] = None
         self.__calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
         self.__axes = axes
 
     def __repr__(self) -> str:
         data_sum = numpy.sum(self.__xdata) if self.__xdata else 0.0
-        return f"LineGraphLayer {data_sum} {self.__fill_color} {self.__stroke_color} {self.__stroke_width} {self.__axes}"
+        return f"LineGraphLayer {data_sum} {self.__fill_color} {self.__stroke_color} {self.__stroke_width} {self.__graph_style} {self.__axes}"
 
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, LineGraphLayer):
@@ -410,6 +412,7 @@ class LineGraphLayer:
                 self.__fill_color == other.__fill_color and
                 self.__stroke_color == other.__stroke_color and
                 self.__stroke_width == other.__stroke_width and
+                self.__graph_style == other.__graph_style and
                 self.__axes == other.__axes)
 
     @property
@@ -431,6 +434,11 @@ class LineGraphLayer:
     @property
     def axes(self) -> typing.Optional[LineGraphAxes]:
         return self.__axes
+
+    @property
+    def graph_style(self) -> str:
+        """Graph drawing style: 'bar' (staircase/histogram), 'line' (diagonal), or 'scatter' (markers)."""
+        return self.__graph_style
 
 
 MAX_LAYER_COUNT = 16
@@ -642,6 +650,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                 fill_color_str = display_layer.fill_color
                 stroke_color_str = display_layer.stroke_color
                 stroke_width = display_layer.stroke_width
+                graph_style = display_layer.graph_style
                 data_index = display_layer.data_index or 0
                 data_row = display_layer.data_row or 0
                 if 0 <= data_index < len(xdata_list):
@@ -655,7 +664,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                             intensity_calibration = xdata.intensity_calibration
                             displayed_dimensional_calibration = xdata.dimensional_calibrations[-1]
                             xdata = DataAndMetadata.new_data_and_metadata(scalar_data, intensity_calibration, [displayed_dimensional_calibration])
-                    line_graph_layers.append(LineGraphLayer(xdata, axes, fill_color, stroke_color, stroke_width))
+                    line_graph_layers.append(LineGraphLayer(xdata, axes, fill_color, stroke_color, stroke_width, graph_style))
                     self._has_valid_drawn_graph_data = xdata is not None
             self.__line_graph_layers = line_graph_layers
         return self.__line_graph_layers

--- a/nion/swift/model/LinePlotDisplay.py
+++ b/nion/swift/model/LinePlotDisplay.py
@@ -226,8 +226,8 @@ class LegendEntry:
 class LineGraphAxes:
     """Track information about line graph axes."""
 
-    def __init__(self, data_scale: float, scaled_data_min: float, scaled_data_max: float, data_left: int,
-                 data_right: int, x_calibration: typing.Optional[Calibration.Calibration],
+    def __init__(self, data_scale: float, scaled_data_min: float, scaled_data_max: float, data_left: float,
+                 data_right: float, x_calibration: typing.Optional[Calibration.Calibration],
                  y_calibration: typing.Optional[Calibration.Calibration], axis_scale_id: typing.Optional[str],
                  y_ticker: Geometry.Ticker) -> None:
         assert x_calibration is None or x_calibration.is_valid
@@ -297,11 +297,11 @@ class LineGraphAxes:
         return calibrated_value
 
     @property
-    def drawn_left_channel(self) -> int:
+    def drawn_left_channel(self) -> float:
         return self.__uncalibrated_left_channel
 
     @property
-    def drawn_right_channel(self) -> int:
+    def drawn_right_channel(self) -> float:
         return self.__uncalibrated_right_channel
 
     @property
@@ -390,18 +390,20 @@ class LineGraphLayer:
                  axes: typing.Optional[LineGraphAxes],
                  fill_color: typing.Optional[Color.Color],
                  stroke_color: typing.Optional[Color.Color],
-                 stroke_width: typing.Optional[float]) -> None:
+                 stroke_width: typing.Optional[float],
+                 graph_style: typing.Optional[str] = None) -> None:
         self.__xdata = xdata
         self.__fill_color = fill_color
         self.__stroke_color = stroke_color
         self.__stroke_width = stroke_width or 0.5
+        self.__graph_style: str = graph_style or "bar"
         self.__canvas_bounds: typing.Optional[Geometry.IntRect] = None
         self.__calibrated_xdata: typing.Optional[DataAndMetadata.DataAndMetadata] = None
         self.__axes = axes
 
     def __repr__(self) -> str:
         data_sum = numpy.sum(self.__xdata) if self.__xdata else 0.0
-        return f"LineGraphLayer {data_sum} {self.__fill_color} {self.__stroke_color} {self.__stroke_width} {self.__axes}"
+        return f"LineGraphLayer {data_sum} {self.__fill_color} {self.__stroke_color} {self.__stroke_width} {self.__graph_style} {self.__axes}"
 
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, LineGraphLayer):
@@ -410,6 +412,7 @@ class LineGraphLayer:
                 self.__fill_color == other.__fill_color and
                 self.__stroke_color == other.__stroke_color and
                 self.__stroke_width == other.__stroke_width and
+                self.__graph_style == other.__graph_style and
                 self.__axes == other.__axes)
 
     @property
@@ -431,6 +434,11 @@ class LineGraphLayer:
     @property
     def axes(self) -> typing.Optional[LineGraphAxes]:
         return self.__axes
+
+    @property
+    def graph_style(self) -> str:
+        """Graph drawing style: 'bar' (centered staircase, spans [c-0.5, c+0.5)) or 'line' (diagonal)"""
+        return self.__graph_style
 
 
 MAX_LAYER_COUNT = 16
@@ -606,6 +614,13 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
             left_channel = typing.cast(int, min(left_channel, right_channel))
             right_channel = typing.cast(int, max(left_channel, right_channel))
 
+            # if any display layer uses the centered "bar" style, extend the drawn range 0.5 channel to the
+            # left so the leftmost bar (which is centered on its sample position, spanning [c-0.5, c+0.5)) is
+            # fully visible rather than being clipped at the left edge of the plot.
+            uses_bar_style = any(display_layer.graph_style == "bar" for display_layer in self.display_layers[0:MAX_LAYER_COUNT])
+            drawn_left_channel: float = left_channel #left_channel - 0.5 if uses_bar_style else left_channel
+            drawn_right_channel: float = right_channel #right_channel + 0.5 if uses_bar_style else right_channel
+
             if y_min is not None:
                 y_min_calibrated = displayed_intensity_calibration.convert_to_calibrated_value(y_min)
             else:
@@ -621,8 +636,8 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
             self.__axes = LineGraphAxes(data_scale,
                                         scaled_data_min,
                                         scaled_data_max,
-                                        left_channel,
-                                        right_channel,
+                                        drawn_left_channel,
+                                        drawn_right_channel,
                                         displayed_dimensional_calibration,
                                         displayed_intensity_calibration,
                                         y_axis_scale_id,
@@ -642,6 +657,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                 fill_color_str = display_layer.fill_color
                 stroke_color_str = display_layer.stroke_color
                 stroke_width = display_layer.stroke_width
+                graph_style = display_layer.graph_style
                 data_index = display_layer.data_index or 0
                 data_row = display_layer.data_row or 0
                 if 0 <= data_index < len(xdata_list):
@@ -655,7 +671,7 @@ class LinePlotDisplayInfo(DisplayInfo.DisplayInfo):
                             intensity_calibration = xdata.intensity_calibration
                             displayed_dimensional_calibration = xdata.dimensional_calibrations[-1]
                             xdata = DataAndMetadata.new_data_and_metadata(scalar_data, intensity_calibration, [displayed_dimensional_calibration])
-                    line_graph_layers.append(LineGraphLayer(xdata, axes, fill_color, stroke_color, stroke_width))
+                    line_graph_layers.append(LineGraphLayer(xdata, axes, fill_color, stroke_color, stroke_width, graph_style))
                     self._has_valid_drawn_graph_data = xdata is not None
             self.__line_graph_layers = line_graph_layers
         return self.__line_graph_layers

--- a/nion/swift/model/Model.py
+++ b/nion/swift/model/Model.py
@@ -109,6 +109,7 @@ DisplayLayer = Schema.entity("display_layer", None, None, {
     "label": Schema.prop(Schema.STRING),
     "display_data_channel": Schema.reference(DisplayDataChannel),
     "stroke_width": Schema.prop(Schema.FLOAT),
+    "graph_style": Schema.prop(Schema.STRING),  # "bar" | "line"
 })
 
 Graphic = Schema.entity("graphic", None, None, {

--- a/nion/swift/test/LineGraphCanvasItem_test.py
+++ b/nion/swift/test/LineGraphCanvasItem_test.py
@@ -173,7 +173,7 @@ class TestLineGraphCanvasItem(unittest.TestCase):
         data[1] = 1
         data[2] = numpy.nan
         data[3:] = range(3,16,1)
-        segments, baseline = LineGraphCanvasItem.calculate_line_graph(
+        segments, baseline = LineGraphCanvasItem.calculate_bar_segments(
             100, 32, 0, 0, DataAndMetadata.new_data_and_metadata(data),
             0, 16, 0, 16, Calibration.Calibration(), None, LinePlotDisplay._get_axis_scale("linear")
         )


### PR DESCRIPTION
Adds a graph_style property to LineGraphs.  graph_style can be either None (defaulting to Bar), "bar" which is the stepped bar graph, or "line" which provides a simple line graph between the provided data points.
A selector is added to the Inspector to allow for switching between these types.