### PR TITLE
Improve chunking algorithm

### DIFF
--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -42,31 +42,52 @@ def make_directory_if_needed(directory_path: str) -> None:
         os.makedirs(directory_path)
 
 
-def get_write_chunk_shape_for_data(data_shape: DataAndMetadata.ShapeType, data_dtype: numpy.typing.DTypeLike) -> typing.Optional[DataAndMetadata.ShapeType]:
+def get_write_chunk_shape_for_data(data_shape: DataAndMetadata.ShapeType, data_dtype: numpy.typing.DTypeLike, data_descriptor: DataAndMetadata.DataDescriptor, target_chunk_size: int=240000) -> typing.Optional[DataAndMetadata.ShapeType]:
     """
     Calculate an appropriate write chunk shape for a given data shape and dtype.
 
-    The target chunk size is 580 kB which seems to be a sweet spot according to benchmarks.
+    The default target chunk size is 240 kB which seems to be a sweet spot according to benchmarks.
     The algorithm assumes that the data is c-contiguous in memory.
 
     If the total number of chunks that the calculated chunk shape would lead to is less than 100 (i.e. the file will
-    be less than 58 MB in size) or if the data shape is not suitable for chunking, return None.
+    be less than 24 MB in size) or if the data shape is not suitable for chunking, return None.
+
+    The chunk shape is calculated according to the following rules:
+    - Use a quarter of the data axis (i.e. the last axis for 1D data and the last two axis for 2D data)
+      if the number of elements in the last two or last three dimensions is large enough. If not, use
+      the entire data axis.
+    - Work backwards from the last axis and increse the number of elements per axis until prod(chunk_chape) >= target_chunk size.
+      A chunk cannot exceed the number of elements of an axis, so if one dimension is "full", move to the next axis.
+    - The slow scan axis and the sequence axis when acquiring a sequence of SIs or 4D STEM images can never be chunked (i.e.
+      chunk shape == 1 for these axis).
+    - The sequence axis in a sequence of 1D or 2D data can be chunked.
     """
     data_dtype = numpy.dtype(data_dtype)
 
-    target_chunk_size = 580*1024/data_dtype.itemsize
+    is_2d_data = data_descriptor.datum_dimension_count == 2
+
+    target_chunk_size = int(round(target_chunk_size / data_dtype.itemsize))
+    divisors = [1] * len(data_shape)
+    if len(data_shape) > 2 and (
+        (numpy.prod(data_shape[-3:]) > 8 * target_chunk_size and is_2d_data) or
+        (numpy.prod(data_shape[-2:]) > 2 * target_chunk_size)):
+        if is_2d_data:
+            divisors[-2:] = [4, 4]
+        else:
+            divisors[-1] = 4
+
     chunk_size = 1
     counter = len(data_shape)
     chunk_shape = [1] * len(data_shape)
     while chunk_size < target_chunk_size and counter > 0:
         counter -= 1
-        chunk_size *= data_shape[counter]
-        chunk_shape[counter] = data_shape[counter]
+        chunk_size *= data_shape[counter] // divisors[counter]
+        chunk_shape[counter] = data_shape[counter] // divisors[counter]
 
     if chunk_size == 0: # This means one of the input dimensions was "0", so chunking cannot be used
         return None
 
