### PR TITLE
Lazily construct display panel browsers and fix related focus/persistence bugs

### DIFF
--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2140,55 +2140,40 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                     return True
                 return True
 
-        display_items_model = document_controller.filtered_display_items_model
+        self.__filtered_display_items_model = document_controller.filtered_display_items_model
 
-        item_delegate = ItemDelegate(self, self.__selection, document_controller.ui)
+        # item_delegate only holds a weak reference back to this display panel (via ItemDelegate.__display_panel_ref),
+        # so it is safe to store as an instance attribute for later (lazy) use.
+        self.__item_delegate = ItemDelegate(self, self.__selection, document_controller.ui)
 
+        # these factories only capture document_controller (not self), so they are also safe to store as instance
+        # attributes for later (lazy) use.
         def strip_thumbnail_item_factory(item: typing.Any, is_selected_model: Model.PropertyModel[bool]) -> CanvasItem.AbstractCanvasItem:
             return DataPanel.DataPanelGridItem(typing.cast(DisplayItem.DisplayItem, item), document_controller.ui, DataPanel.DataPanelUISettings(document_controller.ui), draw_label=False)
-
-        strip_canvas_item = DisplayPanelListCanvasItem(Panel.ThreadSafeListModel(display_items_model, document_controller.event_loop), self.__selection, strip_thumbnail_item_factory, item_delegate, item_width=80, key="display_items", is_shared_selection=True)
-        strip_canvas_item.on_focus_changed = ReferenceCounting.weak_partial(DisplayPanel.set_focused, self)
-
-        strip_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(strip_canvas_item)
-        strip_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(strip_scroll_area_canvas_item, CanvasItem.Orientation.Horizontal)
-        strip_scroll_group_canvas_item = CanvasItem.CanvasItemComposition()
-        strip_scroll_group_canvas_item.layout = CanvasItem.CanvasItemColumnLayout()
-        strip_scroll_group_canvas_item.add_canvas_item(strip_scroll_area_canvas_item)
-        strip_scroll_group_canvas_item.add_canvas_item(strip_scroll_bar_canvas_item)
 
         def grid_thumbnail_item_factory(item: typing.Any, is_selected_model: Model.PropertyModel[bool]) -> CanvasItem.AbstractCanvasItem:
             return DataPanel.DataPanelGridItem(typing.cast(DisplayItem.DisplayItem, item), document_controller.ui, DataPanel.DataPanelUISettings(document_controller.ui))
 
-        grid_canvas_item = DisplayPanelGridCanvasItem(Panel.ThreadSafeListModel(display_items_model, document_controller.event_loop), self.__selection, grid_thumbnail_item_factory, item_delegate, item_size=Geometry.IntSize(80, 80), key="display_items", is_shared_selection=True)
-        grid_canvas_item.on_focus_changed = ReferenceCounting.weak_partial(DisplayPanel.set_focused, self)
+        self.__strip_thumbnail_item_factory = strip_thumbnail_item_factory
+        self.__grid_thumbnail_item_factory = grid_thumbnail_item_factory
 
