### PR TITLE
Change SVG export dialog to support bitmap exports w/ PPI

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -3503,3 +3503,23 @@ def preview(drawing_metrics: UISettings.DrawingMetrics, display_style: UISetting
                 display_canvas_item.update_canvas_items()
                 display_canvas_item.repaint_immediate(drawing_context, pixel_shape)
     return drawing_context
+
+
+def get_drawing_context_for_export(ui_settings: UISettings.UISettings, display_item: DisplayItem.DisplayItem, display_shape: Geometry.IntSize, ppi: float, font_ppi: int) -> DrawingContext.DrawingContext:
+    # take a snapshot so to modify the display properties for the proper image zoom, position, and canvas mode.
+    # ensure that the snapshot is closed when finished.
+    display_item_snapshot = display_item.snapshot()
+    try:
+        # update the zoom, position, and canvas mode for the export. these are neutral values that ensure it will
+        # draw at 1:1 scale and centered in the canvas.
+        display_properties = display_item_snapshot.display_properties
+        display_properties["image_zoom"] = 1.0
+        display_properties["image_position"] = (0.5, 0.5)
+        display_properties["image_canvas_mode"] = "fit"
+        display_item_snapshot.display_properties = display_properties
+        # create the drawing context and shape for the preview
+        drawing_metrics = UISettings.DrawingMetrics(ui_settings=ui_settings, ppi=ppi, device_dpi=96.0)
+        # standard font pt is PPI / 6 for bitmaps; PPI for SVG is 72 PPI.
+        return preview(drawing_metrics, UISettings.DisplayStyle(font_ppi / 6), display_item_snapshot, display_shape)
+    finally:
+        display_item_snapshot.close()

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -1075,8 +1075,9 @@ class DocumentController(Window.Window):
         else:
             self.ui.save_rgba_data_to_file(rgba_data, str(path), image_format)
 
-    def export_svg(self, display_item: DisplayItem.DisplayItem) -> None:
-        ExportDialog.ExportSVGDialog(self, display_item)
+    def export_display(self, display_item: DisplayItem.DisplayItem) -> None:
+        ExportDialog.ExportDisplayDialog(self, display_item)
+
 
     # this method creates a task. it is thread safe.
     def create_task_context_manager(self, title: str, task_type: str, logging: bool = True) -> Task.TaskContextManager:
@@ -3205,9 +3206,9 @@ class ExportBatchAction(Window.Action):
         return len(context.display_items) > 0 or context.display_item is not None
 
 
-class ExportSVGAction(Window.Action):
-    action_id = "file.export_svg"
-    action_name = _("Export SVG...")
+class ExportDisplayAction(Window.Action):
+    action_id = "file.export_display"
+    action_name = _("Export SVG/Bitmap...")
 
     def execute(self, context: Window.ActionContext) -> Window.ActionResult:
         raise NotImplementedError()
@@ -3216,7 +3217,7 @@ class ExportSVGAction(Window.Action):
         window = typing.cast(DocumentController, context.window)
         selected_display_item = window.selected_display_item
         if selected_display_item:
-            window.export_svg(selected_display_item)
+            window.export_display(selected_display_item)
         return Window.ActionResult(Window.ActionStatus.FINISHED)
 
     def is_enabled(self, context: Window.ActionContext) -> bool:
@@ -3254,7 +3255,7 @@ Window.register_action(DeleteItemAction())
 Window.register_action(DeleteDataItemAction())
 Window.register_action(ExportAction())
 Window.register_action(ExportBatchAction())
-Window.register_action(ExportSVGAction())
+Window.register_action(ExportDisplayAction())
 Window.register_action(ImportDataAction())
 Window.register_action(ImportFolderAction())
 

--- a/nion/swift/DocumentController.py
+++ b/nion/swift/DocumentController.py
@@ -22,6 +22,9 @@ import typing
 import uuid
 import weakref
 
+# third party libraries
+import imageio.v3 as imageio
+
 from nion.data import DataAndMetadata
 from nion.swift import ComputationPanel
 from nion.swift import ConsoleDialog
@@ -59,6 +62,7 @@ from nion.swift.model import Utility
 from nion.swift.model import WorkspaceLayout
 from nion.ui import CanvasItem
 from nion.ui import Dialog
+from nion.ui import DrawingContext
 from nion.ui import PreferencesDialog
 from nion.ui import Window
 from nion.ui import UserInterface
@@ -1043,29 +1047,33 @@ class DocumentController(Window.Window):
             ExportDialog.ExportDialog(self.ui, self, display_items)
 
     def export_svg_file(self, ui_settings: UISettings.UISettings, display_item: DisplayItem.DisplayItem, display_shape: Geometry.IntSize, path: pathlib.Path) -> None:
-        # take a snapshot so to modify the display properties for the proper image zoom, position, and canvas mode.
-        # ensure that the snapshot is closed when finished.
-        display_item_snapshot = display_item.snapshot()
-        try:
-            # update the zoom, position, and canvas mode for the export. these are neutral values that ensure it will
-            # draw at 1:1 scale and centered in the canvas.
-            display_properties = display_item_snapshot.display_properties
-            display_properties["image_zoom"] = 1.0
-            display_properties["image_position"] = (0.5, 0.5)
-            display_properties["image_canvas_mode"] = "fit"
-            display_item_snapshot.display_properties = display_properties
-            # create the drawing context and shape for the preview
-            drawing_metrics = UISettings.DrawingMetrics(ui_settings=ui_settings, ppi=96.0, device_dpi=96.0)
-            font = UISettings.DisplayStyle().get_font('legend', drawing_metrics)
-            drawing_context = DisplayPanel.preview(drawing_metrics, UISettings.DisplayStyle(), display_item_snapshot, display_shape)
-            # set up the SVG
-            view_box = Geometry.IntRect(Geometry.IntPoint(), display_shape)
-            svg = drawing_context.to_svg(display_shape, view_box)
-            # write the file
-            with Utility.AtomicFileWriter(path.with_suffix(".svg")) as fp:
-                fp.write(svg)
-        finally:
-            display_item_snapshot.close()
+        drawing_context = DisplayPanel.get_drawing_context_for_export(ui_settings, display_item, display_shape, 96, 72)
+        # set up the SVG
+        view_box = Geometry.IntRect(Geometry.IntPoint(), display_shape)
+        svg = drawing_context.to_svg(display_shape, view_box)
+        # write the file
+        with Utility.AtomicFileWriter(path.with_suffix(".svg")) as fp:
+            fp.write(svg)
+
+    def export_bitmap_file(self, ui_settings: UISettings.UISettings, display_item: DisplayItem.DisplayItem, display_shape: Geometry.IntSize, ppi: int, path: pathlib.Path, image_format: str) -> None:
+        drawing_context = DisplayPanel.get_drawing_context_for_export(ui_settings, display_item, display_shape, ppi, ppi)
+        # rasterize the drawing context into an RGBA bitmap at the target pixel shape and write it to disk
+        rgba_data = self.ui.create_rgba_image(drawing_context, display_shape.width, display_shape.height)
+        if rgba_data is None:
+            return
+        if image_format in ("png", "jpg"):
+            # imageio (via Pillow) can embed the target DPI in these formats, so downstream apps
+            # display/print the exported image at the correct physical size. the data returned by
+            # create_rgba_image comes from Qt's rendering, which is byte-ordered BGRA in memory; reorder
+            # to RGBA before handing it to imageio.
+            rgba_array = DrawingContext.get_rgba_view_from_rgba_data(rgba_data)[..., (2, 1, 0, 3)]
+            if image_format == "png":
+                imageio.imwrite(str(path), rgba_array, extension=".png", dpi=(ppi, ppi))
+            elif image_format == "jpg":
+                # JPEG does not support an alpha channel.
+                imageio.imwrite(str(path), rgba_array[..., :3], extension=".jpg", dpi=(ppi, ppi))
+        else:
+            self.ui.save_rgba_data_to_file(rgba_data, str(path), image_format)
 
     def export_svg(self, display_item: DisplayItem.DisplayItem) -> None:
         ExportDialog.ExportSVGDialog(self, display_item)

--- a/nion/swift/ExportDialog.py
+++ b/nion/swift/ExportDialog.py
@@ -418,6 +418,16 @@ class Quantity:
     def with_unit_description(self, unit_description: UnitDescription) -> Quantity:
         return Quantity(unit_description.convert_value_from_pixels(self.pixels), unit_description)
 
+    def with_same_value_new_description(self, unit_description: UnitDescription) -> Quantity:
+        """Return a new quantity with the same numeric value but a different unit description.
+
+        Unlike `with_unit_description`, this does not reconvert through pixels. Use this when the
+        unit id is unchanged but its conversion factor has changed (e.g. the ppi used for inches or
+        centimeters changed) and the displayed value (e.g. "4" inches) should be preserved while the
+        underlying pixel size changes to match the new conversion factor.
+        """
+        return Quantity(self.__value, unit_description)
+
     @property
     def value(self) -> float:
         return self.__value
@@ -450,6 +460,20 @@ svg_export_unit_descriptions = [
 ]
 
 
+def make_unit_descriptions_for_ppi(ppi: int) -> dict[str, UnitDescription]:
+    """Return unit descriptions (keyed by unit id) scaled to the given ppi.
+
+    The pixel unit never scales with ppi (a pixel is always a pixel); inches and centimeters
+    scale their pixels-per-unit conversion factor with ppi, since that is the definition of dpi/ppi:
+    the same physical size (in inches or centimeters) maps to more or fewer pixels depending on ppi.
+    """
+    return {
+        pixel_unit_description.unit_id: pixel_unit_description,
+        "inches": UnitDescription("inches", _("Inches"), ppi),
+        "centimeters": UnitDescription("centimeters", _("Centimeters"), ppi / 2.54),
+    }
+
+
 def calculate_display_size_in_pixels(display_item: DisplayItem.DisplayItem) -> Geometry.IntSize:
     """Return the display size in pixels.
 
@@ -467,20 +491,18 @@ def calculate_display_size_in_pixels(display_item: DisplayItem.DisplayItem) -> G
 
 
 class ExportSizeModel(Observable.Observable):
-    def __init__(self, display_item: DisplayItem.DisplayItem, unit_id_model: Model.PropertyModel[str]) -> None:
+    def __init__(self, display_item: DisplayItem.DisplayItem, unit_id_model: Model.PropertyModel[str], ppi: int = 96) -> None:
         super().__init__()
         self.__display_item = display_item
         self.__unit_id_model = unit_id_model
+        self.__ppi = ppi
+        self.__unit_descriptions_by_id = make_unit_descriptions_for_ppi(ppi)
         display_size = calculate_display_size_in_pixels(display_item)
         self.__aspect_ratio = (display_size.width / display_size.height if display_size.height > 0 else 1.0) if display_size.width > 0 else 1.0
         self.aspect_ratio_mode = Model.PropertyModel("default")
         self.__float_to_string_converter = Converter.FloatToStringConverter()
         self.__primary_field = 'width'
-        unit_description = pixel_unit_description
-        for unit_description_ in svg_export_unit_descriptions:
-            if unit_description_.unit_id == unit_id_model.value:
-                unit_description = unit_description_
-                break
+        unit_description = self.__unit_descriptions_by_id.get(unit_id_model.value or str(), pixel_unit_description)
         self.aspect_ratio_locked = Model.PropertyModel(True)
         self.is_line_plot = (display_item.used_display_type == "line_plot")
         self.__width_quantity = get_quantity_from_pixels(display_size.width, unit_description)
@@ -635,15 +657,16 @@ class ExportSizeModel(Observable.Observable):
     @property
     def unit_description(self) -> UnitDescription:
         """Return the unit description for the current unit id."""
-        for unit_description in svg_export_unit_descriptions:
-            if unit_description.unit_id == self.__unit_id_model.value:
-                return unit_description
-        return pixel_unit_description
+        return self.__unit_descriptions_by_id.get(self.__unit_id_model.value or str(), pixel_unit_description)
 
     @property
     def unit_index(self) -> int:
         """Return the unit index for the current unit description."""
-        return svg_export_unit_descriptions.index(self.unit_description)
+        unit_id = self.unit_description.unit_id
+        for index, unit_description_ in enumerate(svg_export_unit_descriptions):
+            if unit_description_.unit_id == unit_id:
+                return index
+        return 0
 
     @unit_index.setter
     def unit_index(self, unit_index: int) -> None:
@@ -666,6 +689,43 @@ class ExportSizeModel(Observable.Observable):
         self.notify_property_changed("height_text")
         self.notify_property_changed("placeholder_width_text")
         self.notify_property_changed("placeholder_height_text")
+        self.notify_property_changed("is_pixel_unit")
+
+    @property
+    def is_pixel_unit(self) -> bool:
+        """Return whether the currently selected unit is Pixels.
+
+        PPI only affects the pixel output when the unit is a physical unit (inches, centimeters);
+        when the unit is Pixels, an exact pixel count has been specified and PPI has no effect on
+        the output dimensions.
+        """
+        return self.unit_description.unit_id == pixel_unit_description.unit_id
+
+    @property
+    def ppi(self) -> int:
+        """Return the ppi used to convert between physical units (inches, centimeters) and pixels."""
+        return self.__ppi
+
+    def set_ppi(self, ppi: int) -> None:
+        """Set the ppi used to convert between physical units (inches, centimeters) and pixels.
+
+        Rebuilds the ppi-scaled unit descriptions. If the currently selected unit is ppi-dependent
+        (inches or centimeters), the displayed value is preserved (e.g. "4" inches stays "4") while the
+        underlying pixel size changes to match the new ppi. The pixel unit is unaffected by ppi, since a
+        pixel-specified size means an exact pixel count regardless of ppi.
+        """
+        if ppi == self.__ppi:
+            return
+        self.__ppi = ppi
+        self.__unit_descriptions_by_id = make_unit_descriptions_for_ppi(ppi)
+        new_unit_description = self.unit_description
+        self.__width_quantity = self.__width_quantity.with_same_value_new_description(new_unit_description)
+        self.__height_quantity = self.__height_quantity.with_same_value_new_description(new_unit_description)
+        self.notify_property_changed("width_text")
+        self.notify_property_changed("height_text")
+        self.notify_property_changed("placeholder_width_text")
+        self.notify_property_changed("placeholder_height_text")
+        self.notify_property_changed("shape_str")
 
     @property
     def pixel_shape(self) -> Geometry.IntSize:
@@ -724,10 +784,196 @@ class ExportSizeModel(Observable.Observable):
         self.notify_property_changed("height_text")
 
 
-class ExportSVGHandler(Declarative.Handler):
-    def __init__(self, model: ExportSizeModel, get_font_metrics_fn: typing.Callable[[str, str], UserInterface.FontMetrics]) -> None:
+class ExportFormatModel(Observable.Observable):
+    """Holds the export-target state: SVG vs. Bitmap Image, the bitmap file format, and the target ppi.
+
+    This model is intentionally decoupled from ExportSizeModel -- it knows nothing about physical size,
+    units, or aspect ratio. It exposes `effective_ppi`, a fixed 96.0 while exporting SVG (matching
+    today's behavior), or the user's chosen ppi while exporting a bitmap; note this does not yet account
+    for the size unit being Pixels (see ExportDisplayHandler.effective_ppi for the fully-corrected value
+    used for size math, rendering, and export metadata, which also forces 96 in that case). Callers
+    (e.g. ExportDisplayHandler) are responsible for pushing the fully-corrected ppi into
+    `ExportSizeModel.set_ppi(...)` whenever it changes; this model does not do that itself, to avoid any
+    dependency between the two models.
+    """
+
+    # (format id, title, default file extension)
+    bitmap_format_descriptions: typing.Sequence[tuple[str, str, str]] = (
+        ("png", _("PNG"), "png"),
+        ("bmp", _("BMP"), "bmp"),
+        ("jpeg", _("JPEG"), "jpg"),
+    )
+
+    export_categories: typing.Sequence[tuple[str, str]] = (
+        ("svg", _("SVG")),
+        ("bitmap", _("Bitmap Image")),
+    )
+
+    ppi_presets: typing.Sequence[int] = (72, 96, 150, 300, 600)
+
+    def __init__(self, ui: UserInterface.UserInterface) -> None:
+        super().__init__()
+        self.__int_to_string_converter = Converter.IntegerToStringConverter()
+        self.__category_model = UserInterface.StringPersistentModel(ui=ui, storage_key="export_category", value="svg")
+        self.__bitmap_format_model = UserInterface.StringPersistentModel(ui=ui, storage_key="export_bitmap_format", value="png")
+        self.__ppi_model = UserInterface.IntegerPersistentModel(ui=ui, storage_key="export_ppi", value=96)
+        # tracks whether "Custom" is the user's explicit selection in the PPI combo box. This is
+        # distinct from "ppi is not a preset value": choosing "Custom" while ppi already happens to
+        # equal a preset (e.g. the default 96) must still reveal the custom-entry field, even though
+        # the underlying ppi value hasn't changed yet.
+        self.__custom_ppi_selected = self.ppi not in self.ppi_presets
+
+    @property
+    def export_category(self) -> str:
+        return self.__category_model.value or "svg"
+
+    @export_category.setter
+    def export_category(self, value: str) -> None:
+        self.__category_model.value = value
+        self.notify_property_changed("export_category")
+        self.notify_property_changed("export_category_index")
+        self.notify_property_changed("is_svg")
+        self.notify_property_changed("is_bitmap")
+        self.notify_property_changed("effective_ppi")
+        self.notify_property_changed("show_custom_ppi")
+
+    @property
+    def export_category_index(self) -> int:
+        ids = [category_id for category_id, _title in self.export_categories]
+        try:
+            return ids.index(self.export_category)
+        except ValueError:
+            return 0
+
+    @export_category_index.setter
+    def export_category_index(self, index: int) -> None:
+        ids = [category_id for category_id, _title in self.export_categories]
+        self.export_category = ids[index] if 0 <= index < len(ids) else "svg"
+
+    @property
+    def is_svg(self) -> bool:
+        return self.export_category == "svg"
+
+    @property
+    def is_bitmap(self) -> bool:
+        return self.export_category == "bitmap"
+
+    @property
+    def bitmap_format(self) -> str:
+        return self.__bitmap_format_model.value or "png"
+
+    @bitmap_format.setter
+    def bitmap_format(self, value: str) -> None:
+        self.__bitmap_format_model.value = value
+        self.notify_property_changed("bitmap_format")
+        self.notify_property_changed("bitmap_format_index")
+        self.notify_property_changed("bitmap_format_extension")
+
+    @property
+    def bitmap_format_index(self) -> int:
+        ids = [format_id for format_id, _title, _extension in self.bitmap_format_descriptions]
+        try:
+            return ids.index(self.bitmap_format)
+        except ValueError:
+            return 0
+
+    @bitmap_format_index.setter
+    def bitmap_format_index(self, index: int) -> None:
+        ids = [format_id for format_id, _title, _extension in self.bitmap_format_descriptions]
+        self.bitmap_format = ids[index] if 0 <= index < len(ids) else "png"
+
+    @property
+    def bitmap_format_extension(self) -> str:
+        """Return the default file extension (without leading dot) for the current bitmap format."""
+        for format_id, _title, extension in self.bitmap_format_descriptions:
+            if format_id == self.bitmap_format:
+                return extension
+        return "png"
+
+    @property
+    def ppi(self) -> int:
+        return self.__ppi_model.value or 96
+
+    @ppi.setter
+    def ppi(self, value: int) -> None:
+        if value <= 0:
+            return
+        custom_ppi_selected_changed = (value not in self.ppi_presets) != self.__custom_ppi_selected
+        self.__custom_ppi_selected = value not in self.ppi_presets
+        if value == self.ppi:
+            if custom_ppi_selected_changed:
+                self.notify_property_changed("ppi_index")
+                self.notify_property_changed("is_custom_ppi")
+                self.notify_property_changed("show_custom_ppi")
+            return
+        self.__ppi_model.value = value
+        self.notify_property_changed("ppi")
+        self.notify_property_changed("ppi_text")
+        self.notify_property_changed("ppi_index")
+        self.notify_property_changed("is_custom_ppi")
+        self.notify_property_changed("effective_ppi")
+        self.notify_property_changed("show_custom_ppi")
+
+    @property
+    def ppi_text(self) -> str | None:
+        return self.__int_to_string_converter.convert(self.ppi)
+
+    @ppi_text.setter
+    def ppi_text(self, value_str: str | None) -> None:
+        if not value_str:
+            return
+        value = self.__int_to_string_converter.convert_back(value_str)
+        if value is not None and value > 0:
+            self.ppi = value
+
+    @property
+    def ppi_index(self) -> int:
+        """Return the index of the current ppi in the presets list, or the "Custom" index if not a preset."""
+        if self.__custom_ppi_selected:
+            return len(self.ppi_presets)
+        try:
+            return self.ppi_presets.index(self.ppi)
+        except ValueError:
+            return len(self.ppi_presets)
+
+    @ppi_index.setter
+    def ppi_index(self, index: int) -> None:
+        if 0 <= index < len(self.ppi_presets):
+            self.ppi = self.ppi_presets[index]
+        else:
+            # "Custom" selected; the ppi value itself is unchanged (until the user types a new one
+            # into the custom-entry field), but the "custom" state must be recorded explicitly here
+            # since ppi may currently equal a preset value (e.g. the default 96) -- the custom entry
+            # field still needs to be revealed in that case.
+            self.__custom_ppi_selected = True
+            self.notify_property_changed("ppi_index")
+            self.notify_property_changed("is_custom_ppi")
+            self.notify_property_changed("show_custom_ppi")
+
+    @property
+    def is_custom_ppi(self) -> bool:
+        return self.__custom_ppi_selected
+
+    @property
+    def show_custom_ppi(self) -> bool:
+        """Return whether the custom-ppi text entry should be shown (bitmap mode and a non-preset ppi)."""
+        return self.is_bitmap and self.is_custom_ppi
+
+    @property
+    def effective_ppi(self) -> int:
+        """Return the ppi that should currently be used for size math.
+
+        Fixed at 96.0 while exporting SVG (matches today's fixed-96 SVG behavior); the user's chosen
+        ppi while exporting a Bitmap Image.
+        """
+        return 96 if self.is_svg else self.ppi
+
+
+class ExportDisplayHandler(Declarative.Handler):
+    def __init__(self, model: ExportSizeModel, format_model: ExportFormatModel, get_font_metrics_fn: typing.Callable[[str, str], UserInterface.FontMetrics]) -> None:
         super().__init__()
         self.model = model
+        self.format_model = format_model
         u = Declarative.DeclarativeUI()
         left_column_width = get_font_metrics_fn("normal", "Shape (calibrated units)").width + 20
 
@@ -740,7 +986,32 @@ class ExportSVGHandler(Declarative.Handler):
         unit_titles = [unit_description.title for unit_description in svg_export_unit_descriptions]
         unit_combo_box_width = max(get_font_metrics_fn("normal", s).width for s in unit_titles) + 72
 
+        export_category_titles = [title for _category_id, title in ExportFormatModel.export_categories]
+        bitmap_format_titles = [title for _format_id, title, _extension in ExportFormatModel.bitmap_format_descriptions]
+        ppi_combo_titles = [str(int(ppi)) for ppi in ExportFormatModel.ppi_presets] + [_("Custom")]
+
         self.ui_view = u.create_column(
+            u.create_row(
+                u.create_label(text=_("Export As"), width=left_column_width),
+                u.create_combo_box(
+                    items=export_category_titles,
+                    current_index="@binding(format_model.export_category_index)",
+                    width=140
+                ),
+                u.create_stretch(),
+                spacing=8
+            ),
+            u.create_row(
+                u.create_label(text=_("File Format"), width=left_column_width),
+                u.create_combo_box(
+                    items=bitmap_format_titles,
+                    current_index="@binding(format_model.bitmap_format_index)",
+                    enabled="@binding(format_model.is_bitmap)",
+                    width=140
+                ),
+                u.create_stretch(),
+                spacing=8
+            ),
             u.create_row(
                 u.create_label(text="Title", width=left_column_width),
                 u.create_label(text="@binding(model.title)", width=right_column_width),
@@ -802,9 +1073,92 @@ class ExportSVGHandler(Declarative.Handler):
                 u.create_stretch(),
                 spacing=8
             ),
+            u.create_row(
+                u.create_label(text=_("PPI"), width=left_column_width),
+                u.create_combo_box(
+                    items=ppi_combo_titles,
+                    current_index="@binding(format_model.ppi_index)",
+                    enabled="@binding(show_ppi_controls)",
+                    width=140
+                ),
+                u.create_stretch(),
+                spacing=8
+            ),
+            u.create_row(
+                u.create_label(text=_("Custom PPI"), width=left_column_width),
+                u.create_line_edit(
+                    text="@binding(format_model.ppi_text)",
+                    enabled="@binding(show_custom_ppi_controls)",
+                    width=100
+                ),
+                u.create_stretch(),
+                spacing=8
+            ),
             spacing=8,
             margin=12,
         )
+
+        # keep the size model's ppi synced with effective_ppi (96 for SVG or when the size unit is
+        # Pixels, the user's chosen ppi otherwise). this is the only coupling between the two models.
+        self.__apply_effective_ppi()
+        self.__format_property_changed_listener = format_model.property_changed_event.listen(self.__handle_format_property_changed)
+        # the PPI controls are only meaningful (and only shown) when exporting a bitmap AND the size
+        # unit is a physical unit (inches/centimeters); when the unit is Pixels, an exact pixel count
+        # has been specified and PPI has no effect on the output dimensions, so hide it to avoid the
+        # appearance of a dead control.
+        self.__model_property_changed_listener = model.property_changed_event.listen(self.__handle_model_property_changed)
+
+    def close(self) -> None:
+        self.__model_property_changed_listener.close()
+        self.__model_property_changed_listener = typing.cast(typing.Any, None)
+        self.__format_property_changed_listener.close()
+        self.__format_property_changed_listener = typing.cast(typing.Any, None)
+        super().close()
+
+    def __handle_format_property_changed(self, property_name: str) -> None:
+        if property_name in ("export_category", "ppi", "effective_ppi"):
+            self.__apply_effective_ppi()
+        if property_name in ("export_category", "is_bitmap", "ppi", "is_custom_ppi"):
+            self.notify_property_changed("show_ppi_controls")
+            self.notify_property_changed("show_custom_ppi_controls")
+
+    def __handle_model_property_changed(self, property_name: str) -> None:
+        if property_name == "is_pixel_unit":
+            self.__apply_effective_ppi()
+            self.notify_property_changed("show_ppi_controls")
+            self.notify_property_changed("show_custom_ppi_controls")
+
+    def __apply_effective_ppi(self) -> None:
+        self.model.set_ppi(self.effective_ppi)
+
+    @property
+    def effective_ppi(self) -> int:
+        """Return the ppi that should currently be used for size math, rendering, and export metadata.
+
+        Fixed at 96 while exporting SVG, or while exporting a Bitmap Image with the size unit set to
+        Pixels (an exact pixel count has been specified, so there is no physical size for ppi to apply
+        to -- using the user's last-chosen physical-unit ppi here would silently bake a stale, unrelated
+        ppi into font/line rendering and the exported file's DPI metadata). Otherwise, the user's chosen
+        ppi.
+        """
+        if self.format_model.is_svg or self.model.is_pixel_unit:
+            return 96
+        return self.format_model.ppi
+
+    @property
+    def show_ppi_controls(self) -> bool:
+        """Return whether the PPI preset combo box should be shown.
+
+        PPI only has a visible effect when exporting a bitmap with a physical (inches/centimeters)
+        size unit; when the unit is Pixels, an exact pixel count has already been specified and PPI
+        would have no effect on the output dimensions, so the control is hidden in that case.
+        """
+        return self.format_model.is_bitmap and not self.model.is_pixel_unit
+
+    @property
+    def show_custom_ppi_controls(self) -> bool:
+        """Return whether the custom-ppi text entry should be shown."""
+        return self.show_ppi_controls and self.format_model.is_custom_ppi
 
     def on_aspect_ratio_changed(self, widget: Declarative.UIWidget, current_index: int) -> None:
         modes = ["default", "16:9", "4:3", "1:1", "custom"]
@@ -816,7 +1170,7 @@ class ExportSVGHandler(Declarative.Handler):
             self.model.snap_dimensions_to_aspect_ratio()
 
 
-class ExportSVGDialog:
+class ExportDisplayDialog:
     def __init__(self, document_controller: DocumentController.DocumentController,
                  display_item: DisplayItem.DisplayItem) -> None:
         super().__init__()
@@ -827,8 +1181,9 @@ class ExportSVGDialog:
             storage_key="export_units",
             value=pixel_unit_description.unit_id
         )
-        self.__model = ExportSizeModel(display_item, self.__units_model)
-        self.__handler = ExportSVGHandler(self.__model, document_controller.ui.get_font_metrics)
+        self.__format_model = ExportFormatModel(document_controller.ui)
+        self.__model = ExportSizeModel(display_item, self.__units_model, self.__format_model.effective_ppi)
+        self.__handler = ExportDisplayHandler(self.__model, self.__format_model, document_controller.ui.get_font_metrics)
         self.__init_ui()
 
     def __init_ui(self) -> None:
@@ -837,7 +1192,7 @@ class ExportSVGDialog:
             self.__document_controller.ui,
             self.__document_controller,
             u.create_modeless_dialog(
-                self.__handler.ui_view, title=_("Export SVG")
+                self.__handler.ui_view, title=_("Export SVG/Bitmap")
             ),
             self.__handler
         ))
@@ -848,22 +1203,38 @@ class ExportSVGDialog:
     def __ok_clicked(self) -> bool:
         pixel_shape = self.__model.pixel_shape
         ui = self.__document_controller.ui
-        filter = "SVG File (*.svg);;All Files (*.*)"
+        if self.__format_model.is_bitmap:
+            extension = self.__format_model.bitmap_format_extension
+            format_title = dict((format_id, title) for format_id, title, _extension in ExportFormatModel.bitmap_format_descriptions)[self.__format_model.bitmap_format]
+            filter = f"{format_title} File (*.{extension});;All Files (*.*)"
+        else:
+            extension = "svg"
+            filter = "SVG File (*.svg);;All Files (*.*)"
         export_dir = ui.get_persistent_string("export_directory", ui.get_document_location())
         export_dir = os.path.join(export_dir, self.__display_item.displayed_title)
         path, selected_filter, selected_directory = self.__document_controller.get_save_file_path(
             _("Export File"), export_dir, filter, None
         )
         if path and not os.path.splitext(path)[1]:
-            path = path + os.path.extsep + "svg"
+            path = path + os.path.extsep + extension
         if path:
             ui.set_persistent_string("export_directory", selected_directory)
-            self.__document_controller.export_svg_file(
-                DisplayPanel.DisplayPanelUISettings(ui),
-                self.__display_item,
-                pixel_shape,
-                pathlib.Path(path)
-            )
+            if self.__format_model.is_bitmap:
+                self.__document_controller.export_bitmap_file(
+                    DisplayPanel.DisplayPanelUISettings(ui),
+                    self.__display_item,
+                    pixel_shape,
+                    self.__handler.effective_ppi,
+                    pathlib.Path(path),
+                    extension
+                )
+            else:
+                self.__document_controller.export_svg_file(
+                    DisplayPanel.DisplayPanelUISettings(ui),
+                    self.__display_item,
+                    pixel_shape,
+                    pathlib.Path(path)
+                )
         return True
 
     def __cancel_clicked(self) -> bool:

--- a/nion/swift/model/UISettings.py
+++ b/nion/swift/model/UISettings.py
@@ -46,15 +46,21 @@ class DisplayStyle:
         "graphic-label": 9,
     }
 
-    def __init__(self) -> None:
+    def __init__(self, standard_font_pt: float | None = None) -> None:
+        self.__font_scaling = standard_font_pt / 9 if standard_font_pt else None
         self.__font_sizes_pt = dict(self._FONT_SIZES_PT)
 
     def get_font_size_pt(self, part: str) -> float:
         return self.__font_sizes_pt.get(part, 9)
 
     def get_font(self, part: str, drawing_metrics: DrawingMetrics) -> str:
-        """Get the complete font string for a display style part."""
-        size_pt = self.get_font_size_pt(part) * drawing_metrics.scale * 96.0 / drawing_metrics.device_dpi
+        """Get the complete font string for a display style part.
+
+        If standard_font_pt is provided, font is scaled by standard_font_pt / 9pt. Used during bitmap rendering.
+        Otherwise, font is scaled by drawing_metrics.scale, which is PPI / 96.0. Used during screen rendering.
+        """
+        font_scaling = self.__font_scaling if self.__font_scaling else drawing_metrics.scale
+        size_pt = self.get_font_size_pt(part) * font_scaling * 96.0 / drawing_metrics.device_dpi
         scaled_size_str = f"{size_pt:.2f}".rstrip("0").rstrip(".")
         return f"normal {scaled_size_str}pt Helvetica, Arial, sans-serif"
 

--- a/nion/swift/resources/menu_config.json
+++ b/nion/swift/resources/menu_config.json
@@ -53,7 +53,7 @@
             },
             {
                 "type": "item",
-                "action_id": "file.export_svg"
+                "action_id": "file.export_display"
             },
             {
                 "type": "separator"

--- a/nion/swift/test/DocumentController_test.py
+++ b/nion/swift/test/DocumentController_test.py
@@ -2,12 +2,15 @@
 import contextlib
 import gc
 import logging
+import pathlib
+import tempfile
 import typing
 import unittest
 import uuid
 import weakref
 
 # third party libraries
+import imageio.v3 as imageio
 import numpy
 
 # local libraries
@@ -1234,6 +1237,51 @@ class TestDocumentControllerClass(unittest.TestCase):
                 document_model.append_data_item(data_item)
                 data_item_reference.data_item = data_item
                 document_controller.periodic()
+
+
+class TestExportBitmapFile(unittest.TestCase):
+    """Tests for DocumentController.export_bitmap_file's imageio-based writers (PNG/JPEG) and its
+    fallback to UserInterface.save_rgba_data_to_file for other formats (e.g. BMP)."""
+
+    def setUp(self) -> None:
+        TestContext.begin_leaks()
+        self._test_setup = TestContext.TestSetup()
+
+    def tearDown(self) -> None:
+        self._test_setup = typing.cast(typing.Any, None)
+        TestContext.end_leaks(self)
+
+    def _make_display_item(self, document_controller: DocumentController.DocumentController) -> DisplayItem.DisplayItem:
+        document_model = document_controller.document_model
+        data_item = DataItem.DataItem(numpy.random.rand(8, 8).astype(numpy.float32))
+        document_model.append_data_item(data_item)
+        display_item = document_model.get_display_item_for_data_item(data_item)
+        assert display_item
+        return display_item
+
+    def test_bitmap_export_embeds_target_dpi_for_each_format(self) -> None:
+        """PNG and JPEG are both written via imageio, and both embed the target ppi as DPI metadata
+        that imageio itself can read back -- so no extra reader library (e.g. PIL) is needed to verify
+        the metadata; imageio.v3 alone (already a project dependency) is enough."""
+        cases = (("png", "png", 300, 4), ("jpg", "jpg", 150, 3))
+        for extension, image_format, ppi, expected_channel_count in cases:
+            with self.subTest(image_format=image_format):
+                with TestContext.create_memory_context() as test_context:
+                    document_controller = test_context.create_document_controller()
+                    display_item = self._make_display_item(document_controller)
+                    with tempfile.TemporaryDirectory() as tmp_dir:
+                        path = pathlib.Path(tmp_dir) / f"test.{extension}"
+                        document_controller.export_bitmap_file(
+                            DisplayPanel.DisplayPanelUISettings(document_controller.ui),
+                            display_item, Geometry.IntSize(w=16, h=16), ppi, path, image_format)
+                        self.assertTrue(path.exists())
+                        image_data = imageio.imread(path)
+                        self.assertEqual(expected_channel_count, image_data.shape[-1])  # jpeg has no alpha channel
+                        metadata = imageio.immeta(path)
+                        resolution_x, resolution_y = metadata["dpi"]
+                        self.assertAlmostEqual(resolution_x, ppi, delta=0.1)
+                        self.assertAlmostEqual(resolution_y, ppi, delta=0.1)
+
 
 
 if __name__ == '__main__':

--- a/nion/swift/test/ExportDialog_test.py
+++ b/nion/swift/test/ExportDialog_test.py
@@ -10,6 +10,7 @@ from nion.swift import ExportDialog
 from nion.swift.model import DataItem
 from nion.swift.model import ImportExportManager
 from nion.swift.test import TestContext
+from nion.ui import TestUI
 from nion.utils import Model
 
 
@@ -155,29 +156,21 @@ class TestExportSizeModel(unittest.TestCase):
             ar = expected_px_size.width / expected_px_size.height
             self.assertAlmostEqual(ar, 5.0 / 3.0, places=6)
 
-    def test_locked_edit_width_updates_height(self):
-        """With lock on and primary field width, H = W / AR."""
+    def test_locked_edit_updates_opposite_dimension(self):
+        """With lock on, editing either primary field recomputes the other via the aspect ratio."""
         with TestContext.create_memory_context() as test_context:
             model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
             model.aspect_ratio_locked.value = True
             base_px = ExportDialog.calculate_display_size_in_pixels(display_item)
             ar = base_px.width / base_px.height
-            model.width_text = "960"
-            expected_h = round(960 / ar)
-            self.assertEqual(model.pixel_shape.width, 960)
-            self.assertEqual(model.pixel_shape.height, expected_h)
-
-    def test_locked_edit_height_updates_width(self):
-        """With lock on and primary field height, W = H * AR."""
-        with TestContext.create_memory_context() as test_context:
-            model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
-            model.aspect_ratio_locked.value = True
-            base_px = ExportDialog.calculate_display_size_in_pixels(display_item)
-            ar = base_px.width / base_px.height
-            model.height_text = "600"
-            expected_w = round(600 * ar)
-            self.assertEqual(model.pixel_shape.height, 600)
-            self.assertEqual(model.pixel_shape.width, expected_w)
+            with self.subTest(primary="width"):
+                model.width_text = "960"
+                self.assertEqual(model.pixel_shape.width, 960)
+                self.assertEqual(model.pixel_shape.height, round(960 / ar))
+            with self.subTest(primary="height"):
+                model.height_text = "600"
+                self.assertEqual(model.pixel_shape.height, 600)
+                self.assertEqual(model.pixel_shape.width, round(600 * ar))
 
     def test_unlock_breaks_link_between_width_and_height(self):
         """With lock off, editing width does not change height """
@@ -252,43 +245,36 @@ class TestExportSizeModel(unittest.TestCase):
             self.assertAlmostEqual(float(model.placeholder_width_text), expected_w_cm, places=6)
             self.assertAlmostEqual(float(model.placeholder_height_text), expected_h_cm, places=6)
 
-    def test_relock_snaps_to_aspect_ratio_using_width_as_primary(self):
-        """When unlocked and user last edits WIDTH, re-lock snaps H = W / AR."""
-        with TestContext.create_memory_context() as test_context:
-            model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
-            base_px = ExportDialog.calculate_display_size_in_pixels(display_item)
-            ar = base_px.width / base_px.height
-            model.aspect_ratio_locked.value = False
-            model.width_text = "700"  # non-AR
-            # Currently not at aspect ratio
-            self.assertEqual(model.pixel_shape.width, 700)
-            self.assertNotEqual(round(model.pixel_shape.width / ar), model.pixel_shape.height)
-            # Simulate checkbox
-            model.aspect_ratio_locked.value = True
-            model.snap_dimensions_to_aspect_ratio()
-            # Expect height snapped to W/AR while width preserved
-            expected_h = round(700 / ar)
-            self.assertEqual(model.pixel_shape.width, 700)
-            self.assertEqual(model.pixel_shape.height, expected_h)
+    def test_relock_snaps_to_aspect_ratio_using_last_edited_field_as_primary(self):
+        """When unlocked and the user last edits a field, re-locking snaps the *other* field to match
+        the aspect ratio, whichever field (width or height) was edited last."""
+        for primary in ("width", "height"):
+            with self.subTest(primary=primary):
+                with TestContext.create_memory_context() as test_context:
+                    model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
+                    base_px = ExportDialog.calculate_display_size_in_pixels(display_item)
+                    ar = base_px.width / base_px.height
+                    model.aspect_ratio_locked.value = False
+                    if primary == "width":
+                        model.width_text = "700"  # non-AR
+                        self.assertEqual(model.pixel_shape.width, 700)
+                        self.assertNotEqual(round(model.pixel_shape.width / ar), model.pixel_shape.height)
+                    else:
+                        model.height_text = "350"  # non-AR
+                        self.assertEqual(model.pixel_shape.height, 350)
+                        self.assertNotEqual(round(350 * ar), model.pixel_shape.width)
+                    # Simulate checkbox
+                    model.aspect_ratio_locked.value = True
+                    model.snap_dimensions_to_aspect_ratio()
+                    if primary == "width":
+                        # Expect height snapped to W/AR while width preserved
+                        self.assertEqual(model.pixel_shape.width, 700)
+                        self.assertEqual(model.pixel_shape.height, round(700 / ar))
+                    else:
+                        # Expect width snapped to H*AR while height preserved
+                        self.assertEqual(model.pixel_shape.height, 350)
+                        self.assertEqual(model.pixel_shape.width, round(350 * ar))
 
-    def test_relock_snaps_to_aspect_ratio_using_height_as_primary(self):
-        """When unlocked and user last edits HEIGHT, re-lock snaps W = H * AR."""
-        with TestContext.create_memory_context() as test_context:
-            model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
-            base_px = ExportDialog.calculate_display_size_in_pixels(display_item)
-            ar = base_px.width / base_px.height
-            model.aspect_ratio_locked.value = False
-            model.height_text = "350"  # non-AR
-            # Currently not at aspect ratio
-            self.assertEqual(model.pixel_shape.height, 350)
-            self.assertNotEqual(round(350 * ar), model.pixel_shape.width)
-            # Simulate checkbox
-            model.aspect_ratio_locked.value = True
-            model.snap_dimensions_to_aspect_ratio()
-            # Expect width snapped to H*AR while height preserved
-            expected_w = round(350 * ar)
-            self.assertEqual(model.pixel_shape.height, 350)
-            self.assertEqual(model.pixel_shape.width, expected_w)
 
     def test_aspect_ratio_locked_focus_change_does_not_zero_dimensions(self):
         with TestContext.create_memory_context() as test_context:
@@ -321,6 +307,283 @@ class TestExportSizeModel(unittest.TestCase):
             self.assertEqual(updated_shape.width, 300)
             self.assertGreater(updated_shape.height, 0)
             self.assertEqual(updated_shape.height, round(300 * 9 / 16))
+
+    def test_set_ppi_does_not_affect_pixel_unit(self):
+        """A size specified in Pixels must be unaffected by ppi changes."""
+        with TestContext.create_memory_context() as test_context:
+            model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
+            model.width_text = "800"
+            model.aspect_ratio_locked.value = False
+            model.height_text = "600"
+            before_shape = model.pixel_shape
+            before_width_text = model.width_text
+            model.set_ppi(300)
+            self.assertEqual(model.pixel_shape.width, before_shape.width)
+            self.assertEqual(model.pixel_shape.height, before_shape.height)
+            self.assertEqual(model.width_text, before_width_text)
+
+    def test_set_ppi_scales_physical_units_pixel_shape_and_preserves_displayed_value(self):
+        """Changing ppi while unit is Inches or Centimeters scales pixel_shape by the unit's ppi-based
+        conversion factor, while the displayed value (in that physical unit) stays unchanged."""
+        cases = (
+            (ExportDialog.inch_unit_description, 4, 3, 96.0, 300.0),
+            (ExportDialog.centimeter_unit_description, 10, 5, 96.0 / 2.54, 300.0 / 2.54),
+        )
+        for unit_description, width, height, factor_before, factor_after in cases:
+            with self.subTest(unit=unit_description.unit_id):
+                with TestContext.create_memory_context() as test_context:
+                    model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
+                    model.unit_index = self._get_unit_index(unit_description)
+                    model.aspect_ratio_locked.value = False
+                    model.width_text = str(width)
+                    model.height_text = str(height)
+                    self.assertEqual(model.pixel_shape.width, round(width * factor_before))
+                    self.assertEqual(model.pixel_shape.height, round(height * factor_before))
+                    model.set_ppi(300)
+                    self.assertEqual(model.width_text, str(width))
+                    self.assertEqual(model.height_text, str(height))
+                    self.assertEqual(model.pixel_shape.width, round(width * factor_after))
+                    self.assertEqual(model.pixel_shape.height, round(height * factor_after))
+
+    def test_unit_switch_after_ppi_change_round_trips(self):
+        """Switching units after a ppi change should still round-trip pixel_shape correctly."""
+        with TestContext.create_memory_context() as test_context:
+            model, display_item, _ = self._make_line_plot_model(test_context, unit_id="pixels")
+            model.aspect_ratio_locked.value = True
+            model.set_ppi(300)
+            base_px = model.pixel_shape
+            model.unit_index = self._get_unit_index(ExportDialog.inch_unit_description)
+            self.assertEqual(model.pixel_shape.width, base_px.width)
+            self.assertEqual(model.pixel_shape.height, base_px.height)
+            model.unit_index = self._get_unit_index(ExportDialog.centimeter_unit_description)
+            self.assertEqual(model.pixel_shape.width, base_px.width)
+            self.assertEqual(model.pixel_shape.height, base_px.height)
+            model.unit_index = self._get_unit_index(ExportDialog.pixel_unit_description)
+            self.assertEqual(model.pixel_shape.width, base_px.width)
+            self.assertEqual(model.pixel_shape.height, base_px.height)
+
+
+class TestExportFormatModel(unittest.TestCase):
+    """Unit tests for ExportFormatModel, isolated from ExportSizeModel."""
+
+    class _PersistingUserInterface(TestUI.UserInterface):
+        """A TestUI.UserInterface whose persistent-string storage actually persists.
+
+        TestUI's built-in get/set_persistent_string are no-ops (by design, for test isolation), so
+        this subclass backs them with an in-memory dict to exercise the persistence round-trip
+        behavior of UserInterface.StringPersistentModel/FloatPersistentModel.
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.__persisted: dict[str, str] = {}
+
+        def get_persistent_string(self, key: str, default_value: str | None = None) -> str:
+            return self.__persisted.get(key, super().get_persistent_string(key, default_value))
+
+        def set_persistent_string(self, key: str, value: str) -> None:
+            self.__persisted[key] = value
+
+    def _make_persisting_ui(self) -> TestUI.UserInterface:
+        return TestExportFormatModel._PersistingUserInterface()
+
+    def test_defaults(self) -> None:
+        ui = TestUI.UserInterface()
+        model = ExportDialog.ExportFormatModel(ui)
+        self.assertEqual(model.export_category, "svg")
+        self.assertTrue(model.is_svg)
+        self.assertFalse(model.is_bitmap)
+        self.assertEqual(model.bitmap_format, "png")
+        self.assertEqual(model.ppi, 96)
+        self.assertEqual(model.effective_ppi, 96)
+
+    def test_switching_category_persists_and_round_trips(self) -> None:
+        ui = self._make_persisting_ui()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.export_category = "bitmap"
+        self.assertTrue(model.is_bitmap)
+        self.assertFalse(model.is_svg)
+        # a new model instance backed by the same (persisting) ui should see the persisted value
+        model2 = ExportDialog.ExportFormatModel(ui)
+        self.assertEqual(model2.export_category, "bitmap")
+
+    def test_switching_bitmap_format_persists(self) -> None:
+        ui = self._make_persisting_ui()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.bitmap_format = "jpeg"
+        self.assertEqual(model.bitmap_format, "jpeg")
+        self.assertEqual(model.bitmap_format_extension, "jpg")
+        model2 = ExportDialog.ExportFormatModel(ui)
+        self.assertEqual(model2.bitmap_format, "jpeg")
+
+    def test_ppi_preset_selection(self) -> None:
+        ui = TestUI.UserInterface()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.ppi_index = ExportDialog.ExportFormatModel.ppi_presets.index(300)
+        self.assertEqual(model.ppi, 300)
+        self.assertFalse(model.is_custom_ppi)
+        self.assertEqual(model.ppi_text, "300")
+
+    def test_ppi_custom_freeform_entry(self) -> None:
+        ui = TestUI.UserInterface()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.ppi_text = "133"
+        self.assertEqual(model.ppi, 133)
+        self.assertTrue(model.is_custom_ppi)
+        self.assertEqual(model.ppi_index, len(ExportDialog.ExportFormatModel.ppi_presets))
+
+    def test_custom_ppi_index_selection_round_trips_with_presets(self) -> None:
+        """Regression test: selecting "Custom" in the PPI combo box must reveal the custom-entry
+        field even when the current ppi value (e.g. the default 96) already equals a preset -- the
+        underlying ppi value doesn't change just by selecting "Custom", only by then typing into the
+        custom field, so is_custom_ppi must not be derived purely from "ppi not in presets". Re-selecting
+        a preset afterward must clear that custom state again."""
+        ui = TestUI.UserInterface()
+        model = ExportDialog.ExportFormatModel(ui)
+        self.assertEqual(model.ppi, 96)  # default, a preset value
+        self.assertFalse(model.is_custom_ppi)
+        model.ppi_index = len(ExportDialog.ExportFormatModel.ppi_presets)  # select "Custom"
+        self.assertTrue(model.is_custom_ppi)
+        self.assertEqual(model.ppi, 96)  # unchanged until the user types a new value
+        self.assertEqual(model.ppi_index, len(ExportDialog.ExportFormatModel.ppi_presets))
+        # re-select the preset that already matches the current (unchanged) ppi value
+        model.ppi_index = ExportDialog.ExportFormatModel.ppi_presets.index(96)
+        self.assertFalse(model.is_custom_ppi)
+        self.assertEqual(model.ppi_index, ExportDialog.ExportFormatModel.ppi_presets.index(96))
+
+    def test_ppi_persists_across_model_instances(self) -> None:
+        ui = self._make_persisting_ui()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.ppi = 150
+        model2 = ExportDialog.ExportFormatModel(ui)
+        self.assertEqual(model2.ppi, 150)
+
+    def test_effective_ppi_is_fixed_96_for_svg_and_follows_ppi_for_bitmap(self) -> None:
+        ui = TestUI.UserInterface()
+        model = ExportDialog.ExportFormatModel(ui)
+        model.ppi = 300
+        self.assertEqual(model.export_category, "svg")
+        self.assertEqual(model.effective_ppi, 96)
+        model.export_category = "bitmap"
+        self.assertEqual(model.effective_ppi, 300)
+
+
+class TestExportDisplayHandler(unittest.TestCase):
+    """Tests for the ppi-sync glue wiring between ExportFormatModel and ExportSizeModel."""
+
+    def setUp(self) -> None:
+        TestContext.begin_leaks()
+        self._test_setup = TestContext.TestSetup()
+
+    def tearDown(self) -> None:
+        self._test_setup = typing.cast(typing.Any, None)
+        TestContext.end_leaks(self)
+
+    def _make_handler(self, initial_size_model_ppi: int | None = None) -> tuple[ExportDialog.ExportFormatModel, ExportDialog.ExportSizeModel, ExportDialog.ExportDisplayHandler]:
+        with TestContext.create_memory_context() as test_context:
+            document_controller = test_context.create_document_controller()
+            document_model = document_controller.document_model
+            data_item = DataItem.DataItem(numpy.zeros((8, 8), numpy.float32))
+            document_model.append_data_item(data_item)
+            display_item = document_model.get_display_item_for_data_item(data_item)
+            ui = TestUI.UserInterface()
+            format_model = ExportDialog.ExportFormatModel(ui)
+            units_model = Model.PropertyModel(ExportDialog.pixel_unit_description.unit_id)
+            if initial_size_model_ppi is None:
+                initial_size_model_ppi = format_model.effective_ppi
+            size_model = ExportDialog.ExportSizeModel(display_item, units_model, initial_size_model_ppi)
+            handler = ExportDialog.ExportDisplayHandler(size_model, format_model, ui.get_font_metrics)
+            return format_model, size_model, handler
+
+    def test_size_model_ppi_starts_synced_at_construction(self) -> None:
+        # construct size_model with a ppi that deliberately mismatches format_model.effective_ppi (96),
+        # so this test actually proves the handler applies effective_ppi during __init__, rather than
+        # merely observing a value the test itself supplied to the constructor.
+        format_model, size_model, handler = self._make_handler(initial_size_model_ppi=300)
+        self.assertEqual(size_model.ppi, 96)
+        handler.close()
+
+    def test_size_model_ppi_follows_format_model_ppi_when_bitmap(self) -> None:
+        format_model, size_model, handler = self._make_handler()
+        size_model.unit_index = 1  # inches; ppi only has an effect for physical units
+        format_model.export_category = "bitmap"
+        self.assertEqual(size_model.ppi, 96)  # default bitmap ppi is 96
+        format_model.ppi = 300
+        self.assertEqual(size_model.ppi, 300)
+        handler.close()
+
+    def test_size_model_ppi_reverts_to_96_when_switched_back_to_svg(self) -> None:
+        format_model, size_model, handler = self._make_handler()
+        size_model.unit_index = 1  # inches; ppi only has an effect for physical units
+        format_model.export_category = "bitmap"
+        format_model.ppi = 300
+        self.assertEqual(size_model.ppi, 300)
+        format_model.export_category = "svg"
+        self.assertEqual(size_model.ppi, 96)
+        handler.close()
+
+    def test_size_model_ppi_stays_96_for_bitmap_with_pixel_unit(self) -> None:
+        """Regression test: effective_ppi must stay fixed at 96 while the size unit is Pixels, even if
+        the user previously chose a non-96 ppi while a physical unit was selected -- otherwise a stale
+        ppi would silently affect font/line rendering and get embedded as misleading DPI metadata for a
+        pixel-exact export where no physical size was specified."""
+        format_model, size_model, handler = self._make_handler()
+        format_model.export_category = "bitmap"
+        format_model.ppi = 300
+        self.assertTrue(size_model.is_pixel_unit)
+        self.assertEqual(size_model.ppi, 96)
+        self.assertEqual(handler.effective_ppi, 96)
+        handler.close()
+
+    def test_closing_handler_stops_sync(self) -> None:
+        format_model, size_model, handler = self._make_handler()
+        handler.close()
+        format_model.export_category = "bitmap"
+        format_model.ppi = 300
+        # no more listener attached, so size_model should remain at its last-applied value (96.0)
+        self.assertEqual(size_model.ppi, 96)
+
+    def test_ppi_controls_visibility_transitions(self) -> None:
+        """The PPI controls should only be shown when exporting a bitmap with a physical (non-pixel)
+        size unit -- PPI has no effect on the output when the unit is Pixels (an exact pixel count has
+        already been specified), so the controls stay hidden in that case, and always hidden for SVG.
+        """
+        format_model, size_model, handler = self._make_handler()
+        self.assertFalse(handler.show_ppi_controls)  # svg
+        format_model.export_category = "bitmap"
+        self.assertTrue(size_model.is_pixel_unit)
+        self.assertFalse(handler.show_ppi_controls)  # bitmap, but pixels
+        size_model.unit_index = 1  # switch to inches
+        self.assertTrue(handler.show_ppi_controls)  # bitmap, physical unit
+        size_model.unit_index = 0  # switch back to pixels
+        self.assertFalse(handler.show_ppi_controls)
+        handler.close()
+
+    def test_custom_ppi_controls_hide_when_pixel_unit_overrides_custom_ppi(self) -> None:
+        """show_custom_ppi_controls must respect show_ppi_controls even when is_custom_ppi is True --
+        e.g. a custom (non-preset) ppi is set while the unit is Pixels, where ppi controls are hidden."""
+        format_model, size_model, handler = self._make_handler()
+        size_model.unit_index = 1  # inches
+        format_model.export_category = "bitmap"
+        format_model.ppi = 133  # not a preset
+        self.assertTrue(handler.show_custom_ppi_controls)
+        size_model.unit_index = 0  # switch to pixels; custom ppi controls should hide regardless
+        self.assertFalse(handler.show_custom_ppi_controls)
+        handler.close()
+
+    def test_custom_ppi_controls_enable_via_combo_selection_even_at_default_preset_ppi(self) -> None:
+        """Regression test for the reported bug: choosing "Custom" from the PPI combo box must
+        enable the custom-entry field immediately, even before the user types a new value (i.e. while
+        ppi still equals a preset like the default 96)."""
+        format_model, size_model, handler = self._make_handler()
+        size_model.unit_index = 1  # inches
+        format_model.export_category = "bitmap"
+        self.assertFalse(handler.show_custom_ppi_controls)
+        format_model.ppi_index = len(format_model.ppi_presets)  # select "Custom" in the combo box
+        self.assertTrue(handler.show_custom_ppi_controls)
+        handler.close()
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1852

- **Add export_bitmap_file function; allow font-size override.**
- **Change SVG export dialog to support bitmap exports w/ PPI.**

AI assisted (dialog).

This is a step to update the existing dialog; follow-ups will consolidate the various export workflows, make exporting modeless (and threaded), etc.

Note: the font size is fixed at 1/6 PPI in this version. PPI for SVG is 96.

The menu item is renamed from Export SVG... to Export SVG/Bitmap... in this PR.

<img width="444" height="485" alt="image" src="https://github.com/user-attachments/assets/e83e7ddb-7d51-4c24-ba1a-54b2a2621f21" />