-    chunk_size //= data_shape[counter]
+    chunk_size //= chunk_shape[counter]
     remaining_elements = min(max(target_chunk_size // chunk_size, 1), data_shape[counter])
     chunk_shape[counter] = int(remaining_elements)
 
@@ -75,6 +96,12 @@ def get_write_chunk_shape_for_data(data_shape: DataAndMetadata.ShapeType, data_d
         n_chunks *= data_shape[i] // chunk_shape[i]
     if n_chunks < 100:
         return None
+
+    # Do not allow chunking of the slow scan axis or the sequence axis when acquiring a sequence of SIs or 4D STEM images.
+    if is_2d_data and len(data_shape) > 3:
+        chunk_shape[:-3] = [1] * (len(data_shape) - 3)
+    elif not is_2d_data and len(data_shape) > 2:
+        chunk_shape[:-2] = [1] * (len(data_shape) - 2)
 
     return tuple(chunk_shape)
 

--- a/nion/swift/model/HDF5Handler.py
+++ b/nion/swift/model/HDF5Handler.py
@@ -248,7 +248,7 @@ class HDF5Handler(StorageHandler.StorageHandler):
             #   3 - 'data' exists and is the same size (overwrite)
             if not "data" in self.__file.fp:
                 # case 1
-                chunks = get_write_chunk_shape_for_data(data.shape, data.dtype)
+                chunks = get_write_chunk_shape_for_data(data.shape, data.dtype, data_descriptor)
                 self.__dataset = self.__file.fp.require_dataset("data", shape=data.shape, dtype=data.dtype, chunks=chunks)
             else:
                 if self.__dataset is None:
@@ -258,7 +258,7 @@ class HDF5Handler(StorageHandler.StorageHandler):
                     json_properties = self.__dataset.attrs.get("properties", "")
                     self.__close_fp()
                     os.remove(self.__file_path)
-                    chunks = get_write_chunk_shape_for_data(data.shape, data.dtype)
+                    chunks = get_write_chunk_shape_for_data(data.shape, data.dtype, data_descriptor)
                     self.__dataset = self.__file.fp.require_dataset("data", shape=data.shape, dtype=data.dtype, chunks=chunks)
             self.__copy_data(data)
             if json_properties is not None:
@@ -278,7 +278,7 @@ class HDF5Handler(StorageHandler.StorageHandler):
                 os.remove(self.__file_path)
                 self.__file.open()
             # reserve the data
-            chunks = get_write_chunk_shape_for_data(data_shape, data_dtype)
+            chunks = get_write_chunk_shape_for_data(data_shape, data_dtype, data_descriptor)
             self.__dataset = self.__file.fp.require_dataset("data", shape=data_shape, dtype=data_dtype, fillvalue=0, chunks=chunks)
             if json_properties is not None:
                 self.__dataset.attrs["properties"] = json_properties

--- a/nion/swift/test/HDF5Handler_test.py
+++ b/nion/swift/test/HDF5Handler_test.py
@@ -25,24 +25,28 @@ class TestHDF5Handler(unittest.TestCase):
 
     def test_get_write_chunk_shape_for_data(self):
 
-        data_shapes_and_dtypes = [((512, 512, 130, 130), 'float32'),
-                                  ((971, 971, 130, 130), 'float32'),
-                                  ((1024, 1024, 130, 260), 'uint8'),
-                                  ((1024, 1024, 1030), 'int16'),
-                                  ((1024, 1024, 1032), 'float32'),
-                                  ((512, 512), 'float32'),
-                                  ((int(1e12),), 'int64')]
-        expected_chunk_shapes = [(1, 8, 130, 130),
-                                 (1, 8, 130, 130),
-                                 (1, 17, 130, 260),
-                                 (1, 288, 1030),
-                                 (1, 143, 1032),
+        data_shapes_and_dtypes = [((512, 512, 130, 130), 'float32', DataAndMetadata.DataDescriptor(False, 2, 2)),
+                                  ((971, 971, 130, 130), 'float32', DataAndMetadata.DataDescriptor(False, 2, 2)),
+                                  ((1024, 1024, 130, 260), 'uint8', DataAndMetadata.DataDescriptor(True, 2, 1)),
+                                  ((1024, 1024, 1030), 'int16', DataAndMetadata.DataDescriptor(False, 2, 1)),
+                                  ((1024, 1024, 1032), 'float32', DataAndMetadata.DataDescriptor(False, 2, 1)),
+                                  ((512, 512), 'float32', DataAndMetadata.DataDescriptor(False, 0, 2)),
+                                  ((int(1e12),), 'int64', DataAndMetadata.DataDescriptor(False, 0, 1)),
+                                  ((10, 1024, 1024, 1030), 'float32', DataAndMetadata.DataDescriptor(True, 2, 1)),
+                                  ((3, 123, 17, 31, 29), 'float32', DataAndMetadata.DataDescriptor(False, 2, 2))]
+        expected_chunk_shapes = [(1, 58, 32, 32),
+                                 (1, 58, 32, 32),
+                                 (1, 1, 130, 260),
+                                 (1, 466, 257),
+                                 (1, 232, 258),
                                  None,
-                                 (74240,)]
+                                 (30000,),
+                                 (1, 1, 233, 257),
+                                 (1, 1, 17, 31, 29)]
 
-        for shape_dtype, expected_chunk_shape in zip(data_shapes_and_dtypes, expected_chunk_shapes):
-            with self.subTest(shape=shape_dtype[0], dtype=shape_dtype[1]):
-                chunk_shape = HDF5Handler.get_write_chunk_shape_for_data(*shape_dtype)
+        for shape_dtype_descriptor, expected_chunk_shape in zip(data_shapes_and_dtypes, expected_chunk_shapes):
+            with self.subTest(shape=shape_dtype_descriptor[0], dtype=shape_dtype_descriptor[1], data_descriptor=shape_dtype_descriptor[2]):
+                chunk_shape = HDF5Handler.get_write_chunk_shape_for_data(*shape_dtype_descriptor)
 
                 if expected_chunk_shape is None:
                     self.assertIsNone(chunk_shape)


### PR DESCRIPTION
This PR adds just the chunking algorithm from PR #1641 to allow more efficient iteration over large datasets.

The problem with the exisiting chunking algorithm is that is is only optimized towards iteration along the collection or sequence axis, which causes terrible performance when iterating along another axis of the dataset.

This PR introduces a chunking algorithm with better balancing for iteration along different axis, which does have a negative impact on iterations along the sequence/collection axis but massively improves the performance along other axis (see issue https://github.com/nion-software/nion-internal/issues/359).