-        grid_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(grid_canvas_item)
-        grid_scroll_area_canvas_item.auto_resize_contents = True
-        grid_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(grid_scroll_area_canvas_item, CanvasItem.Orientation.Vertical)
-        grid_scroll_group_canvas_item = CanvasItem.CanvasItemComposition()
-        grid_scroll_group_canvas_item.layout = CanvasItem.CanvasItemRowLayout()
-        grid_scroll_group_canvas_item.add_canvas_item(grid_scroll_area_canvas_item)
-        grid_scroll_group_canvas_item.add_canvas_item(grid_scroll_bar_canvas_item)
-
-        self.__strip_canvas_item = strip_canvas_item
-
-        self.__horizontal_browser_canvas_item = strip_scroll_group_canvas_item
-        self.__horizontal_browser_canvas_item.update_sizing(self.__horizontal_browser_canvas_item.sizing.with_fixed_height(96))
-        self.__horizontal_browser_canvas_item.visible = False
-
-        self.__grid_canvas_item = grid_canvas_item
-
-        self.__grid_browser_canvas_item = grid_scroll_group_canvas_item
-        self.__grid_browser_canvas_item.visible = False
+        # the horizontal and grid browser canvas items (and the display items model, canvas items, etc. that back
+        # them) are constructed lazily, only when the display panel is switched into that browser mode, and are
+        # fully destroyed (dropping all references so the underlying list model listeners are released) when
+        # switched away from. this avoids every display panel's non-visible browsers reacting to and mirroring
+        # every change in the shared display items model, which is otherwise wasteful when many display panels
+        # are open at once. see __ensure_horizontal_browser_canvas_item / __destroy_horizontal_browser_canvas_item
+        # and __ensure_grid_browser_canvas_item / __destroy_grid_browser_canvas_item.
+        self.__strip_canvas_item: DisplayPanelListCanvasItem | None = None
+        self.__horizontal_browser_canvas_item: CanvasItem.CanvasItemComposition | None = None
+        self.__grid_canvas_item: DisplayPanelGridCanvasItem | None = None
+        self.__grid_browser_canvas_item: CanvasItem.CanvasItemComposition | None = None
 
         # the column composition layout permits displaying data item and horizontal browser simultaneously and also the
         # data item and grid as the only items just by selecting hiding/showing individual canvas items.
         self.__browser_composition_canvas_item = CanvasItem.CanvasItemComposition()
         self.__browser_composition_canvas_item.layout = CanvasItem.CanvasItemColumnLayout()
         self.__browser_composition_canvas_item.add_canvas_item(self.__display_composition_canvas_item)
-        self.__browser_composition_canvas_item.add_canvas_item(self.__horizontal_browser_canvas_item)
-        self.__browser_composition_canvas_item.add_canvas_item(self.__grid_browser_canvas_item)
 
         self.__content_canvas_item.insert_canvas_item(0, self.__browser_composition_canvas_item)
 
@@ -2223,9 +2208,10 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
         # NOTE: the enclosing canvas item should be closed AFTER this close is called.
         self.__set_display_panel_controller(None)
-        self.__strip_canvas_item = typing.cast(typing.Any, None)
-        self.__grid_canvas_item = typing.cast(typing.Any, None)
-        self.__grid_browser_canvas_item = typing.cast(typing.Any, None)
+        self.__strip_canvas_item = None
+        self.__horizontal_browser_canvas_item = None
+        self.__grid_canvas_item = None
+        self.__grid_browser_canvas_item = None
         self.__selection_changed_event_listener.close()
         self.__selection_changed_event_listener = typing.cast(typing.Any, None)
         self.__document_controller.filtered_display_items_model.release_selection(self.__selection)
@@ -2335,9 +2321,9 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             self.__display_panel_controller.save(d)
         if self.__display_item:
             d["display_item_specifier"] = Persistence.write_persistent_specifier(self.__display_item.uuid)
-        if self.__display_panel_controller is None and self.__horizontal_browser_canvas_item.visible:
+        if self.__display_panel_controller is None and self.__is_horizontal_browser_visible:
             d["browser_type"] = "horizontal"
-        if self.__display_panel_controller is None and self.__grid_browser_canvas_item.visible:
+        if self.__display_panel_controller is None and self.__is_grid_browser_visible:
             d["browser_type"] = "grid"
         d["uuid"] = str(self.uuid)
         d["identifier"] = self.identifier
@@ -2372,13 +2358,13 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
     @property
     def _is_result_panel(self) -> bool:
-        return not self.__display_item and not self.__grid_browser_canvas_item.visible and not self.__display_panel_controller
+        return not self.__display_item and not self.__is_grid_browser_visible and not self.__display_panel_controller
 
     @property
     def _display_panel_type(self) -> str:
-        if self.__horizontal_browser_canvas_item.visible:
+        if self.__is_horizontal_browser_visible:
             return "horizontal"
-        elif self.__grid_browser_canvas_item.visible:
+        elif self.__is_grid_browser_visible:
             return "grid"
         elif self.__display_item:
             return "data_item"
@@ -2742,15 +2728,15 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         if self.__display_panel_controller is None:
             # the second part of the if statement below handles the case where the data item has been changed by
             # the user so the cycle should go back to the main display.
