### PR TITLE
Compressed nhdf export

### DIFF
--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -313,10 +313,17 @@ class HDF5HandlerFactory(StorageHandler.StorageHandlerFactoryLike):
 
 
 def _create_dataset(data_group: typing.Any, dataset_id: str, data: numpy.typing.NDArray[typing.Any], filter: h5py.filters.FilterRefBase | None = None) -> typing.Any:
+    chunks: tuple[int, ...] | None | bool = getattr(data, "chunks", True)
     data_shape = data.shape
 
     # create the dataset, preallocate space.
-    ds = data_group.create_dataset(dataset_id, shape=data_shape, dtype=data.dtype, compression=filter)
+    ds = data_group.create_dataset(dataset_id, shape=data_shape, dtype=data.dtype, compression=filter, chunks=chunks)
+
+    if callable(getattr(data, "iter_chunks", None)):
+        # if the data has an iter_chunks method, use it to write the data in chunks.
+        for selection in getattr(data, "iter_chunks")():
+            ds[selection] = data[selection]
+        return ds
 
     # search for the chunk size by iterating backwards through the shape and finding the
     # largest chunk size that is less than 64MB.

--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import datetime
 import io
 import json
+import logging
 import os
 import pathlib
 import threading
+import time
 import typing
 import uuid
 
@@ -348,6 +350,7 @@ class HDFImportExportDriver:
         self.__filter = filter
 
     def read_data(self, file_path: pathlib.Path, storage_handler_provider: StorageHandler.StorageHandlerProvider) -> StorageHandler.StorageHandlerImportData:
+        t0 = time.time()
         storage_handlers = list[StorageHandler.StorageHandler]()
         uuid_map = dict[uuid.UUID, uuid.UUID]()
         items = list[PersistentDictType]()
@@ -382,6 +385,7 @@ class HDFImportExportDriver:
             for key in sorted(index_group.attrs.keys()):
                 items.append(json.loads(index_group.attrs[key]))
         fp.close()
+        logging.getLogger("import").info(f"Import of {file_path} took {time.time() - t0:.2f} seconds")
         return StorageHandler.StorageHandlerImportData(storage_handlers, uuid_map, items)
 
     def write_display_item(self, path: pathlib.Path, items: typing.Sequence[StorageHandler.StorageHandlerExportItem]) -> None:

--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -13,6 +13,7 @@ import typing
 import uuid
 
 import h5py
+import hdf5plugin
 import numpy
 import numpy.typing
 
@@ -311,11 +312,11 @@ class HDF5HandlerFactory(StorageHandler.StorageHandlerFactoryLike):
         return ".h5"
 
 
-def _create_dataset(data_group: typing.Any, dataset_id: str, data: numpy.typing.NDArray[typing.Any]) -> typing.Any:
+def _create_dataset(data_group: typing.Any, dataset_id: str, data: numpy.typing.NDArray[typing.Any], filter: h5py.filters.FilterRefBase | None = None) -> typing.Any:
     data_shape = data.shape
 
     # create the dataset, preallocate space.
-    ds = data_group.create_dataset(dataset_id, shape=data_shape, dtype=data.dtype)
+    ds = data_group.create_dataset(dataset_id, shape=data_shape, dtype=data.dtype, compression=filter)
 
     # search for the chunk size by iterating backwards through the shape and finding the
     # largest chunk size that is less than 64MB.