-            if self.__display_composition_canvas_item.visible and (not self.__horizontal_browser_canvas_item.visible or not self.__display_changed):
-                if self.__horizontal_browser_canvas_item.visible:
-                    self.__switch_to_grid_browser()
+            if self.__display_composition_canvas_item.visible and (not self.__is_horizontal_browser_visible or not self.__display_changed):
+                if self.__is_horizontal_browser_visible:
+                    grid_canvas_item = self.__switch_to_grid_browser()
                     self.__update_selection_to_display()
-                    self.__grid_canvas_item.request_focus()
+                    grid_canvas_item.request_focus()
                 else:
-                    self.__switch_to_horizontal_browser()
+                    strip_canvas_item = self.__switch_to_horizontal_browser()
                     self.__update_selection_to_display()
-                    self.__strip_canvas_item.request_focus()
+                    strip_canvas_item.request_focus()
             else:
                 self.__switch_to_no_browser()
                 self._select()
@@ -2766,29 +2752,113 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
         self.__selection_changed_event_listener = typing.cast(typing.Any, None)
         if self.__display_item in display_items:
             self.__selection.set(display_items.index(self.__display_item))
-            self.__strip_canvas_item.make_selection_visible()
-            self.__grid_canvas_item.make_selection_visible()
+            if self.__strip_canvas_item is not None:
+                self.__strip_canvas_item.make_selection_visible()
+            if self.__grid_canvas_item is not None:
+                self.__grid_canvas_item.make_selection_visible()
         else:
             self.__selection.clear()
         self.__selection_changed_event_listener = self.__selection.changed_event.listen(self.__selection_changed)
 
+    @property
+    def __is_horizontal_browser_visible(self) -> bool:
+        horizontal_browser_canvas_item = self.__horizontal_browser_canvas_item
+        return horizontal_browser_canvas_item is not None and horizontal_browser_canvas_item.visible
+
+    @property
+    def __is_grid_browser_visible(self) -> bool:
+        grid_browser_canvas_item = self.__grid_browser_canvas_item
+        return grid_browser_canvas_item is not None and grid_browser_canvas_item.visible
+
+    def __ensure_horizontal_browser_canvas_item(self) -> CanvasItem.CanvasItemComposition:
+        horizontal_browser_canvas_item = self.__horizontal_browser_canvas_item
+        if horizontal_browser_canvas_item is None:
+            document_controller = self.__document_controller
+
+            strip_canvas_item = DisplayPanelListCanvasItem(Panel.ThreadSafeListModel(self.__filtered_display_items_model, document_controller.event_loop), self.__selection, self.__strip_thumbnail_item_factory, self.__item_delegate, item_width=80, key="display_items", is_shared_selection=True)
+            strip_canvas_item.on_focus_changed = ReferenceCounting.weak_partial(DisplayPanel.set_focused, self)
+
+            strip_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(strip_canvas_item)
+            strip_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(strip_scroll_area_canvas_item, CanvasItem.Orientation.Horizontal)
+            strip_scroll_group_canvas_item = CanvasItem.CanvasItemComposition()
+            strip_scroll_group_canvas_item.layout = CanvasItem.CanvasItemColumnLayout()
+            strip_scroll_group_canvas_item.add_canvas_item(strip_scroll_area_canvas_item)
+            strip_scroll_group_canvas_item.add_canvas_item(strip_scroll_bar_canvas_item)
+            strip_scroll_group_canvas_item.update_sizing(strip_scroll_group_canvas_item.sizing.with_fixed_height(96))
+
+            self.__strip_canvas_item = strip_canvas_item
+
+            horizontal_browser_canvas_item = strip_scroll_group_canvas_item
+            horizontal_browser_canvas_item.visible = False
+            self.__horizontal_browser_canvas_item = horizontal_browser_canvas_item
+            self.__browser_composition_canvas_item.insert_canvas_item(1, horizontal_browser_canvas_item)
+        return horizontal_browser_canvas_item
+
+    def __destroy_horizontal_browser_canvas_item(self) -> None:
+        horizontal_browser_canvas_item = self.__horizontal_browser_canvas_item
+        if horizontal_browser_canvas_item is not None:
+            self.__browser_composition_canvas_item.remove_canvas_item(horizontal_browser_canvas_item)
+            self.__horizontal_browser_canvas_item = None
+            self.__strip_canvas_item = None
+
+    def __ensure_grid_browser_canvas_item(self) -> CanvasItem.CanvasItemComposition:
+        grid_browser_canvas_item = self.__grid_browser_canvas_item
+        if grid_browser_canvas_item is None:
+            document_controller = self.__document_controller
+
+            grid_canvas_item = DisplayPanelGridCanvasItem(Panel.ThreadSafeListModel(self.__filtered_display_items_model, document_controller.event_loop), self.__selection, self.__grid_thumbnail_item_factory, self.__item_delegate, item_size=Geometry.IntSize(80, 80), key="display_items", is_shared_selection=True)
+            grid_canvas_item.on_focus_changed = ReferenceCounting.weak_partial(DisplayPanel.set_focused, self)
+
+            grid_scroll_area_canvas_item = CanvasItem.ScrollAreaCanvasItem(grid_canvas_item)
+            grid_scroll_area_canvas_item.auto_resize_contents = True
+            grid_scroll_bar_canvas_item = CanvasItem.ScrollBarCanvasItem(grid_scroll_area_canvas_item, CanvasItem.Orientation.Vertical)
+            grid_scroll_group_canvas_item = CanvasItem.CanvasItemComposition()
+            grid_scroll_group_canvas_item.layout = CanvasItem.CanvasItemRowLayout()
+            grid_scroll_group_canvas_item.add_canvas_item(grid_scroll_area_canvas_item)
+            grid_scroll_group_canvas_item.add_canvas_item(grid_scroll_bar_canvas_item)
+
+            self.__grid_canvas_item = grid_canvas_item
+
+            grid_browser_canvas_item = grid_scroll_group_canvas_item
+            grid_browser_canvas_item.visible = False
+            self.__grid_browser_canvas_item = grid_browser_canvas_item
+            self.__browser_composition_canvas_item.insert_canvas_item(1, grid_browser_canvas_item)
+        return grid_browser_canvas_item
+
+    def __destroy_grid_browser_canvas_item(self) -> None:
+        grid_browser_canvas_item = self.__grid_browser_canvas_item
+        if grid_browser_canvas_item is not None:
+            self.__browser_composition_canvas_item.remove_canvas_item(grid_browser_canvas_item)
+            self.__grid_browser_canvas_item = None
+            self.__grid_canvas_item = None
+
     def __switch_to_no_browser(self) -> None:
+        # release (close) any active horizontal/grid browser canvas item so that a display panel that is not
+        # showing a browser does not keep mirroring and reacting to changes in the shared display items model.
+        self.__destroy_horizontal_browser_canvas_item()
+        self.__destroy_grid_browser_canvas_item()
         self.__display_composition_canvas_item.visible = True
-        self.__horizontal_browser_canvas_item.visible = False
-        self.__grid_browser_canvas_item.visible = False
         self.__display_composition_canvas_item.request_focus()
 
-    def __switch_to_horizontal_browser(self) -> None:
+    def __switch_to_horizontal_browser(self) -> DisplayPanelListCanvasItem:
+        self.__destroy_grid_browser_canvas_item()
+        horizontal_browser_canvas_item = self.__ensure_horizontal_browser_canvas_item()
         self.__display_composition_canvas_item.visible = True
-        self.__horizontal_browser_canvas_item.visible = True
-        self.__grid_browser_canvas_item.visible = False
-        self.__horizontal_browser_canvas_item.request_focus()
+        horizontal_browser_canvas_item.visible = True
+        horizontal_browser_canvas_item.request_focus()
+        strip_canvas_item = self.__strip_canvas_item
+        assert strip_canvas_item is not None
+        return strip_canvas_item
 
-    def __switch_to_grid_browser(self) -> None:
+    def __switch_to_grid_browser(self) -> DisplayPanelGridCanvasItem:
+        self.__destroy_horizontal_browser_canvas_item()
+        grid_browser_canvas_item = self.__ensure_grid_browser_canvas_item()
         self.__display_composition_canvas_item.visible = False