@@ -336,8 +337,8 @@ def _create_dataset(data_group: typing.Any, dataset_id: str, data: numpy.typing.
 
 
 class HDFImportExportDriver:
-    def __init__(self) -> None:
-        pass
+    def __init__(self, filter: h5py.filters.FilterRefBase | None = None) -> None:
+        self.__filter = filter
 
     def read_data(self, file_path: pathlib.Path, storage_handler_provider: StorageHandler.StorageHandlerProvider) -> StorageHandler.StorageHandlerImportData:
         storage_handlers = list[StorageHandler.StorageHandler]()
@@ -385,7 +386,7 @@ class HDFImportExportDriver:
         for index, item in enumerate(items):
             index_group.attrs["1"] = json.dumps(item.write_to_dict())
             for data_item in item.data_items:
-                ds = _create_dataset(data_group, str(data_index), data_item.data)
+                ds = _create_dataset(data_group, str(data_index), data_item.data, self.__filter)
                 ds.attrs["properties"] = json.dumps(data_item.write_to_dict())
                 data_index += 1
         fp.close()
@@ -400,7 +401,17 @@ class HDFImportExportDriverFactory:
         return HDFImportExportDriver()
 
 
+class CompressedHDFImportExportDriverFactory:
+    driver_id = "nhdf-io-handler-compressed"
+    title = "NData HDF (lz4 compressed)"
+    extensions = ["nhdf"]
+
+    def make_import_export_driver(self) -> HDFImportExportDriver:
+        return HDFImportExportDriver(filter=hdf5plugin.Blosc(cname='lz4', clevel=9, shuffle=hdf5plugin.Blosc.BITSHUFFLE))
+
+
 Registry.register_component(HDFImportExportDriverFactory(), {"import-export-driver-factory"})
+Registry.register_component(CompressedHDFImportExportDriverFactory(), {"import-export-driver-factory"})
 
 
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pillow",
     "pytz",
     "scipy",
-    "tzlocal"
+    "tzlocal",
+    "hdf5plugin"
 ]
 
 [project.scripts]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,6 +13,7 @@ h5py
 pytz
 tzlocal
 pillow
+hdf5plugin
 
 # for testing
 types-pytz


### PR DESCRIPTION
This PR adds a new nhdf export option which allows to store the output file as lz4 compressed file. Because the inital performance with just comression enabled was terrible, it also adds an improved handling of hdf5 chunking: If the input data item is already backed by and hdf5 file and uses chunks, the output file will use the same chunking layout. This dramatically improves compressed  export performance and even slightly improves uncompressed export performance.
Finally this PR adds logging output for nhdf imports so that it becomes easier to compare compressed vs. uncompressed imports.
I will open a follow-up issue for improving import performance by improving how chunks are handled.

Benchmark results for a ~37 GB dataset with real Dectris data (~10% of the pixels have counts in them):

Without https://github.com/nion-software/nionswift/pull/1938/commits/0d561a578263809bcaae32ca203d4e5d675f8483 (chunking improvements):

```
Export 138s (D:\4D Data for march 1st heterostructure 4d .nhdf) C(512 x 512) x D(192 x 192), Real (32-bit)
Export 768s (D:\4D Data for march 1st heterostructure 4d compressed.nhdf) C(512 x 512) x D(192 x 192), Real (32-bit)
```

With chunking improvements:

```
Export 127s (D:\4D Data for march 1st heterostructure 4d .nhdf) C(512 x 512) x D(192 x 192), Real (32-bit)
Export 126s (D:\4D Data for march 1st heterostructure 4d compressed.nhdf) C(512 x 512) x D(192 x 192), Real (32-bit)
```

Which means that with chunking improvements, there is no speed penalty for compressed export, but the data size goes from 37 GB down to 1.5 GB, which is a 25x file size reduction!

A note on [hdf5plugin](https://hdf5plugin.readthedocs.io/en/stable/index.html): Yes, this introduces a new dependency, but it is a small library with no additional dependencies itself. It is mostly a convenience library because it compiles and registers the HDF5 compression filters and provides convenience classes for setting up compression. It does not develop or host the compression libaries themselves, they are all hosted by the hdf5group [here](https://github.com/HDFGroup/hdf5_plugins). That means, that even if `hdf5plugin` causes us issues in the future, it is easy to compile and register the relevant filter plugins ourselves and use them from h5py. However, right now the risk of using hdf5plugin is very low in my opinion and it makes development a lot easier if we want to experiment with different compression algorithms.