-        self.__horizontal_browser_canvas_item.visible = False
-        self.__grid_browser_canvas_item.visible = True
-        self.__grid_browser_canvas_item.request_focus()
+        grid_browser_canvas_item.visible = True
+        grid_browser_canvas_item.request_focus()
+        grid_canvas_item = self.__grid_canvas_item
+        assert grid_canvas_item is not None
+        return grid_canvas_item
 
     # from the canvas item directly. dispatches to the display canvas item. if the display canvas item
     # doesn't handle it, gives the display controller a chance to handle it.

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -339,8 +339,8 @@ class DisplayPanelOverlayCanvasItemComposition(CanvasItem.CanvasItemComposition)
     """
         An overlay for image panels to draw and handle focus, selection, and drop targets.
 
-        The overlay has a focused property, but this is not the same as the canvas focused_item.
-        The focused property here is just a flag to indicate whether to draw the focus ring.
+        The overlay has an is_focus_ring_visible property, just a flag to indicate whether to draw
+        the focus ring.
 
         Clients can connect to the following messages:
             on_context_menu_event(x, y, gx, gy)
@@ -383,11 +383,11 @@ class DisplayPanelOverlayCanvasItemComposition(CanvasItem.CanvasItemComposition)
         super().close()
 
     @property
-    def focused(self) -> bool:
+    def is_focus_ring_visible(self) -> bool:
         return self.__display_panel_overlay_canvas_item.is_focused
 
-    @focused.setter
-    def focused(self, value: bool) -> None:
+    @is_focus_ring_visible.setter
+    def is_focus_ring_visible(self, value: bool) -> None:
         self.__display_panel_overlay_canvas_item.is_focused = value
 
     @property
@@ -2591,7 +2591,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                     self.__display_composition_canvas_item.add_canvas_item(threaded_canvas_item)
                     add_display_controls(new_display_canvas_item)
                     # whenever focus or the display canvas item changes, update the focused status
-                    new_display_canvas_item.set_focused(self.__content_canvas_item.focused)
+                    new_display_canvas_item.set_focused(self.__content_canvas_item.is_focus_ring_visible)
                     self.__display_canvas_item = new_display_canvas_item
                     # configure the display data stream and listener to update the display canvas item when the display data changes.
                     display_info_stream = display_item.display_info_stream
@@ -2687,7 +2687,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
     # if the display panel is receiving focus, tell the window (document_controller) about it so
     # it can update the selected display items. also tell the display panel manager about it.
     def set_focused(self, focused: bool) -> None:
-        self.__content_canvas_item.focused = focused
+        self.__content_canvas_item.is_focus_ring_visible = focused
         if focused:
             self.__document_controller.selected_display_panel = self
         # whenever focus or the display canvas item changes, update the focused status
@@ -2697,7 +2697,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
 
     def _is_focused(self) -> bool:
         """ Used for testing. """
-        return self.__content_canvas_item.focused
+        return self.__content_canvas_item.is_focus_ring_visible
 
     def request_focus(self) -> None:
         self.__content_canvas_item.request_focus()

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2740,6 +2740,7 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
             else:
                 self.__switch_to_no_browser()
                 self._select()
+                self.request_focus()
             self.__display_changed = False
 
     def __update_selection_to_display(self) -> None:
@@ -2835,27 +2836,30 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
     def __switch_to_no_browser(self) -> None:
         # release (close) any active horizontal/grid browser canvas item so that a display panel that is not
         # showing a browser does not keep mirroring and reacting to changes in the shared display items model.
+        # note: this method is also called from restore_contents, so it must not request focus itself;
+        # callers that want to grab focus after switching (e.g. __cycle_display) must do so explicitly.
         self.__destroy_horizontal_browser_canvas_item()
         self.__destroy_grid_browser_canvas_item()
         self.__display_composition_canvas_item.visible = True
-        self.__display_composition_canvas_item.request_focus()
 
     def __switch_to_horizontal_browser(self) -> DisplayPanelListCanvasItem:
+        # note: this method is also called from restore_contents, so it must not request focus itself;
+        # callers that want to grab focus after switching (e.g. __cycle_display) must do so explicitly.
         self.__destroy_grid_browser_canvas_item()
         horizontal_browser_canvas_item = self.__ensure_horizontal_browser_canvas_item()
         self.__display_composition_canvas_item.visible = True
         horizontal_browser_canvas_item.visible = True
-        horizontal_browser_canvas_item.request_focus()
         strip_canvas_item = self.__strip_canvas_item
         assert strip_canvas_item is not None
         return strip_canvas_item
 
     def __switch_to_grid_browser(self) -> DisplayPanelGridCanvasItem:
+        # note: this method is also called from restore_contents, so it must not request focus itself;
+        # callers that want to grab focus after switching (e.g. __cycle_display) must do so explicitly.
         self.__destroy_horizontal_browser_canvas_item()
         grid_browser_canvas_item = self.__ensure_grid_browser_canvas_item()
         self.__display_composition_canvas_item.visible = False
         grid_browser_canvas_item.visible = True
-        grid_browser_canvas_item.request_focus()
         grid_canvas_item = self.__grid_canvas_item
         assert grid_canvas_item is not None
         return grid_canvas_item

--- a/nion/swift/DisplayPanel.py
+++ b/nion/swift/DisplayPanel.py
@@ -2742,6 +2742,9 @@ class DisplayPanel(CanvasItem.LayerCanvasItem):
                 self._select()
                 self.request_focus()
             self.__display_changed = False
+            # notify so that the new browser type gets persisted into the workspace layout.
+            if callable(self.on_contents_changed):
+                self.on_contents_changed()
 
     def __update_selection_to_display(self) -> None:
         # match the selection in the browsers (thumbnail and grid) to the display item.

--- a/nion/swift/LinePlotCanvasItem.py
+++ b/nion/swift/LinePlotCanvasItem.py
@@ -129,6 +129,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         self.__line_graph_legend_row.add_stretch()
         self.__line_graph_legend_column = CanvasItem.CanvasItemComposition()
         self.__line_graph_legend_column.layout = CanvasItem.CanvasItemColumnLayout()
+        self.__line_graph_legend_column.update_sizing(self.__line_graph_legend_column.sizing.with_collapsible(True))
         self.__line_graph_legend_column.add_canvas_item(self.__line_graph_legend_row)
         self.__line_graph_legend_column.add_stretch()
         self.__line_graph_outer_left_column = CanvasItem.CanvasItemComposition()
@@ -181,6 +182,7 @@ class LinePlotCanvasItem(DisplayCanvasItem.DisplayCanvasItem):
         # create and add the outer level labels
         legend_row = CanvasItem.CanvasItemComposition()
         legend_row.layout = CanvasItem.CanvasItemRowLayout()
+        legend_row.update_sizing(legend_row.sizing.with_collapsible(True))
         legend_row.add_canvas_item(self.__line_graph_outer_left_column)
         legend_row.add_canvas_item(line_graph_group_canvas_item)
         legend_row.add_canvas_item(self.__line_graph_outer_right_column)

--- a/nion/swift/test/DisplayPanel_test.py
+++ b/nion/swift/test/DisplayPanel_test.py
@@ -129,6 +129,16 @@ class TestDisplayPanelClass(unittest.TestCase):
         # trigger layout
         return self.display_panel.display_canvas_item
 
+    def test_line_plot_legend_hidden_columns_do_not_impose_minimum_width(self):
+        # regression test: the outer left/right legend columns and the inner top legend row are normally hidden
+        # (invisible) unless the user has chosen an "outer" or "top" legend position. hidden canvas items should
+        # not contribute to the minimum width of their containing row/column, so the line plot should still be
+        # able to lay out (and draw) narrower than the hidden legend content would otherwise require.
+        line_plot_canvas_item = self.setup_line_plot()
+        minimum_width = line_plot_canvas_item.layout_sizing.minimum_width
+        self.assertIsNotNone(minimum_width)
+        self.assertLess(minimum_width, 100)
+
     def test_image_panel_gets_destructed(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -1388,13 +1388,13 @@ class TestWorkspaceClass(unittest.TestCase):
             document_controller.workspace_controller.display_panels[0].request_focus()
             root_canvas_item.refresh_layout_immediate()
             self.assertTrue(document_controller.workspace_controller.display_panels[0].content_canvas_item.selected)
-            self.assertTrue(document_controller.workspace_controller.display_panels[0].content_canvas_item.focused)
+            self.assertTrue(document_controller.workspace_controller.display_panels[0].content_canvas_item.is_focus_ring_visible)
             # drag header. can't really test dragging without more test harness support. but make sure it gets this far.
             document_controller.workspace_controller.display_panels[1].header_canvas_item.simulate_click(Geometry.IntPoint(y=12, x=12))
             self.assertFalse(document_controller.workspace_controller.display_panels[0].content_canvas_item.selected)
-            self.assertFalse(document_controller.workspace_controller.display_panels[0].content_canvas_item.focused)
+            self.assertFalse(document_controller.workspace_controller.display_panels[0].content_canvas_item.is_focus_ring_visible)
             self.assertTrue(document_controller.workspace_controller.display_panels[1].content_canvas_item.selected)
-            self.assertTrue(document_controller.workspace_controller.display_panels[1].content_canvas_item.focused)
+            self.assertTrue(document_controller.workspace_controller.display_panels[1].content_canvas_item.is_focus_ring_visible)
 
     def test_creating_invalid_workspace_fails_gracefully(self):
         with TestContext.create_memory_context() as test_context:
@@ -1425,15 +1425,15 @@ class TestWorkspaceClass(unittest.TestCase):
             display_panel1.set_display_item(None)
             display_panel1.request_focus()
             # check assumptions
-            self.assertFalse(display_panel0.content_canvas_item.focused)
-            self.assertTrue(display_panel1.content_canvas_item.focused)
+            self.assertFalse(display_panel0.content_canvas_item.is_focus_ring_visible)
+            self.assertTrue(display_panel1.content_canvas_item.is_focus_ring_visible)
             # do drop
             mime_data = TestUI.MimeData()
             MimeTypes.mime_data_put_display_item(mime_data, display_item)
             document_controller.workspace_controller.handle_drop(display_panel0, mime_data, "middle", 160, 240)
             # check focus
-            self.assertTrue(display_panel0.content_canvas_item.focused)
-            self.assertFalse(display_panel1.content_canvas_item.focused)
+            self.assertTrue(display_panel0.content_canvas_item.is_focus_ring_visible)
+            self.assertFalse(display_panel1.content_canvas_item.is_focus_ring_visible)
 
     def test_browser_does_not_reset_selected_display_item_when_root_loses_focus(self):
         # make sure the inspector doesn't disappear when focus changes to one of its fields

--- a/nion/swift/test/Workspace_test.py
+++ b/nion/swift/test/Workspace_test.py
@@ -489,6 +489,26 @@ class TestWorkspaceClass(unittest.TestCase):
                 root_canvas_item.layout_immediate(Geometry.IntSize(width=640, height=480))
                 self.assertEqual("grid", display_panel.save_contents()["browser_type"])
 
+    def test_workspace_saves_contents_immediately_following_cycle_display(self):
+        with create_memory_profile_context() as profile_context:
+            document_controller = profile_context.create_document_controller(auto_close=False)
+            document_model = document_controller.document_model
+            with contextlib.closing(document_controller):
+                workspace_controller = document_controller.workspace_controller
+                root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
+                root_canvas_item.layout_immediate(Geometry.IntSize(width=640, height=480))
+                display_panel = workspace_controller.display_panels[0]
+                display_panel.cycle_display()  # none -> horizontal
+            # reload with the storage copied before the document closes
+            document_controller = profile_context.create_document_controller(auto_close=False)
+            document_model = document_controller.document_model
+            with contextlib.closing(document_controller):
+                workspace_controller = document_controller.workspace_controller
+                display_panel = workspace_controller.display_panels[0]
+                root_canvas_item = document_controller.workspace_controller.image_row.children[0]._root_canvas_item()
+                root_canvas_item.layout_immediate(Geometry.IntSize(width=640, height=480))
+                self.assertEqual("horizontal", display_panel.save_contents()["browser_type"])
+
     def test_workspace_insert_into_no_splitter_undo_and_redo_works_cleanly(self):
         with TestContext.create_memory_context() as test_context:
             document_controller = test_context.create_document_controller()


### PR DESCRIPTION
Fixes #1456. Fixes #1953. Fixes #1954. Fixes #1955. Fixes #1956.

- **Construct horizontal and grid browser canvas items lazily, on demand**
- **Mark hidden line plot legend rows/columns collapsible to avoid imposing minimum width**
- **Restore focus to the primary display when cycling back from a browser view**
- **Rename DisplayPanelOverlayCanvasItemComposition.focused to is_focus_ring_visible**
- **Persist browser type change when cycling display panel view style**

In the process of adding a detail browser first implementation, these issues came up; and I thought of a way to dramatically improve the process of switching workspaces with a lot of panels and a lot of data items [issue 1456](https://github.com/nion-software/nionswift/issues/1456).